### PR TITLE
minimize Bevy deps and ship compressed WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,9 @@ version = "0.18"
 default-features = false
 features = [
   "bevy_winit",         # Windowing backend
-  "bevy_log",           # Logging
+  "bevy_log",           # Log subscriber (crate compiles anyway; enables LogPlugin in DefaultPlugins)
   "default_font",       # Built-in font for text rendering
-  "2d_bevy_render",     # 2D rendering (includes sprite, render, core_pipeline)
-  "bevy_ui",            # UI framework (nodes, text, layout)
-  "bevy_ui_render",     # UI rendering backend
+  "bevy_ui_render",     # UI + sprite + render + camera + text (full transitive chain)
   "webgl2",             # WebGL2 for broad WASM browser support
 ]
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Building release WASM with trunk..."
+trunk build --release
+
+echo "==> Build complete. Contents of dist/:"
+ls -lh dist/
+
+WASM_FILE=$(ls dist/*.wasm 2>/dev/null | head -1)
+if [ -z "$WASM_FILE" ]; then
+    echo "ERROR: No .wasm file found in dist/"
+    exit 1
+fi
+
+RAW_SIZE=$(wc -c < "$WASM_FILE" | tr -d ' ')
+echo "==> Raw WASM size: $(echo "$RAW_SIZE" | awk '{printf "%.1f MiB", $1/1048576}') ($RAW_SIZE bytes)"
+
+echo "==> Compressing with brotli..."
+brotli -9 -f "$WASM_FILE"
+BR_SIZE=$(wc -c < "${WASM_FILE}.br" | tr -d ' ')
+echo "==> Brotli size:   $(echo "$BR_SIZE" | awk '{printf "%.1f MiB", $1/1048576}') ($BR_SIZE bytes, $(echo "$RAW_SIZE $BR_SIZE" | awk '{printf "%.0f%% smaller", (1-$2/$1)*100}'))"
+
+echo ""
+echo "==> Done. Run ./up.sh to deploy to GCS."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod ui;
 
 use bevy::prelude::*;
 use derive_more::From;
+use log::{error, warn};
 use rand::Rng;
 
 pub use boundary::{BoundaryPlugin, BoundaryWrap, Bounding};

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use bevy::{
     prelude::*,
     window::{PresentMode, PrimaryWindow},
 };
+use log::{error, info};
 use rand::Rng;
 
 fn main() {

--- a/up.sh
+++ b/up.sh
@@ -1,1 +1,31 @@
-gsutil cp -r dist/* gs://an.org/gatherers/
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUCKET="gs://an.org/gatherers/"
+
+WASM_FILE=$(ls dist/*.wasm 2>/dev/null | head -1)
+WASM_BR="${WASM_FILE}.br"
+
+if [ -z "$WASM_FILE" ]; then
+    echo "ERROR: No .wasm file in dist/. Run ./build.sh first."
+    exit 1
+fi
+
+if [ ! -f "$WASM_BR" ]; then
+    echo "No brotli-compressed .wasm found. Compressing now..."
+    brotli -9 -f "$WASM_FILE"
+fi
+
+WASM_BASENAME=$(basename "$WASM_FILE")
+
+echo "==> Uploading non-WASM assets..."
+gsutil -m -h "Cache-Control:public, max-age=600" \
+    cp -r $(ls dist/* | grep -v '\.wasm') "$BUCKET"
+
+echo "==> Uploading brotli-compressed WASM as $WASM_BASENAME..."
+gsutil -h "Content-Encoding:br" \
+       -h "Content-Type:application/wasm" \
+       -h "Cache-Control:public, max-age=600" \
+    cp "$WASM_BR" "${BUCKET}${WASM_BASENAME}"
+
+echo "==> Deploy complete: https://an.org/gatherers/"


### PR DESCRIPTION
## Summary
- reduce the Bevy feature set to the minimum working configuration by relying on `bevy_ui_render` transitively instead of explicitly enabling broader 2D/UI feature groups
- add `build.sh` to produce a release web build and brotli-compress the generated `.wasm`
- update `up.sh` so GCS serves the brotli-compressed wasm with the correct headers at [an.org/gatherers](https://an.org/gatherers)

## Test plan
- [x] `cargo test`
- [x] `cargo check`
- [x] `cargo check --target wasm32-unknown-unknown`
- [x] `trunk build --release`
- [x] quick native smoke test
- [x] quick `trunk serve` smoke test
- [x] deployed build works at [an.org/gatherers](https://an.org/gatherers)


Made with [Cursor](https://cursor.com)