### PR TITLE
Add Go backend with decoupled realtime aggregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ rand = "0.9"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 wasm-bindgen = "0.2"
 log = "0.4"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+ewebsock = "0.8.0"
 
 #[dependencies.web-sys]
 #version = "0.3"

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,7 +13,9 @@ Protocol and scope are defined in `../docs/go-backend-v1-contract.md`.
 ## Layout
 
 - `cmd/server` for the entrypoint
+- `cmd/fakeclients` for long-lived manual load generation against a live backend
 - `internal/config` for runtime configuration
+- `internal/loadsim` for reusable fake-client streams and runners shared by tests and commands
 - `internal/server` for HTTP and WebSocket wiring
 - `internal/state` for aggregate state logic
 - `internal/ingest` reserved for further ingest-specific code
@@ -34,6 +36,14 @@ Run the backend test suite:
 ```bash
 cd backend
 go test ./...
+```
+
+Fast CI-safe backend checks:
+
+```bash
+cd backend
+go test ./...
+go test -race ./internal/server -run TestStressHundredFakeClients -count=1
 ```
 
 Run the race-checked stress slice:
@@ -58,6 +68,46 @@ cd backend
 GATHERERS_BACKEND_BASE_URL=http://127.0.0.1:18080 \
 go test ./internal/server -run TestFakeClientsPopulatePerSimSummaries -count=1
 ```
+
+Run the opt-in sustained load coverage:
+
+```bash
+cd backend
+GATHERERS_RUN_LONG_STRESS=1 \
+go test ./internal/server -run TestLongStressDashboardReflectsSustainedLoad -count=1
+```
+
+## Realtime dashboard demo
+
+Start the backend on a known port:
+
+```bash
+cd backend
+GATHERERS_BACKEND_ADDR=:18080 go run ./cmd/server
+```
+
+Then open [`http://127.0.0.1:18080`](http://127.0.0.1:18080) in a browser. The page now subscribes to `/ws/dashboard` and updates live without reload.
+
+Drive realistic long-lived fake traffic from a second terminal:
+
+```bash
+cd backend
+go run ./cmd/fakeclients \
+  --base-url http://127.0.0.1:18080 \
+  --clients 100 \
+  --duration 20s \
+  --interval 100ms \
+  --seed 1 \
+  --sim-id-prefix demo
+```
+
+The dashboard should show:
+
+- the connected sim count climbing toward the requested client count
+- loose food and clustering metrics changing over time
+- the per-sim table updating while load is still running
+
+For a smaller local smoke demo, lower `--clients` or shorten `--duration`.
 
 ## Running the Rust sim against the backend
 
@@ -111,3 +161,5 @@ The existing commit history on this branch follows that pattern for:
 - dashboard behavior
 - fake-client integration
 - concurrent stress handling
+- realtime dashboard updates
+- sustained opt-in load coverage

--- a/backend/README.md
+++ b/backend/README.md
@@ -43,6 +43,22 @@ cd backend
 go test -race ./internal/server -run TestStressHundredFakeClients -count=1
 ```
 
+Target a manually running backend instead of `httptest`:
+
+```bash
+cd backend
+GATHERERS_BACKEND_BASE_URL=http://127.0.0.1:18080 \
+go test -race ./internal/server -run TestStressHundredFakeClients -count=1
+```
+
+The fake-client integration test supports the same override:
+
+```bash
+cd backend
+GATHERERS_BACKEND_BASE_URL=http://127.0.0.1:18080 \
+go test ./internal/server -run TestFakeClientsPopulatePerSimSummaries -count=1
+```
+
 ## Running the Rust sim against the backend
 
 Start the Go backend first:

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,8 @@ V1 goals:
 
 Protocol and scope are defined in `../docs/go-backend-v1-contract.md`.
 
+For a runtime-oriented view of data flow, background aggregation, and dashboard demand handling, see `../docs/go-backend-runtime-architecture.md`.
+
 ## Layout
 
 - `cmd/server` for the entrypoint

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,25 @@
+# Go Backend
+
+This directory contains the standalone Go backend for the Gatherers project.
+
+V1 goals:
+
+- ingest simulation events over WebSockets
+- maintain live in-memory aggregate state
+- expose JSON APIs and a small built-in dashboard
+
+Current status:
+
+- protocol and boundaries are defined in `../docs/go-backend-v1-contract.md`
+- this package is only a non-behavioral skeleton so that strict TDD can start next
+
+Expected package layout:
+
+- `cmd/server` for the entrypoint
+- `internal/config` for runtime configuration
+- `internal/server` for app wiring
+- `internal/state` for aggregate state logic
+- `internal/ingest` for websocket ingest
+- `internal/httpapi` for JSON and dashboard routes
+
+The first meaningful backend behavior should be added only after a failing test is written and observed.

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,18 +8,90 @@ V1 goals:
 - maintain live in-memory aggregate state
 - expose JSON APIs and a small built-in dashboard
 
-Current status:
+Protocol and scope are defined in `../docs/go-backend-v1-contract.md`.
 
-- protocol and boundaries are defined in `../docs/go-backend-v1-contract.md`
-- this package is only a non-behavioral skeleton so that strict TDD can start next
-
-Expected package layout:
+## Layout
 
 - `cmd/server` for the entrypoint
 - `internal/config` for runtime configuration
-- `internal/server` for app wiring
+- `internal/server` for HTTP and WebSocket wiring
 - `internal/state` for aggregate state logic
-- `internal/ingest` for websocket ingest
-- `internal/httpapi` for JSON and dashboard routes
+- `internal/ingest` reserved for further ingest-specific code
+- `internal/httpapi` reserved for further HTTP-specific code
+- `web` reserved for dashboard assets if the HTML grows beyond inline rendering
 
-The first meaningful backend behavior should be added only after a failing test is written and observed.
+## Local development
+
+Run the backend:
+
+```bash
+cd backend
+go run ./cmd/server
+```
+
+Run the backend test suite:
+
+```bash
+cd backend
+go test ./...
+```
+
+Run the race-checked stress slice:
+
+```bash
+cd backend
+go test -race ./internal/server -run TestStressHundredFakeClients -count=1
+```
+
+## Running the Rust sim against the backend
+
+Start the Go backend first:
+
+```bash
+cd backend
+go run ./cmd/server
+```
+
+Then, in the repo root, enable backend mode for the Rust sim:
+
+```bash
+GATHERERS_BACKEND_WS_URL=ws://127.0.0.1:8080/ws/ingest cargo run
+```
+
+If `GATHERERS_BACKEND_WS_URL` is unset, the Bevy sim runs standalone and does not try to connect.
+
+## Current architecture choices
+
+- Go HTTP stack: `net/http`
+- Go WebSocket stack: `github.com/coder/websocket`
+- Rust WebSocket client: `ewebsock`
+- Backend state: in-memory only for v1, protected by `sync.RWMutex`
+
+This keeps the stack small and idiomatic while still supporting native and WASM Rust builds.
+
+## Hosting split
+
+The static sim frontend and the Go backend are deployed separately:
+
+- static/web sim: existing GCS-based flow from the repo root
+- Go backend: separate service deployment such as Cloud Run
+
+The backend is intentionally not folded into the static deploy scripts.
+
+## TDD workflow
+
+When extending backend behavior, prefer small RED/GREEN commits:
+
+1. add a meaningful failing test
+2. run it and capture proof of RED
+3. commit the failing test state
+4. implement the smallest fix
+5. commit GREEN once the targeted tests pass
+
+The existing commit history on this branch follows that pattern for:
+
+- aggregation state
+- API/WebSocket behavior
+- dashboard behavior
+- fake-client integration
+- concurrent stress handling

--- a/backend/README.md
+++ b/backend/README.md
@@ -97,9 +97,16 @@ go run ./cmd/fakeclients \
   --clients 100 \
   --duration 20s \
   --interval 100ms \
+  --startup-food-count 80 \
   --seed 1 \
   --sim-id-prefix demo
 ```
+
+Each fake client now sends:
+
+- `sim_hello`
+- `sim_food_snapshot` with its startup loose-food positions
+- then ongoing mixed `food_pickup`, `ant_turn_move`, and `food_drop` events
 
 The dashboard should show:
 
@@ -123,6 +130,12 @@ Then, in the repo root, enable backend mode for the Rust sim:
 ```bash
 GATHERERS_BACKEND_WS_URL=ws://127.0.0.1:8080/ws/ingest cargo run
 ```
+
+When backend mode is enabled, the Rust sim sends:
+
+- `sim_hello` once at startup
+- `sim_food_snapshot` immediately after hello with all current loose-food positions
+- collision-driven pickup/drop/turn events after that
 
 If `GATHERERS_BACKEND_WS_URL` is unset, the Bevy sim runs standalone and does not try to connect.
 

--- a/backend/cmd/fakeclients/main.go
+++ b/backend/cmd/fakeclients/main.go
@@ -14,12 +14,13 @@ import (
 
 func main() {
 	var (
-		baseURL     = flag.String("base-url", "http://127.0.0.1:8080", "target backend base URL")
-		clientCount = flag.Int("clients", 100, "number of fake clients")
-		duration    = flag.Duration("duration", 20*time.Second, "how long to keep sending events")
-		interval    = flag.Duration("interval", 100*time.Millisecond, "per-client event interval")
-		seed        = flag.Int64("seed", 1, "deterministic seed offset")
-		simIDPrefix = flag.String("sim-id-prefix", "fake", "prefix for generated sim IDs")
+		baseURL          = flag.String("base-url", "http://127.0.0.1:8080", "target backend base URL")
+		clientCount      = flag.Int("clients", 100, "number of fake clients")
+		duration         = flag.Duration("duration", 20*time.Second, "how long to keep sending events")
+		interval         = flag.Duration("interval", 100*time.Millisecond, "per-client event interval")
+		seed             = flag.Int64("seed", 1, "deterministic seed offset")
+		initialFoodCount = flag.Int("startup-food-count", 80, "startup loose food positions sent per fake client")
+		simIDPrefix      = flag.String("sim-id-prefix", "fake", "prefix for generated sim IDs")
 	)
 	flag.Parse()
 
@@ -27,12 +28,13 @@ func main() {
 	defer stop()
 
 	if err := loadsim.Run(ctx, loadsim.RunOptions{
-		BaseURL:     *baseURL,
-		ClientCount: *clientCount,
-		Duration:    *duration,
-		Interval:    *interval,
-		Seed:        *seed,
-		SimIDPrefix: *simIDPrefix,
+		BaseURL:          *baseURL,
+		ClientCount:      *clientCount,
+		Duration:         *duration,
+		Interval:         *interval,
+		Seed:             *seed,
+		InitialFoodCount: *initialFoodCount,
+		SimIDPrefix:      *simIDPrefix,
 	}); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 		log.Fatalf("fakeclients failed: %v", err)
 	}

--- a/backend/cmd/fakeclients/main.go
+++ b/backend/cmd/fakeclients/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/antont/gatherers/backend/internal/loadsim"
+)
+
+func main() {
+	var (
+		baseURL     = flag.String("base-url", "http://127.0.0.1:8080", "target backend base URL")
+		clientCount = flag.Int("clients", 100, "number of fake clients")
+		duration    = flag.Duration("duration", 20*time.Second, "how long to keep sending events")
+		interval    = flag.Duration("interval", 100*time.Millisecond, "per-client event interval")
+		seed        = flag.Int64("seed", 1, "deterministic seed offset")
+		simIDPrefix = flag.String("sim-id-prefix", "fake", "prefix for generated sim IDs")
+	)
+	flag.Parse()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := loadsim.Run(ctx, loadsim.RunOptions{
+		BaseURL:     *baseURL,
+		ClientCount: *clientCount,
+		Duration:    *duration,
+		Interval:    *interval,
+		Seed:        *seed,
+		SimIDPrefix: *simIDPrefix,
+	}); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+		log.Fatalf("fakeclients failed: %v", err)
+	}
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/antont/gatherers/backend/internal/server"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	cfg := config.FromEnv()
+	srv := server.New(cfg)
+
+	log.Printf("starting gatherers backend skeleton on %s", cfg.Addr)
+	if err := srv.Run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,5 @@
 module github.com/antont/gatherers/backend
 
-go 1.22
+go 1.23
+
+require github.com/coder/websocket v1.8.14 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module github.com/antont/gatherers/backend
+
+go 1.22

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,2 @@
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,0 +1,18 @@
+package config
+
+import "os"
+
+type Config struct {
+	Addr string
+}
+
+func FromEnv() Config {
+	addr := os.Getenv("GATHERERS_BACKEND_ADDR")
+	if addr == "" {
+		addr = ":8080"
+	}
+
+	return Config{
+		Addr: addr,
+	}
+}

--- a/backend/internal/httpapi/doc.go
+++ b/backend/internal/httpapi/doc.go
@@ -1,0 +1,3 @@
+package httpapi
+
+// Package httpapi will hold JSON and dashboard HTTP handlers.

--- a/backend/internal/ingest/doc.go
+++ b/backend/internal/ingest/doc.go
@@ -1,0 +1,3 @@
+package ingest
+
+// Package ingest will hold websocket event ingest logic.

--- a/backend/internal/loadsim/stream.go
+++ b/backend/internal/loadsim/stream.go
@@ -114,7 +114,9 @@ func (s *ClientEventStream) NextEvent() Event {
 			Seq:         s.seq,
 			TimestampMS: s.timestampMS,
 			Payload: map[string]any{
-				"sim_name": s.opts.SimName,
+				"sim_name":   s.opts.SimName,
+				"ant_count":  s.opts.InitialAntCount,
+				"food_count": s.opts.InitialFoodCount,
 			},
 		}
 	}

--- a/backend/internal/loadsim/stream.go
+++ b/backend/internal/loadsim/stream.go
@@ -1,0 +1,168 @@
+package loadsim
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+type ClientOptions struct {
+	SimID     string
+	SimName   string
+	Seed      int64
+	StartX    float64
+	StartY    float64
+	StartFood string
+	StartAnt  string
+	Interval  time.Duration
+}
+
+type Event struct {
+	Type        string `json:"type"`
+	SimID       string `json:"sim_id"`
+	Seq         uint64 `json:"seq"`
+	TimestampMS int64  `json:"timestamp_ms"`
+	Payload     any    `json:"payload,omitempty"`
+}
+
+type ClientEventStream struct {
+	opts        ClientOptions
+	seq         uint64
+	timestampMS int64
+	x           float64
+	y           float64
+	step        int
+}
+
+func NewClientEventStream(opts ClientOptions) *ClientEventStream {
+	if opts.SimName == "" {
+		opts.SimName = opts.SimID
+	}
+	if opts.StartFood == "" {
+		opts.StartFood = opts.SimID + "-food"
+	}
+	if opts.StartAnt == "" {
+		opts.StartAnt = opts.SimID + "-ant"
+	}
+	if opts.Interval <= 0 {
+		opts.Interval = 20 * time.Millisecond
+	}
+
+	return &ClientEventStream{
+		opts:        opts,
+		timestampMS: 1_000 + opts.Seed,
+		x:           opts.StartX,
+		y:           opts.StartY,
+	}
+}
+
+func (s *ClientEventStream) NextEvents(ctx context.Context, count int) []Event {
+	events := make([]Event, 0, count)
+	for len(events) < count {
+		select {
+		case <-ctx.Done():
+			return events
+		default:
+			events = append(events, s.NextEvent())
+		}
+	}
+	return events
+}
+
+func (s *ClientEventStream) NextEvent() Event {
+	s.seq++
+	advance := s.opts.Interval.Milliseconds()
+	if advance < 1 {
+		advance = 1
+	}
+	s.timestampMS += advance
+
+	if s.seq == 1 {
+		return Event{
+			Type:        "sim_hello",
+			SimID:       s.opts.SimID,
+			Seq:         s.seq,
+			TimestampMS: s.timestampMS,
+			Payload: map[string]any{
+				"sim_name": s.opts.SimName,
+			},
+		}
+	}
+
+	switch s.step % 3 {
+	case 0:
+		event := Event{
+			Type:        "food_drop",
+			SimID:       s.opts.SimID,
+			Seq:         s.seq,
+			TimestampMS: s.timestampMS,
+			Payload: map[string]any{
+				"food_id": s.opts.StartFood,
+				"x":       s.x,
+				"y":       s.y,
+			},
+		}
+		s.step++
+		return event
+	case 1:
+		s.x += 1
+		s.y += 2
+		event := Event{
+			Type:        "ant_turn_move",
+			SimID:       s.opts.SimID,
+			Seq:         s.seq,
+			TimestampMS: s.timestampMS,
+			Payload: map[string]any{
+				"ant_id":       s.opts.StartAnt,
+				"x":            s.x,
+				"y":            s.y,
+				"direction_x":  1.0,
+				"direction_y":  0.0,
+				"frame":        s.seq,
+			},
+		}
+		s.step++
+		return event
+	default:
+		event := Event{
+			Type:        "food_pickup",
+			SimID:       s.opts.SimID,
+			Seq:         s.seq,
+			TimestampMS: s.timestampMS,
+			Payload: map[string]any{
+				"food_id": s.opts.StartFood,
+			},
+		}
+		s.step++
+		return event
+	}
+}
+
+func SendEvents(ctx context.Context, baseURL string, events []Event) error {
+	wsURL := ingestWebsocketURL(baseURL)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	for _, event := range events {
+		if err := wsjson.Write(ctx, conn, event); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ingestWebsocketURL(baseURL string) string {
+	switch {
+	case strings.HasPrefix(baseURL, "https://"):
+		return "wss://" + strings.TrimPrefix(baseURL, "https://") + "/ws/ingest"
+	default:
+		return "ws://" + strings.TrimPrefix(baseURL, "http://") + "/ws/ingest"
+	}
+}

--- a/backend/internal/loadsim/stream.go
+++ b/backend/internal/loadsim/stream.go
@@ -2,7 +2,9 @@ package loadsim
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coder/websocket"
@@ -26,6 +28,15 @@ type Event struct {
 	Seq         uint64 `json:"seq"`
 	TimestampMS int64  `json:"timestamp_ms"`
 	Payload     any    `json:"payload,omitempty"`
+}
+
+type RunOptions struct {
+	BaseURL     string
+	ClientCount int
+	Duration    time.Duration
+	Interval    time.Duration
+	Seed        int64
+	SimIDPrefix string
 }
 
 type ClientEventStream struct {
@@ -158,11 +169,88 @@ func SendEvents(ctx context.Context, baseURL string, events []Event) error {
 	return nil
 }
 
+func Run(ctx context.Context, opts RunOptions) error {
+	if opts.ClientCount <= 0 {
+		return nil
+	}
+	if opts.Interval <= 0 {
+		opts.Interval = 20 * time.Millisecond
+	}
+	if opts.SimIDPrefix == "" {
+		opts.SimIDPrefix = "sim"
+	}
+
+	runCtx := ctx
+	cancel := func() {}
+	if opts.Duration > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, opts.Duration)
+	}
+	defer cancel()
+
+	errCh := make(chan error, opts.ClientCount)
+	var wg sync.WaitGroup
+	for i := 0; i < opts.ClientCount; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			errCh <- runClient(runCtx, opts, index)
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil && err != context.DeadlineExceeded && err != context.Canceled {
+			return err
+		}
+	}
+	return nil
+}
+
 func ingestWebsocketURL(baseURL string) string {
 	switch {
 	case strings.HasPrefix(baseURL, "https://"):
 		return "wss://" + strings.TrimPrefix(baseURL, "https://") + "/ws/ingest"
 	default:
 		return "ws://" + strings.TrimPrefix(baseURL, "http://") + "/ws/ingest"
+	}
+}
+
+func runClient(ctx context.Context, opts RunOptions, index int) error {
+	wsURL := ingestWebsocketURL(opts.BaseURL)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	stream := NewClientEventStream(ClientOptions{
+		SimID:     fmt.Sprintf("%s-%03d", opts.SimIDPrefix, index),
+		SimName:   fmt.Sprintf("%s-%03d", opts.SimIDPrefix, index),
+		Seed:      opts.Seed + int64(index),
+		StartX:    float64(index),
+		StartY:    float64(index),
+		StartFood: fmt.Sprintf("%s-food-%03d", opts.SimIDPrefix, index),
+		StartAnt:  fmt.Sprintf("%s-ant-%03d", opts.SimIDPrefix, index),
+		Interval:  opts.Interval,
+	})
+
+	if err := wsjson.Write(ctx, conn, stream.NextEvent()); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(opts.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := wsjson.Write(ctx, conn, stream.NextEvent()); err != nil {
+				return err
+			}
+		}
 	}
 }

--- a/backend/internal/loadsim/stream.go
+++ b/backend/internal/loadsim/stream.go
@@ -237,6 +237,9 @@ func runClient(ctx context.Context, opts RunOptions, index int) error {
 	})
 
 	if err := wsjson.Write(ctx, conn, stream.NextEvent()); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return err
 	}
 
@@ -249,6 +252,9 @@ func runClient(ctx context.Context, opts RunOptions, index int) error {
 			return ctx.Err()
 		case <-ticker.C:
 			if err := wsjson.Write(ctx, conn, stream.NextEvent()); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				return err
 			}
 		}

--- a/backend/internal/loadsim/stream.go
+++ b/backend/internal/loadsim/stream.go
@@ -19,6 +19,8 @@ type ClientOptions struct {
 	StartY    float64
 	StartFood string
 	StartAnt  string
+	InitialAntCount int
+	InitialFoodCount int
 	Interval  time.Duration
 }
 
@@ -36,6 +38,8 @@ type RunOptions struct {
 	Duration    time.Duration
 	Interval    time.Duration
 	Seed        int64
+	InitialAntCount int
+	InitialFoodCount int
 	SimIDPrefix string
 }
 
@@ -46,6 +50,10 @@ type ClientEventStream struct {
 	x           float64
 	y           float64
 	step        int
+	foodIDs     []string
+	foodIndex   int
+	antIDs      []string
+	antIndex    int
 }
 
 func NewClientEventStream(opts ClientOptions) *ClientEventStream {
@@ -58,6 +66,12 @@ func NewClientEventStream(opts ClientOptions) *ClientEventStream {
 	if opts.StartAnt == "" {
 		opts.StartAnt = opts.SimID + "-ant"
 	}
+	if opts.InitialAntCount <= 0 {
+		opts.InitialAntCount = 26
+	}
+	if opts.InitialFoodCount <= 0 {
+		opts.InitialFoodCount = 80
+	}
 	if opts.Interval <= 0 {
 		opts.Interval = 20 * time.Millisecond
 	}
@@ -67,6 +81,8 @@ func NewClientEventStream(opts ClientOptions) *ClientEventStream {
 		timestampMS: 1_000 + opts.Seed,
 		x:           opts.StartX,
 		y:           opts.StartY,
+		antIDs:      buildAntIDs(opts.StartAnt, opts.InitialAntCount),
+		foodIDs:     buildFoodIDs(opts.StartFood, opts.InitialFoodCount),
 	}
 }
 
@@ -102,18 +118,28 @@ func (s *ClientEventStream) NextEvent() Event {
 			},
 		}
 	}
-
-	switch s.step % 3 {
-	case 0:
-		event := Event{
-			Type:        "food_drop",
+	if s.seq == 2 {
+		return Event{
+			Type:        "sim_food_snapshot",
 			SimID:       s.opts.SimID,
 			Seq:         s.seq,
 			TimestampMS: s.timestampMS,
 			Payload: map[string]any{
-				"food_id": s.opts.StartFood,
-				"x":       s.x,
-				"y":       s.y,
+				"foods": buildStartupFoods(s.foodIDs, s.opts.StartX, s.opts.StartY),
+			},
+		}
+	}
+
+	switch s.step % 3 {
+	case 0:
+		event := Event{
+			Type:        "food_pickup",
+			SimID:       s.opts.SimID,
+			Seq:         s.seq,
+			TimestampMS: s.timestampMS,
+			Payload: map[string]any{
+				"food_id": s.currentFoodID(),
+				"ant_id":  s.currentAntID(),
 			},
 		}
 		s.step++
@@ -127,7 +153,7 @@ func (s *ClientEventStream) NextEvent() Event {
 			Seq:         s.seq,
 			TimestampMS: s.timestampMS,
 			Payload: map[string]any{
-				"ant_id":       s.opts.StartAnt,
+				"ant_id":       s.currentAntID(),
 				"x":            s.x,
 				"y":            s.y,
 				"direction_x":  1.0,
@@ -139,14 +165,19 @@ func (s *ClientEventStream) NextEvent() Event {
 		return event
 	default:
 		event := Event{
-			Type:        "food_pickup",
+			Type:        "food_drop",
 			SimID:       s.opts.SimID,
 			Seq:         s.seq,
 			TimestampMS: s.timestampMS,
 			Payload: map[string]any{
-				"food_id": s.opts.StartFood,
+				"food_id": s.currentFoodID(),
+				"ant_id":  s.currentAntID(),
+				"x":       s.x,
+				"y":       s.y,
 			},
 		}
+		s.foodIndex++
+		s.antIndex++
 		s.step++
 		return event
 	}
@@ -178,6 +209,12 @@ func Run(ctx context.Context, opts RunOptions) error {
 	}
 	if opts.SimIDPrefix == "" {
 		opts.SimIDPrefix = "sim"
+	}
+	if opts.InitialFoodCount <= 0 {
+		opts.InitialFoodCount = 80
+	}
+	if opts.InitialAntCount <= 0 {
+		opts.InitialAntCount = 26
 	}
 
 	runCtx := ctx
@@ -233,6 +270,8 @@ func runClient(ctx context.Context, opts RunOptions, index int) error {
 		StartY:    float64(index),
 		StartFood: fmt.Sprintf("%s-food-%03d", opts.SimIDPrefix, index),
 		StartAnt:  fmt.Sprintf("%s-ant-%03d", opts.SimIDPrefix, index),
+		InitialAntCount: opts.InitialAntCount,
+		InitialFoodCount: opts.InitialFoodCount,
 		Interval:  opts.Interval,
 	})
 
@@ -259,4 +298,54 @@ func runClient(ctx context.Context, opts RunOptions, index int) error {
 			}
 		}
 	}
+}
+
+func (s *ClientEventStream) currentFoodID() string {
+	return s.foodIDs[s.foodIndex%len(s.foodIDs)]
+}
+
+func (s *ClientEventStream) currentAntID() string {
+	return s.antIDs[s.antIndex%len(s.antIDs)]
+}
+
+func buildAntIDs(base string, count int) []string {
+	if count <= 1 {
+		return []string{base}
+	}
+
+	ids := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		ids = append(ids, fmt.Sprintf("%s-%03d", base, i))
+	}
+	return ids
+}
+
+func buildFoodIDs(base string, count int) []string {
+	if count <= 1 {
+		return []string{base}
+	}
+
+	ids := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		ids = append(ids, fmt.Sprintf("%s-%03d", base, i))
+	}
+	return ids
+}
+
+func buildStartupFoods(foodIDs []string, startX, startY float64) []map[string]any {
+	foods := make([]map[string]any, 0, len(foodIDs))
+	for i, foodID := range foodIDs {
+		cluster := i % 5
+		ring := i / 5
+		baseX := startX + float64(cluster*120)
+		baseY := startY + float64((cluster%3)*90)
+		offsetX := float64((ring%3)*9 - 9)
+		offsetY := float64((ring/3)*9 - 9)
+		foods = append(foods, map[string]any{
+			"food_id": foodID,
+			"x":       baseX + offsetX,
+			"y":       baseY + offsetY,
+		})
+	}
+	return foods
 }

--- a/backend/internal/loadsim/stream_test.go
+++ b/backend/internal/loadsim/stream_test.go
@@ -2,6 +2,9 @@ package loadsim
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -38,10 +41,98 @@ func TestClientEventStreamStartsWithHelloAndDeterministicEvents(t *testing.T) {
 		}
 	}
 
-	wantTypes := []string{"sim_hello", "food_drop", "ant_turn_move", "food_pickup", "food_drop"}
+	wantTypes := []string{"sim_hello", "sim_food_snapshot", "food_pickup", "ant_turn_move", "food_drop"}
 	for i, want := range wantTypes {
 		if events[i].Type != want {
 			t.Fatalf("expected event %d type %q, got %q", i, want, events[i].Type)
 		}
 	}
+
+	if !strings.Contains(mustJSON(t, events[1]), "\"foods\"") {
+		t.Fatalf("expected startup snapshot payload to include foods, got %+v", events[1])
+	}
+}
+
+func TestClientEventStreamRotatesAcrossMultipleAnts(t *testing.T) {
+	stream := NewClientEventStream(ClientOptions{
+		SimID:            "sim-ants",
+		Seed:             9,
+		StartX:           0,
+		StartY:           0,
+		StartFood:        "food-ants",
+		StartAnt:         "ant-ants",
+		InitialFoodCount: 12,
+		InitialAntCount:  4,
+		Interval:         5 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	events := stream.NextEvents(ctx, 14)
+	ants := map[string]struct{}{}
+	for _, event := range events {
+		json := mustJSON(t, event)
+		for i := 0; i < 4; i++ {
+			id := fmt.Sprintf("ant-ants-%03d", i)
+			if strings.Contains(json, id) {
+				ants[id] = struct{}{}
+			}
+		}
+	}
+
+	if len(ants) < 3 {
+		t.Fatalf("expected fake stream to rotate across multiple ant ids, got %v from %+v", ants, events)
+	}
+}
+
+func TestStartupFoodSnapshotUsesClusteredPositions(t *testing.T) {
+	stream := NewClientEventStream(ClientOptions{
+		SimID:            "sim-foods",
+		Seed:             3,
+		StartX:           0,
+		StartY:           0,
+		StartFood:        "food-cluster",
+		InitialFoodCount: 20,
+		InitialAntCount:  2,
+		Interval:         5 * time.Millisecond,
+	})
+
+	snapshot := stream.NextEvents(context.Background(), 2)[1]
+	payload, ok := snapshot.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("expected snapshot payload map, got %#v", snapshot.Payload)
+	}
+	foods, ok := payload["foods"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected typed foods payload, got %#v", payload["foods"])
+	}
+
+	cells := map[string]int{}
+	for _, food := range foods {
+		x := int(food["x"].(float64) / 50)
+		y := int(food["y"].(float64) / 50)
+		cells[fmt.Sprintf("%d:%d", x, y)]++
+	}
+
+	maxCellCount := 0
+	for _, count := range cells {
+		if count > maxCellCount {
+			maxCellCount = count
+		}
+	}
+
+	if maxCellCount < 3 {
+		t.Fatalf("expected clustered startup foods with repeated cells, got cells=%v foods=%v", cells, foods)
+	}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("expected value to marshal: %v", err)
+	}
+	return string(data)
 }

--- a/backend/internal/loadsim/stream_test.go
+++ b/backend/internal/loadsim/stream_test.go
@@ -51,6 +51,9 @@ func TestClientEventStreamStartsWithHelloAndDeterministicEvents(t *testing.T) {
 	if !strings.Contains(mustJSON(t, events[1]), "\"foods\"") {
 		t.Fatalf("expected startup snapshot payload to include foods, got %+v", events[1])
 	}
+	if !strings.Contains(mustJSON(t, events[0]), "\"ant_count\":26") {
+		t.Fatalf("expected startup hello payload to include ant_count, got %+v", events[0])
+	}
 }
 
 func TestClientEventStreamRotatesAcrossMultipleAnts(t *testing.T) {

--- a/backend/internal/loadsim/stream_test.go
+++ b/backend/internal/loadsim/stream_test.go
@@ -1,0 +1,47 @@
+package loadsim
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestClientEventStreamStartsWithHelloAndDeterministicEvents(t *testing.T) {
+	stream := NewClientEventStream(ClientOptions{
+		SimID:      "sim-007",
+		Seed:       7,
+		StartX:     10,
+		StartY:     20,
+		StartFood:  "food-007",
+		StartAnt:   "ant-007",
+		Interval:   5 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	events := stream.NextEvents(ctx, 5)
+	if len(events) != 5 {
+		t.Fatalf("expected 5 events, got %d", len(events))
+	}
+
+	if events[0].Type != "sim_hello" {
+		t.Fatalf("expected first event to be sim_hello, got %q", events[0].Type)
+	}
+
+	for i, event := range events {
+		if event.SimID != "sim-007" {
+			t.Fatalf("expected event %d sim_id to be sim-007, got %q", i, event.SimID)
+		}
+		if event.Seq != uint64(i+1) {
+			t.Fatalf("expected event %d seq to be %d, got %d", i, i+1, event.Seq)
+		}
+	}
+
+	wantTypes := []string{"sim_hello", "food_drop", "ant_turn_move", "food_pickup", "food_drop"}
+	for i, want := range wantTypes {
+		if events[i].Type != want {
+			t.Fatalf("expected event %d type %q, got %q", i, want, events[i].Type)
+		}
+	}
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/antont/gatherers/backend/internal/config"
+)
+
+type Server struct {
+	cfg config.Config
+}
+
+func New(cfg config.Config) *Server {
+	return &Server{cfg: cfg}
+}
+
+func (s *Server) Handler() http.Handler {
+	return http.NewServeMux()
+}
+
+func (s *Server) Run(ctx context.Context) error {
+	httpServer := &http.Server{
+		Addr:    s.cfg.Addr,
+		Handler: s.Handler(),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- httpServer.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownErr := httpServer.Shutdown(context.Background())
+		if shutdownErr != nil {
+			return shutdownErr
+		}
+		err := <-errCh
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -80,6 +80,12 @@ type foodDropPayload struct {
 	Y      float64 `json:"y"`
 }
 
+type helloPayload struct {
+	SimName   string `json:"sim_name"`
+	AntCount  int    `json:"ant_count"`
+	FoodCount int    `json:"food_count"`
+}
+
 type foodPickupPayload struct {
 	FoodID string `json:"food_id"`
 }
@@ -216,6 +222,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
         <thead>
           <tr>
             <th>Sim</th>
+            <th>Ants</th>
             <th>Drops</th>
             <th>Pickups</th>
             <th>Moves</th>
@@ -223,7 +230,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
           </tr>
         </thead>
         <tbody id="sim-table-body">
-          <tr><td colspan="5">Waiting for realtime data...</td></tr>
+          <tr><td colspan="6">Waiting for realtime data...</td></tr>
         </tbody>
       </table>
     </section>
@@ -245,13 +252,14 @@ func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
 
       const sims = [...(snapshot.sims ?? [])].sort((a, b) => a.sim_id.localeCompare(b.sim_id));
       if (sims.length === 0) {
-        simTableBody.innerHTML = '<tr><td colspan="5">No sims connected yet.</td></tr>';
+        simTableBody.innerHTML = '<tr><td colspan="6">No sims connected yet.</td></tr>';
         return;
       }
 
       simTableBody.innerHTML = sims.map((sim) => {
         return '<tr>' +
           '<td>' + sim.sim_id + '</td>' +
+          '<td>' + (sim.ant_count ?? 0) + '</td>' +
           '<td>' + sim.drop_count + '</td>' +
           '<td>' + sim.pickup_count + '</td>' +
           '<td>' + sim.turn_move_count + '</td>' +
@@ -318,7 +326,13 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 
 		switch event.Type {
 		case "sim_hello":
-			s.store.RecordHello(event.SimID)
+			var payload helloPayload
+			if len(event.Payload) > 0 {
+				if err := json.Unmarshal(event.Payload, &payload); err != nil {
+					return
+				}
+			}
+			s.store.RecordHello(event.SimID, payload.AntCount)
 			s.broadcastDashboardSnapshot()
 		case "sim_food_snapshot":
 			var payload foodSnapshotPayload

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
-	"strconv"
 	"sync"
 
 	"github.com/antont/gatherers/backend/internal/config"
@@ -107,11 +107,166 @@ func (s *Server) handleSummary(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
 	summary := s.store.GlobalSummary()
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write([]byte("<!doctype html><html><body>" +
-		"<h1>Gatherers Backend</h1>" +
-		"<p>Connected sims: " + strconv.Itoa(summary.ConnectedSimCount) + "</p>" +
-		"<p>Loose food: " + strconv.Itoa(summary.LooseFoodCount) + "</p>" +
-		"</body></html>"))
+	_, _ = fmt.Fprintf(w, `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Gatherers Backend</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #111827;
+      --panel: #1f2937;
+      --panel-alt: #0f172a;
+      --text: #e5e7eb;
+      --muted: #94a3b8;
+      --accent: #34d399;
+      --border: #334155;
+    }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+    main {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+      gap: 16px;
+      margin: 24px 0;
+    }
+    .card, .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px;
+    }
+    .label {
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin-bottom: 8px;
+    }
+    .value {
+      font-size: 2rem;
+      font-weight: 700;
+    }
+    table {
+      width: 100%%;
+      border-collapse: collapse;
+    }
+    th, td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+    }
+    th {
+      color: var(--muted);
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .status {
+      color: var(--muted);
+      margin-top: 8px;
+    }
+    .accent {
+      color: var(--accent);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Gatherers Backend</h1>
+    <p class="status">Realtime dashboard fed by <span class="accent">/ws/dashboard</span>.</p>
+    <section class="cards">
+      <div class="card">
+        <div class="label">Connected sims</div>
+        <div class="value" id="connected-sims-value">%d</div>
+      </div>
+      <div class="card">
+        <div class="label">Loose food</div>
+        <div class="value" id="loose-food-value">%d</div>
+      </div>
+      <div class="card">
+        <div class="label">Occupied cells</div>
+        <div class="value" id="occupied-cells-value">%d</div>
+      </div>
+      <div class="card">
+        <div class="label">Mean nearest-neighbor distance</div>
+        <div class="value" id="nearest-neighbor-value">%.2f</div>
+      </div>
+    </section>
+    <section class="panel">
+      <div class="label">Last update</div>
+      <div id="last-updated-value">server-rendered snapshot</div>
+    </section>
+    <section class="panel" style="margin-top: 16px;">
+      <div class="label">Connected sims</div>
+      <table>
+        <thead>
+          <tr>
+            <th>Sim</th>
+            <th>Drops</th>
+            <th>Pickups</th>
+            <th>Moves</th>
+            <th>Loose food</th>
+          </tr>
+        </thead>
+        <tbody id="sim-table-body">
+          <tr><td colspan="5">Waiting for realtime data...</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+  <script>
+    const connectedSimsValue = document.getElementById("connected-sims-value");
+    const looseFoodValue = document.getElementById("loose-food-value");
+    const occupiedCellsValue = document.getElementById("occupied-cells-value");
+    const nearestNeighborValue = document.getElementById("nearest-neighbor-value");
+    const lastUpdatedValue = document.getElementById("last-updated-value");
+    const simTableBody = document.getElementById("sim-table-body");
+
+    function render(snapshot) {
+      connectedSimsValue.textContent = String(snapshot.summary.connected_sim_count ?? 0);
+      looseFoodValue.textContent = String(snapshot.summary.loose_food_count ?? 0);
+      occupiedCellsValue.textContent = String(snapshot.summary.occupied_cell_count ?? 0);
+      nearestNeighborValue.textContent = Number(snapshot.summary.nearest_neighbor_mean_distance ?? 0).toFixed(2);
+      lastUpdatedValue.textContent = new Date().toLocaleTimeString();
+
+      const sims = [...(snapshot.sims ?? [])].sort((a, b) => a.sim_id.localeCompare(b.sim_id));
+      if (sims.length === 0) {
+        simTableBody.innerHTML = '<tr><td colspan="5">No sims connected yet.</td></tr>';
+        return;
+      }
+
+      simTableBody.innerHTML = sims.map((sim) => {
+        return '<tr>' +
+          '<td>' + sim.sim_id + '</td>' +
+          '<td>' + sim.drop_count + '</td>' +
+          '<td>' + sim.pickup_count + '</td>' +
+          '<td>' + sim.turn_move_count + '</td>' +
+          '<td>' + sim.loose_food_count + '</td>' +
+          '</tr>';
+      }).join('');
+    }
+
+    const scheme = window.location.protocol === "https:" ? "wss" : "ws";
+    const socket = new WebSocket(scheme + "://" + window.location.host + "/ws/dashboard");
+    socket.addEventListener("message", (event) => {
+      render(JSON.parse(event.data));
+    });
+    socket.addEventListener("close", () => {
+      lastUpdatedValue.textContent = "dashboard websocket disconnected";
+    });
+  </script>
+</body>
+</html>`, summary.ConnectedSimCount, summary.LooseFoodCount, summary.OccupiedCellCount, summary.NearestNeighborMeanDistance)
 }
 
 func (s *Server) handleDashboardWS(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -28,6 +28,7 @@ func New(cfg config.Config) *Server {
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.handleDashboard)
+	mux.HandleFunc("/api/sims", s.handleSims)
 	mux.HandleFunc("/api/summary", s.handleSummary)
 	mux.HandleFunc("/ws/ingest", s.handleIngest)
 	return mux
@@ -77,6 +78,11 @@ type foodDropPayload struct {
 
 type foodPickupPayload struct {
 	FoodID string `json:"food_id"`
+}
+
+func (s *Server) handleSims(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.store.SimSummaries())
 }
 
 func (s *Server) handleSummary(w http.ResponseWriter, _ *http.Request) {
@@ -129,6 +135,8 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 			s.store.RecordPickup(event.SimID, state.FoodPickup{
 				FoodID: payload.FoodID,
 			})
+		case "ant_turn_move":
+			s.store.RecordTurnMove(event.SimID)
 		}
 	}
 }

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"sync"
 
 	"github.com/antont/gatherers/backend/internal/config"
 	"github.com/antont/gatherers/backend/internal/state"
@@ -14,14 +15,16 @@ import (
 )
 
 type Server struct {
-	cfg config.Config
+	cfg  config.Config
 	store *state.Store
+	hub  *dashboardHub
 }
 
 func New(cfg config.Config) *Server {
 	return &Server{
 		cfg:   cfg,
 		store: state.NewStore(50),
+		hub:   newDashboardHub(),
 	}
 }
 
@@ -30,6 +33,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/", s.handleDashboard)
 	mux.HandleFunc("/api/sims", s.handleSims)
 	mux.HandleFunc("/api/summary", s.handleSummary)
+	mux.HandleFunc("/ws/dashboard", s.handleDashboardWS)
 	mux.HandleFunc("/ws/ingest", s.handleIngest)
 	return mux
 }
@@ -80,6 +84,16 @@ type foodPickupPayload struct {
 	FoodID string `json:"food_id"`
 }
 
+type dashboardSnapshot struct {
+	Summary state.Summary      `json:"summary"`
+	Sims    []state.SimSummary `json:"sims"`
+}
+
+type dashboardHub struct {
+	mu      sync.Mutex
+	clients map[chan dashboardSnapshot]struct{}
+}
+
 func (s *Server) handleSims(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(s.store.SimSummaries())
@@ -100,6 +114,35 @@ func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
 		"</body></html>"))
 }
 
+func (s *Server) handleDashboardWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	updates, unsubscribe := s.hub.subscribe()
+	defer unsubscribe()
+
+	if err := wsjson.Write(r.Context(), conn, s.dashboardSnapshot()); err != nil {
+		return
+	}
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case snapshot, ok := <-updates:
+			if !ok {
+				return
+			}
+			if err := wsjson.Write(r.Context(), conn, snapshot); err != nil {
+				return
+			}
+		}
+	}
+}
+
 func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 	conn, err := websocket.Accept(w, r, nil)
 	if err != nil {
@@ -117,6 +160,7 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 		switch event.Type {
 		case "sim_hello":
 			s.store.RecordHello(event.SimID)
+			s.broadcastDashboardSnapshot()
 		case "food_drop":
 			var payload foodDropPayload
 			if err := json.Unmarshal(event.Payload, &payload); err != nil {
@@ -127,6 +171,7 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 				X:      payload.X,
 				Y:      payload.Y,
 			})
+			s.broadcastDashboardSnapshot()
 		case "food_pickup":
 			var payload foodPickupPayload
 			if err := json.Unmarshal(event.Payload, &payload); err != nil {
@@ -135,8 +180,64 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 			s.store.RecordPickup(event.SimID, state.FoodPickup{
 				FoodID: payload.FoodID,
 			})
+			s.broadcastDashboardSnapshot()
 		case "ant_turn_move":
 			s.store.RecordTurnMove(event.SimID)
+			s.broadcastDashboardSnapshot()
 		}
+	}
+}
+
+func newDashboardHub() *dashboardHub {
+	return &dashboardHub{
+		clients: make(map[chan dashboardSnapshot]struct{}),
+	}
+}
+
+func (h *dashboardHub) subscribe() (<-chan dashboardSnapshot, func()) {
+	ch := make(chan dashboardSnapshot, 1)
+
+	h.mu.Lock()
+	h.clients[ch] = struct{}{}
+	h.mu.Unlock()
+
+	return ch, func() {
+		h.mu.Lock()
+		if _, ok := h.clients[ch]; ok {
+			delete(h.clients, ch)
+			close(ch)
+		}
+		h.mu.Unlock()
+	}
+}
+
+func (h *dashboardHub) broadcast(snapshot dashboardSnapshot) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for ch := range h.clients {
+		select {
+		case ch <- snapshot:
+		default:
+			select {
+			case <-ch:
+			default:
+			}
+			select {
+			case ch <- snapshot:
+			default:
+			}
+		}
+	}
+}
+
+func (s *Server) broadcastDashboardSnapshot() {
+	s.hub.broadcast(s.dashboardSnapshot())
+}
+
+func (s *Server) dashboardSnapshot() dashboardSnapshot {
+	return dashboardSnapshot{
+		Summary: s.store.GlobalSummary(),
+		Sims:    s.store.SimSummaries(),
 	}
 }

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -84,6 +84,10 @@ type foodPickupPayload struct {
 	FoodID string `json:"food_id"`
 }
 
+type foodSnapshotPayload struct {
+	Foods []foodDropPayload `json:"foods"`
+}
+
 type dashboardSnapshot struct {
 	Summary state.Summary      `json:"summary"`
 	Sims    []state.SimSummary `json:"sims"`
@@ -315,6 +319,21 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 		switch event.Type {
 		case "sim_hello":
 			s.store.RecordHello(event.SimID)
+			s.broadcastDashboardSnapshot()
+		case "sim_food_snapshot":
+			var payload foodSnapshotPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return
+			}
+			foods := make([]state.FoodDrop, 0, len(payload.Foods))
+			for _, food := range payload.Foods {
+				foods = append(foods, state.FoodDrop{
+					FoodID: food.FoodID,
+					X:      food.X,
+					Y:      food.Y,
+				})
+			}
+			s.store.RecordFoodSnapshot(event.SimID, foods)
 			s.broadcastDashboardSnapshot()
 		case "food_drop":
 			var payload foodDropPayload

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -2,22 +2,33 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 
 	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/antont/gatherers/backend/internal/state"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 )
 
 type Server struct {
 	cfg config.Config
+	store *state.Store
 }
 
 func New(cfg config.Config) *Server {
-	return &Server{cfg: cfg}
+	return &Server{
+		cfg:   cfg,
+		store: state.NewStore(50),
+	}
 }
 
 func (s *Server) Handler() http.Handler {
-	return http.NewServeMux()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/summary", s.handleSummary)
+	mux.HandleFunc("/ws/ingest", s.handleIngest)
+	return mux
 }
 
 func (s *Server) Run(ctx context.Context) error {
@@ -47,5 +58,65 @@ func (s *Server) Run(ctx context.Context) error {
 			return nil
 		}
 		return err
+	}
+}
+
+type ingestEnvelope struct {
+	Type    string          `json:"type"`
+	SimID   string          `json:"sim_id"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+type foodDropPayload struct {
+	FoodID string  `json:"food_id"`
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+}
+
+type foodPickupPayload struct {
+	FoodID string `json:"food_id"`
+}
+
+func (s *Server) handleSummary(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.store.GlobalSummary())
+}
+
+func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	ctx := r.Context()
+	for {
+		var event ingestEnvelope
+		if err := wsjson.Read(ctx, conn, &event); err != nil {
+			return
+		}
+
+		switch event.Type {
+		case "sim_hello":
+			s.store.RecordHello(event.SimID)
+		case "food_drop":
+			var payload foodDropPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return
+			}
+			s.store.RecordDrop(event.SimID, state.FoodDrop{
+				FoodID: payload.FoodID,
+				X:      payload.X,
+				Y:      payload.Y,
+			})
+		case "food_pickup":
+			var payload foodPickupPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return
+			}
+			s.store.RecordPickup(event.SimID, state.FoodPickup{
+				FoodID: payload.FoodID,
+			})
+		}
 	}
 }

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/antont/gatherers/backend/internal/config"
 	"github.com/antont/gatherers/backend/internal/state"
@@ -26,6 +27,7 @@ func New(cfg config.Config) *Server {
 
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleDashboard)
 	mux.HandleFunc("/api/summary", s.handleSummary)
 	mux.HandleFunc("/ws/ingest", s.handleIngest)
 	return mux
@@ -80,6 +82,16 @@ type foodPickupPayload struct {
 func (s *Server) handleSummary(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(s.store.GlobalSummary())
+}
+
+func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
+	summary := s.store.GlobalSummary()
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte("<!doctype html><html><body>" +
+		"<h1>Gatherers Backend</h1>" +
+		"<p>Connected sims: " + strconv.Itoa(summary.ConnectedSimCount) + "</p>" +
+		"<p>Loose food: " + strconv.Itoa(summary.LooseFoodCount) + "</p>" +
+		"</body></html>"))
 }
 
 func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/antont/gatherers/backend/internal/config"
 	"github.com/antont/gatherers/backend/internal/state"
@@ -15,17 +16,51 @@ import (
 )
 
 type Server struct {
-	cfg  config.Config
+	cfg   config.Config
 	store *state.Store
-	hub  *dashboardHub
+	hub   *dashboardHub
+
+	snapshotMu     sync.RWMutex
+	cachedSnapshot dashboardSnapshot
+
+	refreshMu         sync.Mutex
+	dirty             bool
+	dashboardWatchers int
+	lastAPIReadAt     time.Time
+	nextEligibleAt    time.Time
+
+	refreshCh    chan struct{}
+	workerOnce   sync.Once
+	closeOnce    sync.Once
+	workerCancel context.CancelFunc
+
+	now                func() time.Time
+	minRefreshInterval time.Duration
+	maxRefreshInterval time.Duration
+	refreshMultiplier  int
+	apiDemandTTL       time.Duration
 }
 
 func New(cfg config.Config) *Server {
 	return &Server{
-		cfg:   cfg,
-		store: state.NewStore(50),
-		hub:   newDashboardHub(),
+		cfg:                cfg,
+		store:              state.NewStore(50),
+		hub:                newDashboardHub(),
+		refreshCh:          make(chan struct{}, 1),
+		now:                time.Now,
+		minRefreshInterval: 250 * time.Millisecond,
+		maxRefreshInterval: 5 * time.Second,
+		refreshMultiplier:  3,
+		apiDemandTTL:       10 * time.Second,
 	}
+}
+
+func (s *Server) Close() {
+	s.closeOnce.Do(func() {
+		if s.workerCancel != nil {
+			s.workerCancel()
+		}
+	})
 }
 
 func (s *Server) Handler() http.Handler {
@@ -39,6 +74,8 @@ func (s *Server) Handler() http.Handler {
 }
 
 func (s *Server) Run(ctx context.Context) error {
+	defer s.Close()
+
 	httpServer := &http.Server{
 		Addr:    s.cfg.Addr,
 		Handler: s.Handler(),
@@ -105,17 +142,21 @@ type dashboardHub struct {
 }
 
 func (s *Server) handleSims(w http.ResponseWriter, _ *http.Request) {
+	snapshot := s.currentSnapshot()
+	s.registerAPIDemand()
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(s.store.SimSummaries())
+	_ = json.NewEncoder(w).Encode(snapshot.Sims)
 }
 
 func (s *Server) handleSummary(w http.ResponseWriter, _ *http.Request) {
+	snapshot := s.currentSnapshot()
+	s.registerAPIDemand()
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(s.store.GlobalSummary())
+	_ = json.NewEncoder(w).Encode(snapshot.Summary)
 }
 
 func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
-	summary := s.store.GlobalSummary()
+	summary := s.currentSnapshot().Summary
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = fmt.Fprintf(w, `<!doctype html>
 <html lang="en">
@@ -211,6 +252,14 @@ func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
         <div class="label">Mean nearest-neighbor distance</div>
         <div class="value" id="nearest-neighbor-value">%.2f</div>
       </div>
+      <div class="card">
+        <div class="label">Elapsed time</div>
+        <div class="value" id="elapsed-seconds-value">%.1fs</div>
+      </div>
+      <div class="card">
+        <div class="label">Events/sec</div>
+        <div class="value" id="events-per-second-value">%.2f</div>
+      </div>
     </section>
     <section class="panel">
       <div class="label">Last update</div>
@@ -240,6 +289,8 @@ func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
     const looseFoodValue = document.getElementById("loose-food-value");
     const occupiedCellsValue = document.getElementById("occupied-cells-value");
     const nearestNeighborValue = document.getElementById("nearest-neighbor-value");
+    const elapsedSecondsValue = document.getElementById("elapsed-seconds-value");
+    const eventsPerSecondValue = document.getElementById("events-per-second-value");
     const lastUpdatedValue = document.getElementById("last-updated-value");
     const simTableBody = document.getElementById("sim-table-body");
 
@@ -248,6 +299,8 @@ func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
       looseFoodValue.textContent = String(snapshot.summary.loose_food_count ?? 0);
       occupiedCellsValue.textContent = String(snapshot.summary.occupied_cell_count ?? 0);
       nearestNeighborValue.textContent = Number(snapshot.summary.nearest_neighbor_mean_distance ?? 0).toFixed(2);
+      elapsedSecondsValue.textContent = Number(snapshot.summary.elapsed_seconds ?? 0).toFixed(1) + "s";
+      eventsPerSecondValue.textContent = Number(snapshot.summary.events_per_second ?? 0).toFixed(2);
       lastUpdatedValue.textContent = new Date().toLocaleTimeString();
 
       const sims = [...(snapshot.sims ?? [])].sort((a, b) => a.sim_id.localeCompare(b.sim_id));
@@ -278,7 +331,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, _ *http.Request) {
     });
   </script>
 </body>
-</html>`, summary.ConnectedSimCount, summary.LooseFoodCount, summary.OccupiedCellCount, summary.NearestNeighborMeanDistance)
+</html>`, summary.ConnectedSimCount, summary.LooseFoodCount, summary.OccupiedCellCount, summary.NearestNeighborMeanDistance, summary.ElapsedSeconds, summary.EventsPerSecond)
 }
 
 func (s *Server) handleDashboardWS(w http.ResponseWriter, r *http.Request) {
@@ -288,12 +341,16 @@ func (s *Server) handleDashboardWS(w http.ResponseWriter, r *http.Request) {
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
+	initialSnapshot := s.currentSnapshot()
 	updates, unsubscribe := s.hub.subscribe()
 	defer unsubscribe()
 
-	if err := wsjson.Write(r.Context(), conn, s.dashboardSnapshot()); err != nil {
+	if err := wsjson.Write(r.Context(), conn, initialSnapshot); err != nil {
 		return
 	}
+
+	s.addDashboardWatcher(1)
+	defer s.addDashboardWatcher(-1)
 
 	for {
 		select {
@@ -333,7 +390,7 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			s.store.RecordHello(event.SimID, payload.AntCount)
-			s.broadcastDashboardSnapshot()
+			s.markSnapshotDirty()
 		case "sim_food_snapshot":
 			var payload foodSnapshotPayload
 			if err := json.Unmarshal(event.Payload, &payload); err != nil {
@@ -348,7 +405,7 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 				})
 			}
 			s.store.RecordFoodSnapshot(event.SimID, foods)
-			s.broadcastDashboardSnapshot()
+			s.markSnapshotDirty()
 		case "food_drop":
 			var payload foodDropPayload
 			if err := json.Unmarshal(event.Payload, &payload); err != nil {
@@ -359,7 +416,7 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 				X:      payload.X,
 				Y:      payload.Y,
 			})
-			s.broadcastDashboardSnapshot()
+			s.markSnapshotDirty()
 		case "food_pickup":
 			var payload foodPickupPayload
 			if err := json.Unmarshal(event.Payload, &payload); err != nil {
@@ -368,10 +425,10 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 			s.store.RecordPickup(event.SimID, state.FoodPickup{
 				FoodID: payload.FoodID,
 			})
-			s.broadcastDashboardSnapshot()
+			s.markSnapshotDirty()
 		case "ant_turn_move":
 			s.store.RecordTurnMove(event.SimID)
-			s.broadcastDashboardSnapshot()
+			s.markSnapshotDirty()
 		}
 	}
 }
@@ -419,13 +476,169 @@ func (h *dashboardHub) broadcast(snapshot dashboardSnapshot) {
 	}
 }
 
-func (s *Server) broadcastDashboardSnapshot() {
-	s.hub.broadcast(s.dashboardSnapshot())
+func (s *Server) currentSnapshot() dashboardSnapshot {
+	s.snapshotMu.RLock()
+	defer s.snapshotMu.RUnlock()
+	return s.cachedSnapshot
 }
 
-func (s *Server) dashboardSnapshot() dashboardSnapshot {
+func (s *Server) replaceSnapshot(snapshot dashboardSnapshot) {
+	s.snapshotMu.Lock()
+	s.cachedSnapshot = snapshot
+	s.snapshotMu.Unlock()
+}
+
+func (s *Server) markSnapshotDirty() {
+	s.refreshMu.Lock()
+	s.dirty = true
+	hasDemand := s.hasDemandLocked(s.now())
+	s.refreshMu.Unlock()
+
+	if hasDemand {
+		s.ensureWorker()
+		s.signalRefresh()
+	}
+}
+
+func (s *Server) registerAPIDemand() {
+	s.refreshMu.Lock()
+	s.lastAPIReadAt = s.now()
+	s.refreshMu.Unlock()
+
+	s.ensureWorker()
+	s.signalRefresh()
+}
+
+func (s *Server) addDashboardWatcher(delta int) {
+	s.refreshMu.Lock()
+	s.dashboardWatchers += delta
+	if s.dashboardWatchers < 0 {
+		s.dashboardWatchers = 0
+	}
+	s.refreshMu.Unlock()
+
+	if delta > 0 {
+		s.ensureWorker()
+		s.signalRefresh()
+	}
+}
+
+func (s *Server) ensureWorker() {
+	s.workerOnce.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		s.workerCancel = cancel
+		go s.runSnapshotWorker(ctx)
+	})
+}
+
+func (s *Server) signalRefresh() {
+	select {
+	case s.refreshCh <- struct{}{}:
+	default:
+	}
+}
+
+func (s *Server) runSnapshotWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.refreshCh:
+			for {
+				delay, shouldWait, shouldRefresh := s.nextRefreshPlan(s.now())
+				if !shouldRefresh {
+					break
+				}
+				if shouldWait {
+					timer := time.NewTimer(delay)
+					select {
+					case <-ctx.Done():
+						if !timer.Stop() {
+							<-timer.C
+						}
+						return
+					case <-s.refreshCh:
+						if !timer.Stop() {
+							<-timer.C
+						}
+						continue
+					case <-timer.C:
+					}
+				}
+
+				if !s.claimDirtyRefresh(s.now()) {
+					continue
+				}
+
+				started := s.now()
+				snapshot := s.computeDashboardSnapshot()
+				computeDuration := s.now().Sub(started)
+				s.replaceSnapshot(snapshot)
+				s.finishRefresh(computeDuration)
+				s.hub.broadcast(snapshot)
+			}
+		}
+	}
+}
+
+func (s *Server) nextRefreshPlan(now time.Time) (delay time.Duration, shouldWait bool, shouldRefresh bool) {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	if !s.hasDemandLocked(now) || !s.dirty {
+		return 0, false, false
+	}
+	if !s.nextEligibleAt.IsZero() && now.Before(s.nextEligibleAt) {
+		return s.nextEligibleAt.Sub(now), true, true
+	}
+	return 0, false, true
+}
+
+func (s *Server) claimDirtyRefresh(now time.Time) bool {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	if !s.hasDemandLocked(now) || !s.dirty {
+		return false
+	}
+	if !s.nextEligibleAt.IsZero() && now.Before(s.nextEligibleAt) {
+		return false
+	}
+	s.dirty = false
+	return true
+}
+
+func (s *Server) finishRefresh(computeDuration time.Duration) {
+	s.refreshMu.Lock()
+	s.nextEligibleAt = s.now().Add(s.adaptiveRefreshInterval(computeDuration))
+	s.refreshMu.Unlock()
+}
+
+func (s *Server) adaptiveRefreshInterval(computeDuration time.Duration) time.Duration {
+	interval := computeDuration * time.Duration(s.refreshMultiplier)
+	if interval < s.minRefreshInterval {
+		interval = s.minRefreshInterval
+	}
+	if interval > s.maxRefreshInterval {
+		interval = s.maxRefreshInterval
+	}
+	return interval
+}
+
+func (s *Server) hasDemandLocked(now time.Time) bool {
+	if s.dashboardWatchers > 0 {
+		return true
+	}
+	if s.lastAPIReadAt.IsZero() {
+		return false
+	}
+	return now.Sub(s.lastAPIReadAt) <= s.apiDemandTTL
+}
+
+func (s *Server) computeDashboardSnapshot() dashboardSnapshot {
+	data := s.store.DashboardSnapshotData()
 	return dashboardSnapshot{
-		Summary: s.store.GlobalSummary(),
-		Sims:    s.store.SimSummaries(),
+		Summary: data.Summary(s.now()),
+		Sims:    data.SimSummaries(),
 	}
 }

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -106,6 +106,90 @@ func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
 	}
 }
 
+func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	events := []map[string]any{
+		{
+			"type":         "sim_hello",
+			"sim_id":       "sim-startup",
+			"seq":          1,
+			"timestamp_ms": 1000,
+			"payload":      map[string]any{"sim_name": "startup"},
+		},
+		{
+			"type":         "sim_food_snapshot",
+			"sim_id":       "sim-startup",
+			"seq":          2,
+			"timestamp_ms": 1001,
+			"payload": map[string]any{
+				"foods": []map[string]any{
+					{"food_id": "food-1", "x": 10.0, "y": 20.0},
+					{"food_id": "food-2", "x": 30.0, "y": 40.0},
+					{"food_id": "food-3", "x": 50.0, "y": 60.0},
+				},
+			},
+		},
+	}
+
+	for _, event := range events {
+		if err := wsjson.Write(ctx, conn, event); err != nil {
+			t.Fatalf("expected event %#v to be accepted over websocket: %v", event["type"], err)
+		}
+	}
+
+	resp, err := http.Get(testServer.URL + "/api/sims")
+	if err != nil {
+		t.Fatalf("expected sims endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var sims []struct {
+		SimID          string `json:"sim_id"`
+		LooseFoodCount int    `json:"loose_food_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
+		t.Fatalf("expected sims JSON to decode: %v", err)
+	}
+
+	if len(sims) != 1 {
+		t.Fatalf("expected one sim summary, got %d", len(sims))
+	}
+	if sims[0].SimID != "sim-startup" || sims[0].LooseFoodCount != 3 {
+		t.Fatalf("expected startup snapshot to seed 3 loose food items, got %+v", sims[0])
+	}
+
+	resp, err = http.Get(testServer.URL + "/api/summary")
+	if err != nil {
+		t.Fatalf("expected summary endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var summary struct {
+		ConnectedSimCount int `json:"connected_sim_count"`
+		LooseFoodCount    int `json:"loose_food_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("expected summary JSON to decode: %v", err)
+	}
+
+	if summary.ConnectedSimCount != 1 || summary.LooseFoodCount != 3 {
+		t.Fatalf("expected startup snapshot to count as 3 loose food items, got %+v", summary)
+	}
+}
+
 func TestDashboardShowsConnectedSimAndLooseFoodCounts(t *testing.T) {
 	srv := New(config.Config{})
 	testServer := httptest.NewServer(srv.Handler())

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -172,3 +172,32 @@ func TestDashboardShowsConnectedSimAndLooseFoodCounts(t *testing.T) {
 		t.Fatalf("expected dashboard to include the connected sim or loose food counts, body was %q", bodyText)
 	}
 }
+
+func TestDashboardPageBootstrapsRealtimeWebsocketUi(t *testing.T) {
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	resp, err := http.Get(testServer.URL + "/")
+	if err != nil {
+		t.Fatalf("expected dashboard endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("expected dashboard body to be readable: %v", err)
+	}
+
+	bodyText := string(body)
+	for _, required := range []string{
+		"/ws/dashboard",
+		"connected-sims-value",
+		"loose-food-value",
+		"sim-table-body",
+	} {
+		if !strings.Contains(bodyText, required) {
+			t.Fatalf("expected dashboard HTML to contain %q, body was %q", required, bodyText)
+		}
+	}
+}

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/antont/gatherers/backend/internal/loadsim"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 )
@@ -79,24 +80,12 @@ func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
 		}
 	}
 
-	resp, err := http.Get(testServer.URL + "/api/summary")
-	if err != nil {
-		t.Fatalf("expected summary endpoint to respond: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected summary endpoint status %d, got %d", http.StatusOK, resp.StatusCode)
-	}
-
-	var summary struct {
+	summary := waitForSummary(t, testServer.URL, 1500*time.Millisecond, func(summary struct {
 		ConnectedSimCount int `json:"connected_sim_count"`
 		LooseFoodCount    int `json:"loose_food_count"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
-		t.Fatalf("expected summary JSON to decode: %v", err)
-	}
-
+	}) bool {
+		return summary.ConnectedSimCount == 1 && summary.LooseFoodCount == 1
+	})
 	if summary.ConnectedSimCount != 1 {
 		t.Fatalf("expected 1 connected sim, got %d", summary.ConnectedSimCount)
 	}
@@ -104,6 +93,60 @@ func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
 	if summary.LooseFoodCount != 1 {
 		t.Fatalf("expected 1 loose food item after two drops and one pickup, got %d", summary.LooseFoodCount)
 	}
+}
+
+func TestSummaryReadStartsDemandAndEventuallyRefreshesCachedSnapshot(t *testing.T) {
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := loadsim.SendEvents(ctx, testServer.URL, []loadsim.Event{
+		{
+			Type:        "sim_hello",
+			SimID:       "sim-lazy-api",
+			Seq:         1,
+			TimestampMS: 1000,
+			Payload: map[string]any{
+				"sim_name":   "lazy-api",
+				"ant_count":  26,
+				"food_count": 80,
+			},
+		},
+		{
+			Type:        "food_drop",
+			SimID:       "sim-lazy-api",
+			Seq:         2,
+			TimestampMS: 1001,
+			Payload: map[string]any{
+				"food_id": "food-1",
+				"x":       10.0,
+				"y":       10.0,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected ingest events to succeed before demand starts: %v", err)
+	}
+
+	initial := fetchSummary(t, testServer.URL)
+	if initial.ConnectedSimCount != 0 || initial.LooseFoodCount != 0 {
+		t.Fatalf("expected first summary read to serve stale cached data before demand-driven refresh, got %+v", initial)
+	}
+
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	last := initial
+	for time.Now().Before(deadline) {
+		last = fetchSummary(t, testServer.URL)
+		if last.ConnectedSimCount == 1 && last.LooseFoodCount == 1 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatalf("expected repeated summary reads to trigger eventual cached refresh, last summary was %+v", last)
 }
 
 func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
@@ -150,19 +193,9 @@ func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
 		}
 	}
 
-	resp, err := http.Get(testServer.URL + "/api/sims")
-	if err != nil {
-		t.Fatalf("expected sims endpoint to respond: %v", err)
-	}
-	defer resp.Body.Close()
-
-	var sims []struct {
-		SimID          string `json:"sim_id"`
-		LooseFoodCount int    `json:"loose_food_count"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
-		t.Fatalf("expected sims JSON to decode: %v", err)
-	}
+	sims := waitForSimSummaries(t, testServer.URL, 1500*time.Millisecond, func(sims []simSummaryResponse) bool {
+		return len(sims) == 1 && sims[0].SimID == "sim-startup" && sims[0].LooseFoodCount == 3
+	})
 
 	if len(sims) != 1 {
 		t.Fatalf("expected one sim summary, got %d", len(sims))
@@ -171,22 +204,74 @@ func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
 		t.Fatalf("expected startup snapshot to seed 3 loose food items, got %+v", sims[0])
 	}
 
-	resp, err = http.Get(testServer.URL + "/api/summary")
-	if err != nil {
-		t.Fatalf("expected summary endpoint to respond: %v", err)
-	}
-	defer resp.Body.Close()
-
-	var summary struct {
+	summary := waitForSummary(t, testServer.URL, 1500*time.Millisecond, func(summary struct {
 		ConnectedSimCount int `json:"connected_sim_count"`
 		LooseFoodCount    int `json:"loose_food_count"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
-		t.Fatalf("expected summary JSON to decode: %v", err)
-	}
+	}) bool {
+		return summary.ConnectedSimCount == 1 && summary.LooseFoodCount == 3
+	})
 
 	if summary.ConnectedSimCount != 1 || summary.LooseFoodCount != 3 {
 		t.Fatalf("expected startup snapshot to count as 3 loose food items, got %+v", summary)
+	}
+}
+
+func TestSummaryIncludesElapsedTimeAndEventRate(t *testing.T) {
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	for _, event := range []map[string]any{
+		{
+			"type":         "sim_hello",
+			"sim_id":       "sim-rate",
+			"seq":          1,
+			"timestamp_ms": 1000,
+			"payload": map[string]any{
+				"sim_name":   "rate",
+				"ant_count":  26,
+				"food_count": 80,
+			},
+		},
+		{
+			"type":         "food_drop",
+			"sim_id":       "sim-rate",
+			"seq":          2,
+			"timestamp_ms": 1001,
+			"payload": map[string]any{
+				"food_id": "food-1",
+				"x":       10.0,
+				"y":       20.0,
+			},
+		},
+	} {
+		if err := wsjson.Write(ctx, conn, event); err != nil {
+			t.Fatalf("expected event %#v to be accepted over websocket: %v", event["type"], err)
+		}
+	}
+
+	summary := waitForExtendedSummary(t, testServer.URL, 1500*time.Millisecond, func(summary struct {
+		ElapsedSeconds  float64 `json:"elapsed_seconds"`
+		EventsPerSecond float64 `json:"events_per_second"`
+	}) bool {
+		return summary.ElapsedSeconds > 0 && summary.EventsPerSecond > 0
+	})
+
+	if summary.ElapsedSeconds <= 0 {
+		t.Fatalf("expected elapsed_seconds to be positive, got %f", summary.ElapsedSeconds)
+	}
+	if summary.EventsPerSecond <= 0 {
+		t.Fatalf("expected events_per_second to be positive, got %f", summary.EventsPerSecond)
 	}
 }
 
@@ -220,19 +305,9 @@ func TestSimHelloAntCountAppearsInPerSimSummary(t *testing.T) {
 		t.Fatalf("expected sim_hello to be accepted over websocket: %v", err)
 	}
 
-	resp, err := http.Get(testServer.URL + "/api/sims")
-	if err != nil {
-		t.Fatalf("expected sims endpoint to respond: %v", err)
-	}
-	defer resp.Body.Close()
-
-	var sims []struct {
-		SimID    string `json:"sim_id"`
-		AntCount int    `json:"ant_count"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
-		t.Fatalf("expected sims JSON to decode: %v", err)
-	}
+	sims := waitForSimSummaries(t, testServer.URL, 1500*time.Millisecond, func(sims []simSummaryResponse) bool {
+		return len(sims) == 1 && sims[0].SimID == "sim-meta" && sims[0].AntCount == 26
+	})
 
 	if len(sims) != 1 || sims[0].SimID != "sim-meta" || sims[0].AntCount != 26 {
 		t.Fatalf("expected ant_count metadata to appear in sim summary, got %+v", sims)
@@ -301,8 +376,93 @@ func TestDashboardShowsConnectedSimAndLooseFoodCounts(t *testing.T) {
 		t.Fatalf("expected dashboard to describe connected sims, body was %q", bodyText)
 	}
 
-	if !strings.Contains(bodyText, "1") {
-		t.Fatalf("expected dashboard to include the connected sim or loose food counts, body was %q", bodyText)
+	if !strings.Contains(bodyText, "connected-sims-value") || !strings.Contains(bodyText, "loose-food-value") {
+		t.Fatalf("expected dashboard to include cached count containers, body was %q", bodyText)
+	}
+}
+
+func waitForSummary(t *testing.T, baseURL string, timeout time.Duration, match func(struct {
+	ConnectedSimCount int `json:"connected_sim_count"`
+	LooseFoodCount    int `json:"loose_food_count"`
+}) bool) struct {
+	ConnectedSimCount int `json:"connected_sim_count"`
+	LooseFoodCount    int `json:"loose_food_count"`
+} {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	last := fetchSummary(t, baseURL)
+	for {
+		if match(last) {
+			return last
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected summary to converge before timeout, last summary was %+v", last)
+		}
+		time.Sleep(50 * time.Millisecond)
+		last = fetchSummary(t, baseURL)
+	}
+}
+
+func waitForExtendedSummary(t *testing.T, baseURL string, timeout time.Duration, match func(struct {
+	ElapsedSeconds  float64 `json:"elapsed_seconds"`
+	EventsPerSecond float64 `json:"events_per_second"`
+}) bool) struct {
+	ElapsedSeconds  float64 `json:"elapsed_seconds"`
+	EventsPerSecond float64 `json:"events_per_second"`
+} {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	last := fetchExtendedSummary(t, baseURL)
+	for {
+		if match(last) {
+			return last
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected extended summary to converge before timeout, last summary was %+v", last)
+		}
+		time.Sleep(50 * time.Millisecond)
+		last = fetchExtendedSummary(t, baseURL)
+	}
+}
+
+func fetchExtendedSummary(t *testing.T, baseURL string) struct {
+	ElapsedSeconds  float64 `json:"elapsed_seconds"`
+	EventsPerSecond float64 `json:"events_per_second"`
+} {
+	t.Helper()
+
+	resp, err := http.Get(baseURL + "/api/summary")
+	if err != nil {
+		t.Fatalf("expected summary endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var summary struct {
+		ElapsedSeconds  float64 `json:"elapsed_seconds"`
+		EventsPerSecond float64 `json:"events_per_second"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("expected summary JSON to decode: %v", err)
+	}
+	return summary
+}
+
+func waitForSimSummaries(t *testing.T, baseURL string, timeout time.Duration, match func([]simSummaryResponse) bool) []simSummaryResponse {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	last := fetchSimSummaries(t, baseURL)
+	for {
+		if match(last) {
+			return last
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected sim summaries to converge before timeout, last summaries were %+v", last)
+		}
+		time.Sleep(50 * time.Millisecond)
+		last = fetchSimSummaries(t, baseURL)
 	}
 }
 
@@ -327,6 +487,8 @@ func TestDashboardPageBootstrapsRealtimeWebsocketUi(t *testing.T) {
 		"/ws/dashboard",
 		"connected-sims-value",
 		"loose-food-value",
+		"elapsed-seconds-value",
+		"events-per-second-value",
 		"sim-table-body",
 		"sim.ant_count",
 		"Ants",

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -102,5 +103,72 @@ func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
 
 	if summary.LooseFoodCount != 1 {
 		t.Fatalf("expected 1 loose food item after two drops and one pickup, got %d", summary.LooseFoodCount)
+	}
+}
+
+func TestDashboardShowsConnectedSimAndLooseFoodCounts(t *testing.T) {
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	events := []map[string]any{
+		{
+			"type":         "sim_hello",
+			"sim_id":       "sim-dashboard",
+			"seq":          1,
+			"timestamp_ms": 1000,
+			"payload":      map[string]any{"sim_name": "dashboard"},
+		},
+		{
+			"type":         "food_drop",
+			"sim_id":       "sim-dashboard",
+			"seq":          2,
+			"timestamp_ms": 1001,
+			"payload": map[string]any{
+				"food_id": "food-1",
+				"x":       25.0,
+				"y":       25.0,
+			},
+		},
+	}
+
+	for _, event := range events {
+		if err := wsjson.Write(ctx, conn, event); err != nil {
+			t.Fatalf("expected event %#v to be accepted over websocket: %v", event["type"], err)
+		}
+	}
+
+	resp, err := http.Get(testServer.URL + "/")
+	if err != nil {
+		t.Fatalf("expected dashboard endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected dashboard status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("expected dashboard body to be readable: %v", err)
+	}
+
+	bodyText := string(body)
+	if !strings.Contains(bodyText, "Connected sims") {
+		t.Fatalf("expected dashboard to describe connected sims, body was %q", bodyText)
+	}
+
+	if !strings.Contains(bodyText, "1") {
+		t.Fatalf("expected dashboard to include the connected sim or loose food counts, body was %q", bodyText)
 	}
 }

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -190,6 +190,55 @@ func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
 	}
 }
 
+func TestSimHelloAntCountAppearsInPerSimSummary(t *testing.T) {
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	event := map[string]any{
+		"type":         "sim_hello",
+		"sim_id":       "sim-meta",
+		"seq":          1,
+		"timestamp_ms": 1000,
+		"payload": map[string]any{
+			"sim_name":   "meta",
+			"ant_count":  26,
+			"food_count": 80,
+		},
+	}
+	if err := wsjson.Write(ctx, conn, event); err != nil {
+		t.Fatalf("expected sim_hello to be accepted over websocket: %v", err)
+	}
+
+	resp, err := http.Get(testServer.URL + "/api/sims")
+	if err != nil {
+		t.Fatalf("expected sims endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var sims []struct {
+		SimID    string `json:"sim_id"`
+		AntCount int    `json:"ant_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
+		t.Fatalf("expected sims JSON to decode: %v", err)
+	}
+
+	if len(sims) != 1 || sims[0].SimID != "sim-meta" || sims[0].AntCount != 26 {
+		t.Fatalf("expected ant_count metadata to appear in sim summary, got %+v", sims)
+	}
+}
+
 func TestDashboardShowsConnectedSimAndLooseFoodCounts(t *testing.T) {
 	srv := New(config.Config{})
 	testServer := httptest.NewServer(srv.Handler())
@@ -279,6 +328,8 @@ func TestDashboardPageBootstrapsRealtimeWebsocketUi(t *testing.T) {
 		"connected-sims-value",
 		"loose-food-value",
 		"sim-table-body",
+		"sim.ant_count",
+		"Ants",
 	} {
 		if !strings.Contains(bodyText, required) {
 			t.Fatalf("expected dashboard HTML to contain %q, body was %q", required, bodyText)

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	events := []map[string]any{
+		{
+			"type":         "sim_hello",
+			"sim_id":       "sim-a",
+			"seq":          1,
+			"timestamp_ms": 1000,
+			"payload": map[string]any{
+				"sim_name": "local-a",
+			},
+		},
+		{
+			"type":         "food_drop",
+			"sim_id":       "sim-a",
+			"seq":          2,
+			"timestamp_ms": 1001,
+			"payload": map[string]any{
+				"food_id": "food-1",
+				"x":       10.0,
+				"y":       10.0,
+			},
+		},
+		{
+			"type":         "food_drop",
+			"sim_id":       "sim-a",
+			"seq":          3,
+			"timestamp_ms": 1002,
+			"payload": map[string]any{
+				"food_id": "food-2",
+				"x":       12.0,
+				"y":       12.0,
+			},
+		},
+		{
+			"type":         "food_pickup",
+			"sim_id":       "sim-a",
+			"seq":          4,
+			"timestamp_ms": 1003,
+			"payload": map[string]any{
+				"food_id": "food-1",
+			},
+		},
+	}
+
+	for _, event := range events {
+		if err := wsjson.Write(ctx, conn, event); err != nil {
+			t.Fatalf("expected event %#v to be accepted over websocket: %v", event["type"], err)
+		}
+	}
+
+	resp, err := http.Get(testServer.URL + "/api/summary")
+	if err != nil {
+		t.Fatalf("expected summary endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected summary endpoint status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	var summary struct {
+		ConnectedSimCount int `json:"connected_sim_count"`
+		LooseFoodCount    int `json:"loose_food_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("expected summary JSON to decode: %v", err)
+	}
+
+	if summary.ConnectedSimCount != 1 {
+		t.Fatalf("expected 1 connected sim, got %d", summary.ConnectedSimCount)
+	}
+
+	if summary.LooseFoodCount != 1 {
+		t.Fatalf("expected 1 loose food item after two drops and one pickup, got %d", summary.LooseFoodCount)
+	}
+}

--- a/backend/internal/server/server_dashboard_ws_test.go
+++ b/backend/internal/server/server_dashboard_ws_test.go
@@ -88,6 +88,71 @@ func TestDashboardWebsocketReceivesUpdatedSnapshotAfterIngest(t *testing.T) {
 	}
 }
 
+func TestDashboardWebsocketStartsWithCachedSnapshotThenCatchesUp(t *testing.T) {
+	srv := New(config.Config{})
+	target := newTestTarget(t, srv.Handler())
+	defer target.closeFn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := loadsim.SendEvents(ctx, target.baseURL, []loadsim.Event{
+		{
+			Type:        "sim_hello",
+			SimID:       "sim-lazy-dashboard",
+			Seq:         1,
+			TimestampMS: 1000,
+			Payload: map[string]any{
+				"sim_name":   "lazy-dashboard",
+				"ant_count":  26,
+				"food_count": 80,
+			},
+		},
+		{
+			Type:        "food_drop",
+			SimID:       "sim-lazy-dashboard",
+			Seq:         2,
+			TimestampMS: 1001,
+			Payload: map[string]any{
+				"food_id": "food-1",
+				"x":       12.0,
+				"y":       18.0,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected ingest events to succeed before demand starts: %v", err)
+	}
+
+	dashboardConn, _, err := websocket.Dial(ctx, websocketURL(target.baseURL, "/ws/dashboard"), nil)
+	if err != nil {
+		t.Fatalf("expected dashboard websocket endpoint to accept connection: %v", err)
+	}
+	defer dashboardConn.Close(websocket.StatusNormalClosure, "")
+
+	var initial dashboardSnapshotMessage
+	if err := wsjson.Read(ctx, dashboardConn, &initial); err != nil {
+		t.Fatalf("expected initial cached dashboard snapshot: %v", err)
+	}
+
+	if initial.Summary.ConnectedSimCount != 0 || initial.Summary.LooseFoodCount != 0 || len(initial.Sims) != 0 {
+		t.Fatalf("expected first dashboard snapshot to be stale cached state before demand-driven refresh, got %+v", initial)
+	}
+
+	update := waitForDashboardSnapshot(t, ctx, dashboardConn, func(snapshot dashboardSnapshotMessage) bool {
+		return snapshot.Summary.ConnectedSimCount == 1 &&
+			snapshot.Summary.LooseFoodCount == 1 &&
+			len(snapshot.Sims) == 1 &&
+			snapshot.Sims[0].SimID == "sim-lazy-dashboard" &&
+			snapshot.Sims[0].DropCount == 1 &&
+			snapshot.Sims[0].LooseFoodCount == 1
+	})
+
+	if update.Summary.ConnectedSimCount != 1 || update.Summary.LooseFoodCount != 1 {
+		t.Fatalf("expected demand-driven dashboard refresh to catch up, got %+v", update)
+	}
+}
+
 type dashboardSnapshotMessage struct {
 	Summary struct {
 		ConnectedSimCount int `json:"connected_sim_count"`

--- a/backend/internal/server/server_dashboard_ws_test.go
+++ b/backend/internal/server/server_dashboard_ws_test.go
@@ -45,7 +45,11 @@ func TestDashboardWebsocketReceivesUpdatedSnapshotAfterIngest(t *testing.T) {
 			SimID:       "sim-dashboard",
 			Seq:         1,
 			TimestampMS: 1000,
-			Payload:     map[string]any{"sim_name": "dashboard"},
+			Payload: map[string]any{
+				"sim_name":   "dashboard",
+				"ant_count":  26,
+				"food_count": 80,
+			},
 		},
 		{
 			Type:        "food_drop",
@@ -68,6 +72,7 @@ func TestDashboardWebsocketReceivesUpdatedSnapshotAfterIngest(t *testing.T) {
 			snapshot.Summary.LooseFoodCount == 1 &&
 			len(snapshot.Sims) == 1 &&
 			snapshot.Sims[0].SimID == "sim-dashboard" &&
+			snapshot.Sims[0].AntCount == 26 &&
 			snapshot.Sims[0].DropCount == 1 &&
 			snapshot.Sims[0].LooseFoodCount == 1
 	})
@@ -78,7 +83,7 @@ func TestDashboardWebsocketReceivesUpdatedSnapshotAfterIngest(t *testing.T) {
 	if update.Summary.LooseFoodCount != 1 {
 		t.Fatalf("expected loose food count 1, got %d", update.Summary.LooseFoodCount)
 	}
-	if len(update.Sims) != 1 || update.Sims[0].SimID != "sim-dashboard" || update.Sims[0].DropCount != 1 || update.Sims[0].LooseFoodCount != 1 {
+	if len(update.Sims) != 1 || update.Sims[0].SimID != "sim-dashboard" || update.Sims[0].AntCount != 26 || update.Sims[0].DropCount != 1 || update.Sims[0].LooseFoodCount != 1 {
 		t.Fatalf("unexpected dashboard sim snapshot: %+v", update.Sims)
 	}
 }
@@ -90,6 +95,7 @@ type dashboardSnapshotMessage struct {
 	} `json:"summary"`
 	Sims []struct {
 		SimID          string `json:"sim_id"`
+		AntCount       int    `json:"ant_count"`
 		DropCount      int    `json:"drop_count"`
 		LooseFoodCount int    `json:"loose_food_count"`
 	} `json:"sims"`

--- a/backend/internal/server/server_dashboard_ws_test.go
+++ b/backend/internal/server/server_dashboard_ws_test.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/antont/gatherers/backend/internal/loadsim"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+func TestDashboardWebsocketReceivesUpdatedSnapshotAfterIngest(t *testing.T) {
+	srv := New(config.Config{})
+	target := newTestTarget(t, srv.Handler())
+	defer target.closeFn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	dashboardConn, _, err := websocket.Dial(ctx, websocketURL(target.baseURL, "/ws/dashboard"), nil)
+	if err != nil {
+		t.Fatalf("expected dashboard websocket endpoint to accept connection: %v", err)
+	}
+	defer dashboardConn.Close(websocket.StatusNormalClosure, "")
+
+	var initial struct {
+		Summary struct {
+			ConnectedSimCount int `json:"connected_sim_count"`
+		} `json:"summary"`
+	}
+	if err := wsjson.Read(ctx, dashboardConn, &initial); err != nil {
+		t.Fatalf("expected initial dashboard snapshot: %v", err)
+	}
+
+	if initial.Summary.ConnectedSimCount != 0 {
+		t.Fatalf("expected initial connected sim count to be 0, got %d", initial.Summary.ConnectedSimCount)
+	}
+
+	err = loadsim.SendEvents(ctx, target.baseURL, []loadsim.Event{
+		{
+			Type:        "sim_hello",
+			SimID:       "sim-dashboard",
+			Seq:         1,
+			TimestampMS: 1000,
+			Payload:     map[string]any{"sim_name": "dashboard"},
+		},
+		{
+			Type:        "food_drop",
+			SimID:       "sim-dashboard",
+			Seq:         2,
+			TimestampMS: 1001,
+			Payload: map[string]any{
+				"food_id": "food-1",
+				"x":       25.0,
+				"y":       25.0,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected ingest events to succeed: %v", err)
+	}
+
+	update := waitForDashboardSnapshot(t, ctx, dashboardConn, func(snapshot dashboardSnapshotMessage) bool {
+		return snapshot.Summary.ConnectedSimCount == 1 &&
+			snapshot.Summary.LooseFoodCount == 1 &&
+			len(snapshot.Sims) == 1 &&
+			snapshot.Sims[0].SimID == "sim-dashboard" &&
+			snapshot.Sims[0].DropCount == 1 &&
+			snapshot.Sims[0].LooseFoodCount == 1
+	})
+
+	if update.Summary.ConnectedSimCount != 1 {
+		t.Fatalf("expected connected sim count 1, got %d", update.Summary.ConnectedSimCount)
+	}
+	if update.Summary.LooseFoodCount != 1 {
+		t.Fatalf("expected loose food count 1, got %d", update.Summary.LooseFoodCount)
+	}
+	if len(update.Sims) != 1 || update.Sims[0].SimID != "sim-dashboard" || update.Sims[0].DropCount != 1 || update.Sims[0].LooseFoodCount != 1 {
+		t.Fatalf("unexpected dashboard sim snapshot: %+v", update.Sims)
+	}
+}
+
+type dashboardSnapshotMessage struct {
+	Summary struct {
+		ConnectedSimCount int `json:"connected_sim_count"`
+		LooseFoodCount    int `json:"loose_food_count"`
+	} `json:"summary"`
+	Sims []struct {
+		SimID          string `json:"sim_id"`
+		DropCount      int    `json:"drop_count"`
+		LooseFoodCount int    `json:"loose_food_count"`
+	} `json:"sims"`
+}
+
+func waitForDashboardSnapshot(t *testing.T, ctx context.Context, conn *websocket.Conn, match func(dashboardSnapshotMessage) bool) dashboardSnapshotMessage {
+	t.Helper()
+
+	for {
+		var snapshot dashboardSnapshotMessage
+		if err := wsjson.Read(ctx, conn, &snapshot); err != nil {
+			t.Fatalf("expected matching dashboard snapshot: %v", err)
+		}
+		if match(snapshot) {
+			return snapshot
+		}
+	}
+}
+
+func websocketURL(baseURL, path string) string {
+	switch {
+	case strings.HasPrefix(baseURL, "https://"):
+		return "wss://" + strings.TrimPrefix(baseURL, "https://") + path
+	default:
+		return "ws://" + strings.TrimPrefix(baseURL, "http://") + path
+	}
+}

--- a/backend/internal/server/server_fake_clients_test.go
+++ b/backend/internal/server/server_fake_clients_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 	"slices"
 	"strings"
 	"testing"
@@ -46,12 +44,12 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 			Seq:         3,
 			TimestampMS: 1002,
 			Payload: map[string]any{
-				"ant_id":       "ant-a1",
-				"x":            11.0,
-				"y":            12.0,
-				"direction_x":  0.5,
-				"direction_y":  0.5,
-				"frame":        3,
+				"ant_id":      "ant-a1",
+				"x":           11.0,
+				"y":           12.0,
+				"direction_x": 0.5,
+				"direction_y": 0.5,
+				"frame":       3,
 			},
 		},
 	})
@@ -86,48 +84,30 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 		},
 	})
 
-	resp, err := http.Get(target.baseURL + "/api/sims")
-	if err != nil {
-		t.Fatalf("expected sims endpoint to respond: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected sims endpoint status %d, got %d", http.StatusOK, resp.StatusCode)
-	}
-
-	var sims []struct {
-		SimID         string `json:"sim_id"`
-		PickupCount   int    `json:"pickup_count"`
-		DropCount     int    `json:"drop_count"`
-		TurnMoveCount int    `json:"turn_move_count"`
-		LooseFoodCount int   `json:"loose_food_count"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
-		t.Fatalf("expected sims JSON to decode: %v", err)
-	}
+	sims := waitForSimSummaries(t, target.baseURL, 1500*time.Millisecond, func(sims []simSummaryResponse) bool {
+		if len(sims) < 2 {
+			return false
+		}
+		simAIndex := slices.IndexFunc(sims, func(sim simSummaryResponse) bool { return sim.SimID == "sim-a" })
+		simBIndex := slices.IndexFunc(sims, func(sim simSummaryResponse) bool { return sim.SimID == "sim-b" })
+		if simAIndex == -1 || simBIndex == -1 {
+			return false
+		}
+		simA := sims[simAIndex]
+		simB := sims[simBIndex]
+		return simA.DropCount == 1 && simA.TurnMoveCount == 1 && simA.LooseFoodCount == 1 &&
+			simB.DropCount == 1 && simB.PickupCount == 1 && simB.LooseFoodCount == 0
+	})
 
 	if len(sims) < 2 {
 		t.Fatalf("expected at least 2 sim summaries, got %d", len(sims))
 	}
 
-	slices.SortFunc(sims, func(a, b struct {
-		SimID         string `json:"sim_id"`
-		PickupCount   int    `json:"pickup_count"`
-		DropCount     int    `json:"drop_count"`
-		TurnMoveCount int    `json:"turn_move_count"`
-		LooseFoodCount int   `json:"loose_food_count"`
-	}) int {
+	slices.SortFunc(sims, func(a, b simSummaryResponse) int {
 		return strings.Compare(a.SimID, b.SimID)
 	})
 
-	simAIndex := slices.IndexFunc(sims, func(sim struct {
-		SimID          string `json:"sim_id"`
-		PickupCount    int    `json:"pickup_count"`
-		DropCount      int    `json:"drop_count"`
-		TurnMoveCount  int    `json:"turn_move_count"`
-		LooseFoodCount int    `json:"loose_food_count"`
-	}) bool {
+	simAIndex := slices.IndexFunc(sims, func(sim simSummaryResponse) bool {
 		return sim.SimID == "sim-a"
 	})
 	if simAIndex == -1 {
@@ -138,13 +118,7 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 		t.Fatalf("unexpected sim-a summary: %+v", simA)
 	}
 
-	simBIndex := slices.IndexFunc(sims, func(sim struct {
-		SimID          string `json:"sim_id"`
-		PickupCount    int    `json:"pickup_count"`
-		DropCount      int    `json:"drop_count"`
-		TurnMoveCount  int    `json:"turn_move_count"`
-		LooseFoodCount int    `json:"loose_food_count"`
-	}) bool {
+	simBIndex := slices.IndexFunc(sims, func(sim simSummaryResponse) bool {
 		return sim.SimID == "sim-b"
 	})
 	if simBIndex == -1 {

--- a/backend/internal/server/server_fake_clients_test.go
+++ b/backend/internal/server/server_fake_clients_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"slices"
 	"strings"
 	"testing"
@@ -17,13 +16,13 @@ import (
 
 func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	target := newTestTarget(t, srv.Handler())
+	defer target.closeFn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	sendClientEvents(t, ctx, testServer.URL, []map[string]any{
+	sendClientEvents(t, ctx, target.baseURL, []map[string]any{
 		{
 			"type":         "sim_hello",
 			"sim_id":       "sim-a",
@@ -58,7 +57,7 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 		},
 	})
 
-	sendClientEvents(t, ctx, testServer.URL, []map[string]any{
+	sendClientEvents(t, ctx, target.baseURL, []map[string]any{
 		{
 			"type":         "sim_hello",
 			"sim_id":       "sim-b",
@@ -88,7 +87,7 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 		},
 	})
 
-	resp, err := http.Get(testServer.URL + "/api/sims")
+	resp, err := http.Get(target.baseURL + "/api/sims")
 	if err != nil {
 		t.Fatalf("expected sims endpoint to respond: %v", err)
 	}
@@ -109,8 +108,8 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 		t.Fatalf("expected sims JSON to decode: %v", err)
 	}
 
-	if len(sims) != 2 {
-		t.Fatalf("expected 2 sim summaries, got %d", len(sims))
+	if len(sims) < 2 {
+		t.Fatalf("expected at least 2 sim summaries, got %d", len(sims))
 	}
 
 	slices.SortFunc(sims, func(a, b struct {
@@ -123,12 +122,38 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 		return strings.Compare(a.SimID, b.SimID)
 	})
 
-	if sims[0].SimID != "sim-a" || sims[0].DropCount != 1 || sims[0].TurnMoveCount != 1 || sims[0].LooseFoodCount != 1 {
-		t.Fatalf("unexpected sim-a summary: %+v", sims[0])
+	simAIndex := slices.IndexFunc(sims, func(sim struct {
+		SimID          string `json:"sim_id"`
+		PickupCount    int    `json:"pickup_count"`
+		DropCount      int    `json:"drop_count"`
+		TurnMoveCount  int    `json:"turn_move_count"`
+		LooseFoodCount int    `json:"loose_food_count"`
+	}) bool {
+		return sim.SimID == "sim-a"
+	})
+	if simAIndex == -1 {
+		t.Fatalf("expected sim-a summary to be present, got %+v", sims)
+	}
+	simA := sims[simAIndex]
+	if simA.DropCount != 1 || simA.TurnMoveCount != 1 || simA.LooseFoodCount != 1 {
+		t.Fatalf("unexpected sim-a summary: %+v", simA)
 	}
 
-	if sims[1].SimID != "sim-b" || sims[1].DropCount != 1 || sims[1].PickupCount != 1 || sims[1].LooseFoodCount != 0 {
-		t.Fatalf("unexpected sim-b summary: %+v", sims[1])
+	simBIndex := slices.IndexFunc(sims, func(sim struct {
+		SimID          string `json:"sim_id"`
+		PickupCount    int    `json:"pickup_count"`
+		DropCount      int    `json:"drop_count"`
+		TurnMoveCount  int    `json:"turn_move_count"`
+		LooseFoodCount int    `json:"loose_food_count"`
+	}) bool {
+		return sim.SimID == "sim-b"
+	})
+	if simBIndex == -1 {
+		t.Fatalf("expected sim-b summary to be present, got %+v", sims)
+	}
+	simB := sims[simBIndex]
+	if simB.DropCount != 1 || simB.PickupCount != 1 || simB.LooseFoodCount != 0 {
+		t.Fatalf("unexpected sim-b summary: %+v", simB)
 	}
 }
 

--- a/backend/internal/server/server_fake_clients_test.go
+++ b/backend/internal/server/server_fake_clients_test.go
@@ -10,8 +10,7 @@ import (
 	"time"
 
 	"github.com/antont/gatherers/backend/internal/config"
-	"github.com/coder/websocket"
-	"github.com/coder/websocket/wsjson"
+	"github.com/antont/gatherers/backend/internal/loadsim"
 )
 
 func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
@@ -22,31 +21,31 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	sendClientEvents(t, ctx, target.baseURL, []map[string]any{
+	sendClientEvents(t, ctx, target.baseURL, []loadsim.Event{
 		{
-			"type":         "sim_hello",
-			"sim_id":       "sim-a",
-			"seq":          1,
-			"timestamp_ms": 1000,
-			"payload":      map[string]any{"sim_name": "alpha"},
+			Type:        "sim_hello",
+			SimID:       "sim-a",
+			Seq:         1,
+			TimestampMS: 1000,
+			Payload:     map[string]any{"sim_name": "alpha"},
 		},
 		{
-			"type":         "food_drop",
-			"sim_id":       "sim-a",
-			"seq":          2,
-			"timestamp_ms": 1001,
-			"payload": map[string]any{
+			Type:        "food_drop",
+			SimID:       "sim-a",
+			Seq:         2,
+			TimestampMS: 1001,
+			Payload: map[string]any{
 				"food_id": "food-a1",
 				"x":       10.0,
 				"y":       10.0,
 			},
 		},
 		{
-			"type":         "ant_turn_move",
-			"sim_id":       "sim-a",
-			"seq":          3,
-			"timestamp_ms": 1002,
-			"payload": map[string]any{
+			Type:        "ant_turn_move",
+			SimID:       "sim-a",
+			Seq:         3,
+			TimestampMS: 1002,
+			Payload: map[string]any{
 				"ant_id":       "ant-a1",
 				"x":            11.0,
 				"y":            12.0,
@@ -57,31 +56,31 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 		},
 	})
 
-	sendClientEvents(t, ctx, target.baseURL, []map[string]any{
+	sendClientEvents(t, ctx, target.baseURL, []loadsim.Event{
 		{
-			"type":         "sim_hello",
-			"sim_id":       "sim-b",
-			"seq":          1,
-			"timestamp_ms": 2000,
-			"payload":      map[string]any{"sim_name": "beta"},
+			Type:        "sim_hello",
+			SimID:       "sim-b",
+			Seq:         1,
+			TimestampMS: 2000,
+			Payload:     map[string]any{"sim_name": "beta"},
 		},
 		{
-			"type":         "food_drop",
-			"sim_id":       "sim-b",
-			"seq":          2,
-			"timestamp_ms": 2001,
-			"payload": map[string]any{
+			Type:        "food_drop",
+			SimID:       "sim-b",
+			Seq:         2,
+			TimestampMS: 2001,
+			Payload: map[string]any{
 				"food_id": "food-b1",
 				"x":       100.0,
 				"y":       50.0,
 			},
 		},
 		{
-			"type":         "food_pickup",
-			"sim_id":       "sim-b",
-			"seq":          3,
-			"timestamp_ms": 2002,
-			"payload": map[string]any{
+			Type:        "food_pickup",
+			SimID:       "sim-b",
+			Seq:         3,
+			TimestampMS: 2002,
+			Payload: map[string]any{
 				"food_id": "food-b1",
 			},
 		},
@@ -157,19 +156,14 @@ func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
 	}
 }
 
-func sendClientEvents(t *testing.T, ctx context.Context, baseURL string, events []map[string]any) {
+func sendClientEvents(t *testing.T, ctx context.Context, baseURL string, events []loadsim.Event) {
 	t.Helper()
 
-	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) + "/ws/ingest"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
-	if err != nil {
-		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
-	}
-	defer conn.Close(websocket.StatusNormalClosure, "")
-
-	for _, event := range events {
-		if err := wsjson.Write(ctx, conn, event); err != nil {
-			t.Fatalf("expected event %#v to be accepted over websocket: %v", event["type"], err)
+	if err := loadsim.SendEvents(ctx, baseURL, events); err != nil {
+		failedType := "<unknown>"
+		if len(events) > 0 {
+			failedType = events[0].Type
 		}
+		t.Fatalf("expected %q event batch to be accepted over websocket: %v", failedType, err)
 	}
 }

--- a/backend/internal/server/server_fake_clients_test.go
+++ b/backend/internal/server/server_fake_clients_test.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+func TestFakeClientsPopulatePerSimSummaries(t *testing.T) {
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	sendClientEvents(t, ctx, testServer.URL, []map[string]any{
+		{
+			"type":         "sim_hello",
+			"sim_id":       "sim-a",
+			"seq":          1,
+			"timestamp_ms": 1000,
+			"payload":      map[string]any{"sim_name": "alpha"},
+		},
+		{
+			"type":         "food_drop",
+			"sim_id":       "sim-a",
+			"seq":          2,
+			"timestamp_ms": 1001,
+			"payload": map[string]any{
+				"food_id": "food-a1",
+				"x":       10.0,
+				"y":       10.0,
+			},
+		},
+		{
+			"type":         "ant_turn_move",
+			"sim_id":       "sim-a",
+			"seq":          3,
+			"timestamp_ms": 1002,
+			"payload": map[string]any{
+				"ant_id":       "ant-a1",
+				"x":            11.0,
+				"y":            12.0,
+				"direction_x":  0.5,
+				"direction_y":  0.5,
+				"frame":        3,
+			},
+		},
+	})
+
+	sendClientEvents(t, ctx, testServer.URL, []map[string]any{
+		{
+			"type":         "sim_hello",
+			"sim_id":       "sim-b",
+			"seq":          1,
+			"timestamp_ms": 2000,
+			"payload":      map[string]any{"sim_name": "beta"},
+		},
+		{
+			"type":         "food_drop",
+			"sim_id":       "sim-b",
+			"seq":          2,
+			"timestamp_ms": 2001,
+			"payload": map[string]any{
+				"food_id": "food-b1",
+				"x":       100.0,
+				"y":       50.0,
+			},
+		},
+		{
+			"type":         "food_pickup",
+			"sim_id":       "sim-b",
+			"seq":          3,
+			"timestamp_ms": 2002,
+			"payload": map[string]any{
+				"food_id": "food-b1",
+			},
+		},
+	})
+
+	resp, err := http.Get(testServer.URL + "/api/sims")
+	if err != nil {
+		t.Fatalf("expected sims endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected sims endpoint status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	var sims []struct {
+		SimID         string `json:"sim_id"`
+		PickupCount   int    `json:"pickup_count"`
+		DropCount     int    `json:"drop_count"`
+		TurnMoveCount int    `json:"turn_move_count"`
+		LooseFoodCount int   `json:"loose_food_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
+		t.Fatalf("expected sims JSON to decode: %v", err)
+	}
+
+	if len(sims) != 2 {
+		t.Fatalf("expected 2 sim summaries, got %d", len(sims))
+	}
+
+	slices.SortFunc(sims, func(a, b struct {
+		SimID         string `json:"sim_id"`
+		PickupCount   int    `json:"pickup_count"`
+		DropCount     int    `json:"drop_count"`
+		TurnMoveCount int    `json:"turn_move_count"`
+		LooseFoodCount int   `json:"loose_food_count"`
+	}) int {
+		return strings.Compare(a.SimID, b.SimID)
+	})
+
+	if sims[0].SimID != "sim-a" || sims[0].DropCount != 1 || sims[0].TurnMoveCount != 1 || sims[0].LooseFoodCount != 1 {
+		t.Fatalf("unexpected sim-a summary: %+v", sims[0])
+	}
+
+	if sims[1].SimID != "sim-b" || sims[1].DropCount != 1 || sims[1].PickupCount != 1 || sims[1].LooseFoodCount != 0 {
+		t.Fatalf("unexpected sim-b summary: %+v", sims[1])
+	}
+}
+
+func sendClientEvents(t *testing.T, ctx context.Context, baseURL string, events []map[string]any) {
+	t.Helper()
+
+	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) + "/ws/ingest"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	for _, event := range events {
+		if err := wsjson.Write(ctx, conn, event); err != nil {
+			t.Fatalf("expected event %#v to be accepted over websocket: %v", event["type"], err)
+		}
+	}
+}

--- a/backend/internal/server/server_load_runner_test.go
+++ b/backend/internal/server/server_load_runner_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/antont/gatherers/backend/internal/loadsim"
+)
+
+func TestLoadRunnerGeneratesMixedPerSimActivity(t *testing.T) {
+	srv := New(config.Config{})
+	target := newTestTarget(t, srv.Handler())
+	defer target.closeFn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := loadsim.Run(ctx, loadsim.RunOptions{
+		BaseURL:     target.baseURL,
+		ClientCount: 3,
+		Duration:    150 * time.Millisecond,
+		Interval:    10 * time.Millisecond,
+		Seed:        42,
+		SimIDPrefix: "manual",
+	})
+	if err != nil {
+		t.Fatalf("expected load runner to complete successfully: %v", err)
+	}
+
+	resp, err := http.Get(target.baseURL + "/api/sims")
+	if err != nil {
+		t.Fatalf("expected sims endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var sims []struct {
+		SimID         string `json:"sim_id"`
+		PickupCount   int    `json:"pickup_count"`
+		DropCount     int    `json:"drop_count"`
+		TurnMoveCount int    `json:"turn_move_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
+		t.Fatalf("expected sims JSON to decode: %v", err)
+	}
+
+	if len(sims) != 3 {
+		t.Fatalf("expected 3 sim summaries, got %d", len(sims))
+	}
+
+	for _, sim := range sims {
+		if sim.DropCount == 0 {
+			t.Fatalf("expected %s to report at least one drop, got %+v", sim.SimID, sim)
+		}
+		if sim.PickupCount == 0 {
+			t.Fatalf("expected %s to report at least one pickup, got %+v", sim.SimID, sim)
+		}
+		if sim.TurnMoveCount == 0 {
+			t.Fatalf("expected %s to report at least one move, got %+v", sim.SimID, sim)
+		}
+	}
+}

--- a/backend/internal/server/server_load_runner_test.go
+++ b/backend/internal/server/server_load_runner_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 	"testing"
 	"time"
 
@@ -31,21 +29,17 @@ func TestLoadRunnerGeneratesMixedPerSimActivity(t *testing.T) {
 		t.Fatalf("expected load runner to complete successfully: %v", err)
 	}
 
-	resp, err := http.Get(target.baseURL + "/api/sims")
-	if err != nil {
-		t.Fatalf("expected sims endpoint to respond: %v", err)
-	}
-	defer resp.Body.Close()
-
-	var sims []struct {
-		SimID         string `json:"sim_id"`
-		PickupCount   int    `json:"pickup_count"`
-		DropCount     int    `json:"drop_count"`
-		TurnMoveCount int    `json:"turn_move_count"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
-		t.Fatalf("expected sims JSON to decode: %v", err)
-	}
+	sims := waitForSimSummaries(t, target.baseURL, 1500*time.Millisecond, func(sims []simSummaryResponse) bool {
+		if len(sims) != 3 {
+			return false
+		}
+		for _, sim := range sims {
+			if sim.DropCount == 0 || sim.PickupCount == 0 || sim.TurnMoveCount == 0 {
+				return false
+			}
+		}
+		return true
+	})
 
 	if len(sims) != 3 {
 		t.Fatalf("expected 3 sim summaries, got %d", len(sims))

--- a/backend/internal/server/server_long_stress_test.go
+++ b/backend/internal/server/server_long_stress_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/antont/gatherers/backend/internal/loadsim"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+func TestLongStressDashboardReflectsSustainedLoad(t *testing.T) {
+	if os.Getenv("GATHERERS_RUN_LONG_STRESS") == "" {
+		t.Skip("set GATHERERS_RUN_LONG_STRESS=1 to run sustained load coverage")
+	}
+
+	srv := New(config.Config{})
+	target := newTestTarget(t, srv.Handler())
+	defer target.closeFn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dashboardConn, _, err := websocket.Dial(ctx, websocketURL(target.baseURL, "/ws/dashboard"), nil)
+	if err != nil {
+		t.Fatalf("expected dashboard websocket endpoint to accept connection: %v", err)
+	}
+	defer dashboardConn.Close(websocket.StatusNormalClosure, "")
+
+	var initial dashboardSnapshotMessage
+	if err := wsjson.Read(ctx, dashboardConn, &initial); err != nil {
+		t.Fatalf("expected initial dashboard snapshot: %v", err)
+	}
+
+	err = loadsim.Run(ctx, loadsim.RunOptions{
+		BaseURL:     target.baseURL,
+		ClientCount: 25,
+		Duration:    2 * time.Second,
+		Interval:    25 * time.Millisecond,
+		Seed:        99,
+		SimIDPrefix: "long",
+	})
+	if err != nil {
+		t.Fatalf("expected long stress load to complete successfully: %v", err)
+	}
+
+	update := waitForDashboardSnapshot(t, ctx, dashboardConn, func(snapshot dashboardSnapshotMessage) bool {
+		return snapshot.Summary.ConnectedSimCount >= 25 &&
+			snapshot.Summary.LooseFoodCount >= 10
+	})
+
+	if update.Summary.ConnectedSimCount < 25 {
+		t.Fatalf("expected at least 25 connected sims, got %d", update.Summary.ConnectedSimCount)
+	}
+
+	summary := fetchSummary(t, target.baseURL)
+	if summary.ConnectedSimCount < 25 {
+		t.Fatalf("expected summary endpoint to report at least 25 connected sims, got %d", summary.ConnectedSimCount)
+	}
+
+	resp, err := http.Get(target.baseURL + "/api/sims")
+	if err != nil {
+		t.Fatalf("expected sims endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+}

--- a/backend/internal/server/server_stress_test.go
+++ b/backend/internal/server/server_stress_test.go
@@ -72,7 +72,14 @@ func TestStressHundredFakeClients(t *testing.T) {
 		}
 	}
 
-	finalSummary := fetchSummary(t, target.baseURL)
+	finalSummary := waitForSummary(t, target.baseURL, 1500*time.Millisecond, func(summary struct {
+		ConnectedSimCount int `json:"connected_sim_count"`
+		LooseFoodCount    int `json:"loose_food_count"`
+	}) bool {
+		connectedDelta := summary.ConnectedSimCount - initialSummary.ConnectedSimCount
+		looseFoodDelta := summary.LooseFoodCount - initialSummary.LooseFoodCount
+		return connectedDelta >= clientCount && looseFoodDelta >= clientCount
+	})
 
 	connectedDelta := finalSummary.ConnectedSimCount - initialSummary.ConnectedSimCount
 	looseFoodDelta := finalSummary.LooseFoodCount - initialSummary.LooseFoodCount
@@ -86,8 +93,199 @@ func TestStressHundredFakeClients(t *testing.T) {
 	}
 }
 
+func TestStressHundredFakeClientsDeliversExactEventTotals(t *testing.T) {
+	const (
+		clientCount       = 100
+		initialFoodCount  = 80
+		activityTriplets  = 20
+		totalEventsPerSim = 2 + activityTriplets*3
+	)
+
+	srv := New(config.Config{})
+	target := newTestTarget(t, srv.Handler())
+	defer target.closeFn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := make(chan struct{})
+	errCh := make(chan error, clientCount)
+	var wg sync.WaitGroup
+
+	for i := 0; i < clientCount; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+
+			simID := fmt.Sprintf("exact-%03d", i)
+			stream := loadsim.NewClientEventStream(loadsim.ClientOptions{
+				SimID:            simID,
+				SimName:          simID,
+				Seed:             int64(1_000 + i),
+				StartX:           float64(i),
+				StartY:           float64(i),
+				StartFood:        fmt.Sprintf("%s-food", simID),
+				StartAnt:         fmt.Sprintf("%s-ant", simID),
+				InitialAntCount:  26,
+				InitialFoodCount: initialFoodCount,
+				Interval:         5 * time.Millisecond,
+			})
+			events := stream.NextEvents(context.Background(), totalEventsPerSim)
+			if len(events) != totalEventsPerSim {
+				errCh <- fmt.Errorf("%s generated %d events, want %d", simID, len(events), totalEventsPerSim)
+				return
+			}
+
+			if err := sendClientEventsErr(ctx, target.baseURL, events); err != nil {
+				errCh <- fmt.Errorf("%s failed after attempting %d events: %w", simID, len(events), err)
+				return
+			}
+
+			errCh <- nil
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	var sendErrors []error
+	for err := range errCh {
+		if err != nil {
+			sendErrors = append(sendErrors, err)
+		}
+	}
+	if len(sendErrors) > 0 {
+		t.Fatalf("expected all %d clients to deliver %d events each without error, got %d errors; first error: %v", clientCount, totalEventsPerSim, len(sendErrors), sendErrors[0])
+	}
+
+	sims := waitForExactSimTotals(t, target.baseURL, 10*time.Second, exactSimTotals{
+		SimCount:          clientCount,
+		PickupCount:       clientCount * activityTriplets,
+		DropCount:         clientCount * activityTriplets,
+		TurnMoveCount:     clientCount * activityTriplets,
+		LooseFoodCount:    clientCount * initialFoodCount,
+		PerSimPickupCount: activityTriplets,
+		PerSimDropCount:   activityTriplets,
+		PerSimMoveCount:   activityTriplets,
+		PerSimLooseFood:   initialFoodCount,
+	})
+
+	if len(sims) != clientCount {
+		t.Fatalf("expected %d sim summaries, got %d", clientCount, len(sims))
+	}
+}
+
 func sendClientEventsErr(ctx context.Context, baseURL string, events []loadsim.Event) error {
 	return loadsim.SendEvents(ctx, baseURL, events)
+}
+
+type simSummaryResponse struct {
+	SimID          string `json:"sim_id"`
+	AntCount       int    `json:"ant_count"`
+	PickupCount    int    `json:"pickup_count"`
+	DropCount      int    `json:"drop_count"`
+	TurnMoveCount  int    `json:"turn_move_count"`
+	LooseFoodCount int    `json:"loose_food_count"`
+}
+
+type exactSimTotals struct {
+	SimCount          int
+	PickupCount       int
+	DropCount         int
+	TurnMoveCount     int
+	LooseFoodCount    int
+	PerSimPickupCount int
+	PerSimDropCount   int
+	PerSimMoveCount   int
+	PerSimLooseFood   int
+}
+
+func waitForExactSimTotals(t *testing.T, baseURL string, timeout time.Duration, want exactSimTotals) []simSummaryResponse {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var last []simSummaryResponse
+	for time.Now().Before(deadline) {
+		last = fetchSimSummaries(t, baseURL)
+		if matchesExactTotals(last, want) {
+			return last
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	totalPickups, totalDrops, totalMoves, totalLooseFood := aggregateSimTotals(last)
+	first := simSummaryResponse{}
+	if len(last) > 0 {
+		first = last[0]
+	}
+	t.Fatalf(
+		"lost events under stress: expected sims=%d pickups=%d drops=%d moves=%d loose_food=%d and per-sim pickup/drop/move/loose=%d/%d/%d/%d; got sims=%d pickups=%d drops=%d moves=%d loose_food=%d first_sim=%+v",
+		want.SimCount,
+		want.PickupCount,
+		want.DropCount,
+		want.TurnMoveCount,
+		want.LooseFoodCount,
+		want.PerSimPickupCount,
+		want.PerSimDropCount,
+		want.PerSimMoveCount,
+		want.PerSimLooseFood,
+		len(last),
+		totalPickups,
+		totalDrops,
+		totalMoves,
+		totalLooseFood,
+		first,
+	)
+	return nil
+}
+
+func fetchSimSummaries(t *testing.T, baseURL string) []simSummaryResponse {
+	t.Helper()
+
+	resp, err := http.Get(baseURL + "/api/sims")
+	if err != nil {
+		t.Fatalf("expected sims endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var sims []simSummaryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
+		t.Fatalf("expected sims JSON to decode: %v", err)
+	}
+	return sims
+}
+
+func matchesExactTotals(sims []simSummaryResponse, want exactSimTotals) bool {
+	if len(sims) != want.SimCount {
+		return false
+	}
+	totalPickups, totalDrops, totalMoves, totalLooseFood := aggregateSimTotals(sims)
+	if totalPickups != want.PickupCount || totalDrops != want.DropCount || totalMoves != want.TurnMoveCount || totalLooseFood != want.LooseFoodCount {
+		return false
+	}
+
+	for _, sim := range sims {
+		if sim.PickupCount != want.PerSimPickupCount ||
+			sim.DropCount != want.PerSimDropCount ||
+			sim.TurnMoveCount != want.PerSimMoveCount ||
+			sim.LooseFoodCount != want.PerSimLooseFood {
+			return false
+		}
+	}
+
+	return true
+}
+
+func aggregateSimTotals(sims []simSummaryResponse) (pickups int, drops int, moves int, looseFood int) {
+	for _, sim := range sims {
+		pickups += sim.PickupCount
+		drops += sim.DropCount
+		moves += sim.TurnMoveCount
+		looseFood += sim.LooseFoodCount
+	}
+	return pickups, drops, moves, looseFood
 }
 
 func fetchSummary(t *testing.T, baseURL string) struct {

--- a/backend/internal/server/server_stress_test.go
+++ b/backend/internal/server/server_stress_test.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+func TestStressHundredFakeClients(t *testing.T) {
+	const clientCount = 100
+
+	srv := New(config.Config{})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := make(chan struct{})
+	errCh := make(chan error, clientCount)
+	var wg sync.WaitGroup
+
+	for i := 0; i < clientCount; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+
+			simID := fmt.Sprintf("sim-%03d", i)
+			err := sendClientEventsErr(ctx, testServer.URL, []map[string]any{
+				{
+					"type":         "sim_hello",
+					"sim_id":       simID,
+					"seq":          1,
+					"timestamp_ms": 1000 + i,
+					"payload": map[string]any{
+						"sim_name": simID,
+					},
+				},
+				{
+					"type":         "food_drop",
+					"sim_id":       simID,
+					"seq":          2,
+					"timestamp_ms": 2000 + i,
+					"payload": map[string]any{
+						"food_id": fmt.Sprintf("food-%03d", i),
+						"x":       float64(i),
+						"y":       float64(i),
+					},
+				},
+			})
+			errCh <- err
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("expected all fake clients to complete successfully: %v", err)
+		}
+	}
+
+	resp, err := http.Get(testServer.URL + "/api/summary")
+	if err != nil {
+		t.Fatalf("expected summary endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var summary struct {
+		ConnectedSimCount int `json:"connected_sim_count"`
+		LooseFoodCount    int `json:"loose_food_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("expected summary JSON to decode: %v", err)
+	}
+
+	if summary.ConnectedSimCount != clientCount {
+		t.Fatalf("expected %d connected sims after stress run, got %d", clientCount, summary.ConnectedSimCount)
+	}
+
+	if summary.LooseFoodCount != clientCount {
+		t.Fatalf("expected %d loose food items after stress run, got %d", clientCount, summary.LooseFoodCount)
+	}
+}
+
+func sendClientEventsErr(ctx context.Context, baseURL string, events []map[string]any) error {
+	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) + "/ws/ingest"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	for _, event := range events {
+		if err := wsjson.Write(ctx, conn, event); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/backend/internal/server/server_stress_test.go
+++ b/backend/internal/server/server_stress_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -20,11 +19,13 @@ func TestStressHundredFakeClients(t *testing.T) {
 	const clientCount = 100
 
 	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	target := newTestTarget(t, srv.Handler())
+	defer target.closeFn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	initialSummary := fetchSummary(t, target.baseURL)
 
 	start := make(chan struct{})
 	errCh := make(chan error, clientCount)
@@ -37,7 +38,7 @@ func TestStressHundredFakeClients(t *testing.T) {
 			<-start
 
 			simID := fmt.Sprintf("sim-%03d", i)
-			err := sendClientEventsErr(ctx, testServer.URL, []map[string]any{
+			err := sendClientEventsErr(ctx, target.baseURL, []map[string]any{
 				{
 					"type":         "sim_hello",
 					"sim_id":       simID,
@@ -73,26 +74,17 @@ func TestStressHundredFakeClients(t *testing.T) {
 		}
 	}
 
-	resp, err := http.Get(testServer.URL + "/api/summary")
-	if err != nil {
-		t.Fatalf("expected summary endpoint to respond: %v", err)
-	}
-	defer resp.Body.Close()
+	finalSummary := fetchSummary(t, target.baseURL)
 
-	var summary struct {
-		ConnectedSimCount int `json:"connected_sim_count"`
-		LooseFoodCount    int `json:"loose_food_count"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
-		t.Fatalf("expected summary JSON to decode: %v", err)
+	connectedDelta := finalSummary.ConnectedSimCount - initialSummary.ConnectedSimCount
+	looseFoodDelta := finalSummary.LooseFoodCount - initialSummary.LooseFoodCount
+
+	if connectedDelta < clientCount {
+		t.Fatalf("expected connected sim count to increase by at least %d, got initial=%d final=%d", clientCount, initialSummary.ConnectedSimCount, finalSummary.ConnectedSimCount)
 	}
 
-	if summary.ConnectedSimCount != clientCount {
-		t.Fatalf("expected %d connected sims after stress run, got %d", clientCount, summary.ConnectedSimCount)
-	}
-
-	if summary.LooseFoodCount != clientCount {
-		t.Fatalf("expected %d loose food items after stress run, got %d", clientCount, summary.LooseFoodCount)
+	if looseFoodDelta < clientCount {
+		t.Fatalf("expected loose food count to increase by at least %d, got initial=%d final=%d", clientCount, initialSummary.LooseFoodCount, finalSummary.LooseFoodCount)
 	}
 }
 
@@ -111,4 +103,27 @@ func sendClientEventsErr(ctx context.Context, baseURL string, events []map[strin
 	}
 
 	return nil
+}
+
+func fetchSummary(t *testing.T, baseURL string) struct {
+	ConnectedSimCount int `json:"connected_sim_count"`
+	LooseFoodCount    int `json:"loose_food_count"`
+} {
+	t.Helper()
+
+	resp, err := http.Get(baseURL + "/api/summary")
+	if err != nil {
+		t.Fatalf("expected summary endpoint to respond: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var summary struct {
+		ConnectedSimCount int `json:"connected_sim_count"`
+		LooseFoodCount    int `json:"loose_food_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("expected summary JSON to decode: %v", err)
+	}
+
+	return summary
 }

--- a/backend/internal/server/server_stress_test.go
+++ b/backend/internal/server/server_stress_test.go
@@ -5,14 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/antont/gatherers/backend/internal/config"
-	"github.com/coder/websocket"
-	"github.com/coder/websocket/wsjson"
+	"github.com/antont/gatherers/backend/internal/loadsim"
 )
 
 func TestStressHundredFakeClients(t *testing.T) {
@@ -38,22 +36,22 @@ func TestStressHundredFakeClients(t *testing.T) {
 			<-start
 
 			simID := fmt.Sprintf("sim-%03d", i)
-			err := sendClientEventsErr(ctx, target.baseURL, []map[string]any{
+			err := sendClientEventsErr(ctx, target.baseURL, []loadsim.Event{
 				{
-					"type":         "sim_hello",
-					"sim_id":       simID,
-					"seq":          1,
-					"timestamp_ms": 1000 + i,
-					"payload": map[string]any{
+					Type:        "sim_hello",
+					SimID:       simID,
+					Seq:         1,
+					TimestampMS: int64(1000 + i),
+					Payload: map[string]any{
 						"sim_name": simID,
 					},
 				},
 				{
-					"type":         "food_drop",
-					"sim_id":       simID,
-					"seq":          2,
-					"timestamp_ms": 2000 + i,
-					"payload": map[string]any{
+					Type:        "food_drop",
+					SimID:       simID,
+					Seq:         2,
+					TimestampMS: int64(2000 + i),
+					Payload: map[string]any{
 						"food_id": fmt.Sprintf("food-%03d", i),
 						"x":       float64(i),
 						"y":       float64(i),
@@ -88,21 +86,8 @@ func TestStressHundredFakeClients(t *testing.T) {
 	}
 }
 
-func sendClientEventsErr(ctx context.Context, baseURL string, events []map[string]any) error {
-	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) + "/ws/ingest"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
-	if err != nil {
-		return err
-	}
-	defer conn.Close(websocket.StatusNormalClosure, "")
-
-	for _, event := range events {
-		if err := wsjson.Write(ctx, conn, event); err != nil {
-			return err
-		}
-	}
-
-	return nil
+func sendClientEventsErr(ctx context.Context, baseURL string, events []loadsim.Event) error {
+	return loadsim.SendEvents(ctx, baseURL, events)
 }
 
 func fetchSummary(t *testing.T, baseURL string) struct {

--- a/backend/internal/server/test_target.go
+++ b/backend/internal/server/test_target.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+type testTarget struct {
+	baseURL  string
+	external bool
+	closeFn  func()
+}
+
+func newTestTarget(t *testing.T, handler http.Handler) testTarget {
+	t.Helper()
+
+	if baseURL := os.Getenv("GATHERERS_BACKEND_BASE_URL"); baseURL != "" {
+		return testTarget{
+			baseURL:  strings.TrimRight(baseURL, "/"),
+			external: true,
+			closeFn:  func() {},
+		}
+	}
+
+	server := httptest.NewServer(handler)
+	return testTarget{
+		baseURL:  server.URL,
+		external: false,
+		closeFn:  server.Close,
+	}
+}

--- a/backend/internal/state/doc.go
+++ b/backend/internal/state/doc.go
@@ -1,0 +1,3 @@
+package state
+
+// Package state will hold in-memory aggregate simulation state.

--- a/backend/internal/state/store.go
+++ b/backend/internal/state/store.go
@@ -13,9 +13,10 @@ type FoodPickup struct {
 }
 
 type Summary struct {
-	LooseFoodCount               int
-	OccupiedCellCount            int
-	NearestNeighborMeanDistance  float64
+	ConnectedSimCount           int     `json:"connected_sim_count"`
+	LooseFoodCount              int     `json:"loose_food_count"`
+	OccupiedCellCount           int     `json:"occupied_cell_count"`
+	NearestNeighborMeanDistance float64 `json:"nearest_neighbor_mean_distance"`
 }
 
 type foodPosition struct {
@@ -44,6 +45,10 @@ func (s *Store) RecordDrop(simID string, drop FoodDrop) {
 	state.looseFood[drop.FoodID] = foodPosition{X: drop.X, Y: drop.Y}
 }
 
+func (s *Store) RecordHello(simID string) {
+	s.ensureSim(simID)
+}
+
 func (s *Store) RecordPickup(simID string, pickup FoodPickup) {
 	state := s.ensureSim(simID)
 	delete(state.looseFood, pickup.FoodID)
@@ -56,6 +61,7 @@ func (s *Store) GlobalSummary() Summary {
 	}
 
 	return Summary{
+		ConnectedSimCount:           len(s.sims),
 		LooseFoodCount:              len(positions),
 		OccupiedCellCount:           occupiedCellCount(positions, s.cellSize),
 		NearestNeighborMeanDistance: meanNearestNeighborDistance(positions),

--- a/backend/internal/state/store.go
+++ b/backend/internal/state/store.go
@@ -25,12 +25,23 @@ type foodPosition struct {
 }
 
 type simState struct {
-	looseFood map[string]foodPosition
+	looseFood      map[string]foodPosition
+	pickupCount    int
+	dropCount      int
+	turnMoveCount  int
 }
 
 type Store struct {
 	cellSize float64
 	sims     map[string]*simState
+}
+
+type SimSummary struct {
+	SimID         string `json:"sim_id"`
+	PickupCount   int    `json:"pickup_count"`
+	DropCount     int    `json:"drop_count"`
+	TurnMoveCount int    `json:"turn_move_count"`
+	LooseFoodCount int   `json:"loose_food_count"`
 }
 
 func NewStore(cellSize float64) *Store {
@@ -43,6 +54,7 @@ func NewStore(cellSize float64) *Store {
 func (s *Store) RecordDrop(simID string, drop FoodDrop) {
 	state := s.ensureSim(simID)
 	state.looseFood[drop.FoodID] = foodPosition{X: drop.X, Y: drop.Y}
+	state.dropCount++
 }
 
 func (s *Store) RecordHello(simID string) {
@@ -52,6 +64,12 @@ func (s *Store) RecordHello(simID string) {
 func (s *Store) RecordPickup(simID string, pickup FoodPickup) {
 	state := s.ensureSim(simID)
 	delete(state.looseFood, pickup.FoodID)
+	state.pickupCount++
+}
+
+func (s *Store) RecordTurnMove(simID string) {
+	state := s.ensureSim(simID)
+	state.turnMoveCount++
 }
 
 func (s *Store) GlobalSummary() Summary {
@@ -79,6 +97,20 @@ func (s *Store) ensureSim(simID string) *simState {
 	}
 	s.sims[simID] = state
 	return state
+}
+
+func (s *Store) SimSummaries() []SimSummary {
+	summaries := make([]SimSummary, 0, len(s.sims))
+	for simID, sim := range s.sims {
+		summaries = append(summaries, SimSummary{
+			SimID:          simID,
+			PickupCount:    sim.pickupCount,
+			DropCount:      sim.dropCount,
+			TurnMoveCount:  sim.turnMoveCount,
+			LooseFoodCount: len(sim.looseFood),
+		})
+	}
+	return summaries
 }
 
 func (s *Store) allLooseFood() []foodPosition {

--- a/backend/internal/state/store.go
+++ b/backend/internal/state/store.go
@@ -1,6 +1,9 @@
 package state
 
-import "math"
+import (
+	"math"
+	"sync"
+)
 
 type FoodDrop struct {
 	FoodID string
@@ -32,6 +35,7 @@ type simState struct {
 }
 
 type Store struct {
+	mu       sync.RWMutex
 	cellSize float64
 	sims     map[string]*simState
 }
@@ -52,30 +56,47 @@ func NewStore(cellSize float64) *Store {
 }
 
 func (s *Store) RecordDrop(simID string, drop FoodDrop) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	state := s.ensureSim(simID)
 	state.looseFood[drop.FoodID] = foodPosition{X: drop.X, Y: drop.Y}
 	state.dropCount++
 }
 
 func (s *Store) RecordHello(simID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.ensureSim(simID)
 }
 
 func (s *Store) RecordPickup(simID string, pickup FoodPickup) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	state := s.ensureSim(simID)
 	delete(state.looseFood, pickup.FoodID)
 	state.pickupCount++
 }
 
 func (s *Store) RecordTurnMove(simID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	state := s.ensureSim(simID)
 	state.turnMoveCount++
 }
 
 func (s *Store) GlobalSummary() Summary {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	positions := s.allLooseFood()
 	if len(positions) == 0 {
-		return Summary{}
+		return Summary{
+			ConnectedSimCount: len(s.sims),
+		}
 	}
 
 	return Summary{
@@ -100,6 +121,9 @@ func (s *Store) ensureSim(simID string) *simState {
 }
 
 func (s *Store) SimSummaries() []SimSummary {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	summaries := make([]SimSummary, 0, len(s.sims))
 	for simID, sim := range s.sims {
 		summaries = append(summaries, SimSummary{

--- a/backend/internal/state/store.go
+++ b/backend/internal/state/store.go
@@ -1,0 +1,127 @@
+package state
+
+import "math"
+
+type FoodDrop struct {
+	FoodID string
+	X      float64
+	Y      float64
+}
+
+type FoodPickup struct {
+	FoodID string
+}
+
+type Summary struct {
+	LooseFoodCount               int
+	OccupiedCellCount            int
+	NearestNeighborMeanDistance  float64
+}
+
+type foodPosition struct {
+	X float64
+	Y float64
+}
+
+type simState struct {
+	looseFood map[string]foodPosition
+}
+
+type Store struct {
+	cellSize float64
+	sims     map[string]*simState
+}
+
+func NewStore(cellSize float64) *Store {
+	return &Store{
+		cellSize: cellSize,
+		sims:     make(map[string]*simState),
+	}
+}
+
+func (s *Store) RecordDrop(simID string, drop FoodDrop) {
+	state := s.ensureSim(simID)
+	state.looseFood[drop.FoodID] = foodPosition{X: drop.X, Y: drop.Y}
+}
+
+func (s *Store) RecordPickup(simID string, pickup FoodPickup) {
+	state := s.ensureSim(simID)
+	delete(state.looseFood, pickup.FoodID)
+}
+
+func (s *Store) GlobalSummary() Summary {
+	positions := s.allLooseFood()
+	if len(positions) == 0 {
+		return Summary{}
+	}
+
+	return Summary{
+		LooseFoodCount:              len(positions),
+		OccupiedCellCount:           occupiedCellCount(positions, s.cellSize),
+		NearestNeighborMeanDistance: meanNearestNeighborDistance(positions),
+	}
+}
+
+func (s *Store) ensureSim(simID string) *simState {
+	state, ok := s.sims[simID]
+	if ok {
+		return state
+	}
+
+	state = &simState{
+		looseFood: make(map[string]foodPosition),
+	}
+	s.sims[simID] = state
+	return state
+}
+
+func (s *Store) allLooseFood() []foodPosition {
+	positions := make([]foodPosition, 0)
+	for _, sim := range s.sims {
+		for _, pos := range sim.looseFood {
+			positions = append(positions, pos)
+		}
+	}
+	return positions
+}
+
+func occupiedCellCount(positions []foodPosition, cellSize float64) int {
+	if cellSize <= 0 {
+		cellSize = 1
+	}
+
+	cells := make(map[[2]int]struct{})
+	for _, pos := range positions {
+		cell := [2]int{
+			int(math.Floor(pos.X / cellSize)),
+			int(math.Floor(pos.Y / cellSize)),
+		}
+		cells[cell] = struct{}{}
+	}
+	return len(cells)
+}
+
+func meanNearestNeighborDistance(positions []foodPosition) float64 {
+	if len(positions) < 2 {
+		return 0
+	}
+
+	total := 0.0
+	for i, pos := range positions {
+		best := math.MaxFloat64
+		for j, other := range positions {
+			if i == j {
+				continue
+			}
+			dx := pos.X - other.X
+			dy := pos.Y - other.Y
+			dist := math.Hypot(dx, dy)
+			if dist < best {
+				best = dist
+			}
+		}
+		total += best
+	}
+
+	return total / float64(len(positions))
+}

--- a/backend/internal/state/store.go
+++ b/backend/internal/state/store.go
@@ -3,6 +3,7 @@ package state
 import (
 	"math"
 	"sync"
+	"time"
 )
 
 type FoodDrop struct {
@@ -20,6 +21,8 @@ type Summary struct {
 	LooseFoodCount              int     `json:"loose_food_count"`
 	OccupiedCellCount           int     `json:"occupied_cell_count"`
 	NearestNeighborMeanDistance float64 `json:"nearest_neighbor_mean_distance"`
+	ElapsedSeconds              float64 `json:"elapsed_seconds"`
+	EventsPerSecond             float64 `json:"events_per_second"`
 }
 
 type foodPosition struct {
@@ -28,32 +31,44 @@ type foodPosition struct {
 }
 
 type simState struct {
-	looseFood      map[string]foodPosition
-	antCount       int
-	pickupCount    int
-	dropCount      int
-	turnMoveCount  int
+	looseFood     map[string]foodPosition
+	antCount      int
+	connectedAt   time.Time
+	totalEvents   int
+	pickupCount   int
+	dropCount     int
+	turnMoveCount int
 }
 
 type Store struct {
 	mu       sync.RWMutex
 	cellSize float64
 	sims     map[string]*simState
+	now      func() time.Time
+}
+
+type DashboardSnapshotData struct {
+	cellSize    float64
+	sims        []SimSummary
+	looseFood   []foodPosition
+	startedAt   time.Time
+	totalEvents int
 }
 
 type SimSummary struct {
-	SimID         string `json:"sim_id"`
-	AntCount      int    `json:"ant_count"`
-	PickupCount   int    `json:"pickup_count"`
-	DropCount     int    `json:"drop_count"`
-	TurnMoveCount int    `json:"turn_move_count"`
-	LooseFoodCount int   `json:"loose_food_count"`
+	SimID          string `json:"sim_id"`
+	AntCount       int    `json:"ant_count"`
+	PickupCount    int    `json:"pickup_count"`
+	DropCount      int    `json:"drop_count"`
+	TurnMoveCount  int    `json:"turn_move_count"`
+	LooseFoodCount int    `json:"loose_food_count"`
 }
 
 func NewStore(cellSize float64) *Store {
 	return &Store{
 		cellSize: cellSize,
 		sims:     make(map[string]*simState),
+		now:      time.Now,
 	}
 }
 
@@ -62,6 +77,7 @@ func (s *Store) RecordDrop(simID string, drop FoodDrop) {
 	defer s.mu.Unlock()
 
 	state := s.ensureSim(simID)
+	state.recordEvent(s.now())
 	state.looseFood[drop.FoodID] = foodPosition{X: drop.X, Y: drop.Y}
 	state.dropCount++
 }
@@ -72,6 +88,7 @@ func (s *Store) RecordHello(simID string, antCount int) {
 
 	state := s.ensureSim(simID)
 	state.antCount = antCount
+	state.recordEvent(s.now())
 }
 
 func (s *Store) RecordFoodSnapshot(simID string, foods []FoodDrop) {
@@ -79,6 +96,7 @@ func (s *Store) RecordFoodSnapshot(simID string, foods []FoodDrop) {
 	defer s.mu.Unlock()
 
 	state := s.ensureSim(simID)
+	state.recordEvent(s.now())
 	state.looseFood = make(map[string]foodPosition, len(foods))
 	for _, food := range foods {
 		state.looseFood[food.FoodID] = foodPosition{X: food.X, Y: food.Y}
@@ -90,6 +108,7 @@ func (s *Store) RecordPickup(simID string, pickup FoodPickup) {
 	defer s.mu.Unlock()
 
 	state := s.ensureSim(simID)
+	state.recordEvent(s.now())
 	delete(state.looseFood, pickup.FoodID)
 	state.pickupCount++
 }
@@ -99,26 +118,12 @@ func (s *Store) RecordTurnMove(simID string) {
 	defer s.mu.Unlock()
 
 	state := s.ensureSim(simID)
+	state.recordEvent(s.now())
 	state.turnMoveCount++
 }
 
 func (s *Store) GlobalSummary() Summary {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	positions := s.allLooseFood()
-	if len(positions) == 0 {
-		return Summary{
-			ConnectedSimCount: len(s.sims),
-		}
-	}
-
-	return Summary{
-		ConnectedSimCount:           len(s.sims),
-		LooseFoodCount:              len(positions),
-		OccupiedCellCount:           occupiedCellCount(positions, s.cellSize),
-		NearestNeighborMeanDistance: meanNearestNeighborDistance(positions),
-	}
+	return s.DashboardSnapshotData().Summary(s.now())
 }
 
 func (s *Store) ensureSim(simID string) *simState {
@@ -135,10 +140,17 @@ func (s *Store) ensureSim(simID string) *simState {
 }
 
 func (s *Store) SimSummaries() []SimSummary {
+	return s.DashboardSnapshotData().SimSummaries()
+}
+
+func (s *Store) DashboardSnapshotData() DashboardSnapshotData {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	summaries := make([]SimSummary, 0, len(s.sims))
+	positions := make([]foodPosition, 0)
+	var startedAt time.Time
+	totalEvents := 0
 	for simID, sim := range s.sims {
 		summaries = append(summaries, SimSummary{
 			SimID:          simID,
@@ -148,18 +160,68 @@ func (s *Store) SimSummaries() []SimSummary {
 			TurnMoveCount:  sim.turnMoveCount,
 			LooseFoodCount: len(sim.looseFood),
 		})
-	}
-	return summaries
-}
-
-func (s *Store) allLooseFood() []foodPosition {
-	positions := make([]foodPosition, 0)
-	for _, sim := range s.sims {
+		totalEvents += sim.totalEvents
+		if !sim.connectedAt.IsZero() && (startedAt.IsZero() || sim.connectedAt.Before(startedAt)) {
+			startedAt = sim.connectedAt
+		}
 		for _, pos := range sim.looseFood {
 			positions = append(positions, pos)
 		}
 	}
-	return positions
+
+	return DashboardSnapshotData{
+		cellSize:    s.cellSize,
+		sims:        summaries,
+		looseFood:   positions,
+		startedAt:   startedAt,
+		totalEvents: totalEvents,
+	}
+}
+
+func (d DashboardSnapshotData) SimSummaries() []SimSummary {
+	summaries := make([]SimSummary, len(d.sims))
+	copy(summaries, d.sims)
+	return summaries
+}
+
+func (d DashboardSnapshotData) Summary(now time.Time) Summary {
+	elapsedSeconds, eventsPerSecond := d.metrics(now)
+	if len(d.looseFood) == 0 {
+		return Summary{
+			ConnectedSimCount: len(d.sims),
+			ElapsedSeconds:    elapsedSeconds,
+			EventsPerSecond:   eventsPerSecond,
+		}
+	}
+
+	return Summary{
+		ConnectedSimCount:           len(d.sims),
+		LooseFoodCount:              len(d.looseFood),
+		OccupiedCellCount:           occupiedCellCount(d.looseFood, d.cellSize),
+		NearestNeighborMeanDistance: meanNearestNeighborDistance(d.looseFood),
+		ElapsedSeconds:              elapsedSeconds,
+		EventsPerSecond:             eventsPerSecond,
+	}
+}
+
+func (s *simState) recordEvent(now time.Time) {
+	if s.connectedAt.IsZero() {
+		s.connectedAt = now
+	}
+	s.totalEvents++
+}
+
+func (d DashboardSnapshotData) metrics(now time.Time) (float64, float64) {
+	if d.startedAt.IsZero() {
+		return 0, 0
+	}
+
+	elapsedSeconds := now.Sub(d.startedAt).Seconds()
+	if elapsedSeconds <= 0 {
+		return 0, 0
+	}
+
+	return elapsedSeconds, float64(d.totalEvents) / elapsedSeconds
 }
 
 func occupiedCellCount(positions []foodPosition, cellSize float64) int {

--- a/backend/internal/state/store.go
+++ b/backend/internal/state/store.go
@@ -71,6 +71,17 @@ func (s *Store) RecordHello(simID string) {
 	s.ensureSim(simID)
 }
 
+func (s *Store) RecordFoodSnapshot(simID string, foods []FoodDrop) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := s.ensureSim(simID)
+	state.looseFood = make(map[string]foodPosition, len(foods))
+	for _, food := range foods {
+		state.looseFood[food.FoodID] = foodPosition{X: food.X, Y: food.Y}
+	}
+}
+
 func (s *Store) RecordPickup(simID string, pickup FoodPickup) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/backend/internal/state/store.go
+++ b/backend/internal/state/store.go
@@ -29,6 +29,7 @@ type foodPosition struct {
 
 type simState struct {
 	looseFood      map[string]foodPosition
+	antCount       int
 	pickupCount    int
 	dropCount      int
 	turnMoveCount  int
@@ -42,6 +43,7 @@ type Store struct {
 
 type SimSummary struct {
 	SimID         string `json:"sim_id"`
+	AntCount      int    `json:"ant_count"`
 	PickupCount   int    `json:"pickup_count"`
 	DropCount     int    `json:"drop_count"`
 	TurnMoveCount int    `json:"turn_move_count"`
@@ -64,11 +66,12 @@ func (s *Store) RecordDrop(simID string, drop FoodDrop) {
 	state.dropCount++
 }
 
-func (s *Store) RecordHello(simID string) {
+func (s *Store) RecordHello(simID string, antCount int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.ensureSim(simID)
+	state := s.ensureSim(simID)
+	state.antCount = antCount
 }
 
 func (s *Store) RecordFoodSnapshot(simID string, foods []FoodDrop) {
@@ -139,6 +142,7 @@ func (s *Store) SimSummaries() []SimSummary {
 	for simID, sim := range s.sims {
 		summaries = append(summaries, SimSummary{
 			SimID:          simID,
+			AntCount:       sim.antCount,
 			PickupCount:    sim.pickupCount,
 			DropCount:      sim.dropCount,
 			TurnMoveCount:  sim.turnMoveCount,

--- a/backend/internal/state/store_test.go
+++ b/backend/internal/state/store_test.go
@@ -1,0 +1,80 @@
+package state
+
+import "testing"
+
+func TestStoreTracksLooseFoodAcrossDropAndPickup(t *testing.T) {
+	store := NewStore(50)
+
+	store.RecordDrop("sim-a", FoodDrop{
+		FoodID: "food-1",
+		X:      100,
+		Y:      100,
+	})
+	store.RecordDrop("sim-a", FoodDrop{
+		FoodID: "food-2",
+		X:      110,
+		Y:      100,
+	})
+
+	summary := store.GlobalSummary()
+	if summary.LooseFoodCount != 2 {
+		t.Fatalf("expected 2 loose food items after drops, got %d", summary.LooseFoodCount)
+	}
+
+	store.RecordPickup("sim-a", FoodPickup{
+		FoodID: "food-1",
+	})
+
+	summary = store.GlobalSummary()
+	if summary.LooseFoodCount != 1 {
+		t.Fatalf("expected 1 loose food item after pickup, got %d", summary.LooseFoodCount)
+	}
+}
+
+func TestGlobalSummaryDistinguishesClusteredFromSparseFood(t *testing.T) {
+	clustered := NewStore(50)
+	sparse := NewStore(50)
+
+	clusteredDrops := []FoodDrop{
+		{FoodID: "c1", X: 10, Y: 10},
+		{FoodID: "c2", X: 12, Y: 12},
+		{FoodID: "c3", X: 14, Y: 14},
+		{FoodID: "c4", X: 16, Y: 16},
+		{FoodID: "c5", X: 18, Y: 18},
+		{FoodID: "c6", X: 20, Y: 20},
+	}
+	for _, drop := range clusteredDrops {
+		clustered.RecordDrop("sim-a", drop)
+	}
+
+	sparseDrops := []FoodDrop{
+		{FoodID: "s1", X: 0, Y: 0},
+		{FoodID: "s2", X: 100, Y: 0},
+		{FoodID: "s3", X: 200, Y: 0},
+		{FoodID: "s4", X: 300, Y: 0},
+		{FoodID: "s5", X: 400, Y: 0},
+		{FoodID: "s6", X: 500, Y: 0},
+	}
+	for _, drop := range sparseDrops {
+		sparse.RecordDrop("sim-a", drop)
+	}
+
+	clusteredSummary := clustered.GlobalSummary()
+	sparseSummary := sparse.GlobalSummary()
+
+	if clusteredSummary.OccupiedCellCount >= sparseSummary.OccupiedCellCount {
+		t.Fatalf(
+			"expected clustered food to occupy fewer cells than sparse food, got clustered=%d sparse=%d",
+			clusteredSummary.OccupiedCellCount,
+			sparseSummary.OccupiedCellCount,
+		)
+	}
+
+	if clusteredSummary.NearestNeighborMeanDistance >= sparseSummary.NearestNeighborMeanDistance {
+		t.Fatalf(
+			"expected clustered food to have a smaller nearest-neighbor mean distance than sparse food, got clustered=%f sparse=%f",
+			clusteredSummary.NearestNeighborMeanDistance,
+			sparseSummary.NearestNeighborMeanDistance,
+		)
+	}
+}

--- a/backend/internal/state/store_test.go
+++ b/backend/internal/state/store_test.go
@@ -1,6 +1,10 @@
 package state
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+	"time"
+)
 
 func TestStoreTracksLooseFoodAcrossDropAndPickup(t *testing.T) {
 	store := NewStore(50)
@@ -76,5 +80,58 @@ func TestGlobalSummaryDistinguishesClusteredFromSparseFood(t *testing.T) {
 			clusteredSummary.NearestNeighborMeanDistance,
 			sparseSummary.NearestNeighborMeanDistance,
 		)
+	}
+}
+
+func TestGlobalSummaryReportsElapsedAndEventRate(t *testing.T) {
+	store := NewStore(50)
+	currentTime := time.Unix(1_000, 0)
+	store.now = func() time.Time { return currentTime }
+
+	store.RecordHello("sim-a", 26)
+
+	currentTime = currentTime.Add(2 * time.Second)
+	store.RecordDrop("sim-a", FoodDrop{
+		FoodID: "food-1",
+		X:      10,
+		Y:      10,
+	})
+
+	summary := store.GlobalSummary()
+	if summary.ElapsedSeconds != 2 {
+		t.Fatalf("expected elapsed seconds to be 2, got %f", summary.ElapsedSeconds)
+	}
+	if summary.EventsPerSecond != 1 {
+		t.Fatalf("expected events per second to be 1, got %f", summary.EventsPerSecond)
+	}
+}
+
+func TestDashboardSnapshotDataMatchesCurrentStoreViews(t *testing.T) {
+	store := NewStore(50)
+	currentTime := time.Unix(2_000, 0)
+	store.now = func() time.Time { return currentTime }
+
+	store.RecordHello("sim-a", 26)
+	store.RecordFoodSnapshot("sim-a", []FoodDrop{
+		{FoodID: "food-1", X: 10, Y: 10},
+		{FoodID: "food-2", X: 20, Y: 20},
+	})
+	store.RecordPickup("sim-a", FoodPickup{FoodID: "food-1"})
+	store.RecordTurnMove("sim-a")
+
+	currentTime = currentTime.Add(3 * time.Second)
+	store.RecordHello("sim-b", 13)
+	store.RecordDrop("sim-b", FoodDrop{FoodID: "food-3", X: 100, Y: 100})
+
+	snapshot := store.DashboardSnapshotData()
+	gotSummary := snapshot.Summary(currentTime)
+	gotSims := snapshot.SimSummaries()
+
+	if wantSummary := store.GlobalSummary(); !reflect.DeepEqual(gotSummary, wantSummary) {
+		t.Fatalf("expected snapshot summary %+v to match current store summary %+v", gotSummary, wantSummary)
+	}
+
+	if wantSims := store.SimSummaries(); !reflect.DeepEqual(gotSims, wantSims) {
+		t.Fatalf("expected snapshot sims %+v to match current store sims %+v", gotSims, wantSims)
 	}
 }

--- a/docs/go-backend-actor-notes.md
+++ b/docs/go-backend-actor-notes.md
@@ -1,0 +1,161 @@
+# Go Backend Actor Notes
+
+## Purpose
+
+This note summarizes how the current Go backend relates to the actor model, and where the design could move further in that direction if clearer ownership or stronger robustness becomes important.
+
+## Current Shape
+
+The backend is not implemented as a full actor system, but one important part already behaves a lot like an actor:
+
+- the aggregation worker is a single goroutine
+- it is woken by messages/signals
+- it owns the refresh policy
+- it serializes expensive aggregate recomputation
+- it publishes snapshots to dashboard subscribers
+
+That is already actor-like in the sense of:
+
+- one logical owner
+- one serialized execution context
+- message-driven wakeups
+- no concurrent execution inside that component
+
+## Where It Is Still Not Fully Actor-Like
+
+The aggregation worker does not fully own all of the data it reasons about.
+
+Instead:
+
+- ingest handlers mutate shared store state directly
+- the store is protected by `sync.RWMutex`
+- the worker asks the store for copied snapshot inputs
+
+So the current design is a hybrid:
+
+- actor-like scheduling for analysis
+- shared-memory locking for authoritative state
+
+This is a reasonable Go design, but it means reasoning is split between:
+
+- channel/message flow
+- mutex-protected shared state
+
+## What A More Actor-Like Design Would Mean
+
+The most natural next step would not be “actors everywhere.” It would be to make the analysis side more explicitly actor-shaped.
+
+That could mean:
+
+- define a dedicated analysis goroutine as the sole owner of aggregate-analysis state
+- send it explicit messages such as:
+  - `MarkDirty`
+  - `DashboardWatcherAdded`
+  - `DashboardWatcherRemoved`
+  - `APIRead`
+  - `RefreshNow`
+  - `Shutdown`
+- keep refresh cadence, demand tracking, and cached snapshot ownership inside that goroutine
+- remove some of the mutex-protected coordination fields around refresh state
+
+In that version, the analysis component would look less like “a goroutine plus shared bookkeeping” and more like “an actor with a mailbox.”
+
+## Possible Directions
+
+### Option 1: Keep the store shared, make only analysis more actor-like
+
+This is the smallest conceptual shift.
+
+Shape:
+
+- ingest still updates the shared store under mutex
+- analysis goroutine fully owns:
+  - dirty state
+  - demand state
+  - timer/cadence state
+  - cached snapshot
+  - dashboard broadcasts
+- all analysis coordination happens via a typed command channel
+
+Benefits:
+
+- clearer ownership of refresh logic
+- fewer refresh-related mutex interactions
+- easier to reason about worker state transitions
+- likely the best fit if the store remains shared
+
+Costs:
+
+- store locking still exists
+- there is still a hybrid model rather than pure actors
+
+### Option 2: Make the store itself actor-owned
+
+This would be a much larger change.
+
+Shape:
+
+- one goroutine owns all mutable simulation state
+- ingest handlers send event messages to that goroutine
+- dashboard/API queries are answered by request/response messages
+- mutable maps are no longer shared directly across goroutines
+
+Benefits:
+
+- much less mutex-based shared memory
+- very strong ownership story
+- easier to reason about some classes of races
+
+Costs:
+
+- more message plumbing
+- request/response complexity for reads
+- potentially harder integration with HTTP handlers
+- may become less idiomatic than the current Go shape for a backend this size
+
+For this project, this feels possible but probably larger than needed right now.
+
+## Best Go Practice?
+
+In Go, the current design is already quite normal:
+
+- goroutines for concurrent work
+- channels for signaling
+- mutexes for shared maps and cached state
+
+Go does not push developers toward a large actor framework in the way Akka-based systems do. The common Go style is usually:
+
+- use mutexes where shared memory is simple and local
+- use channels where ownership handoff or serialized workers are clearer
+
+So “more actor-like” is possible and can be good, but it is not automatically more idiomatic or more robust unless it also makes ownership and state transitions meaningfully simpler.
+
+## Recommended Interpretation For This Backend
+
+The current backend can be viewed as:
+
+- a shared-memory ingest/store layer
+- plus an actor-like analysis layer
+
+If this area evolves further, the most promising refinement is:
+
+- keep ingest/store roughly as-is
+- make the analysis worker more explicitly actor-shaped with a typed command channel and sole ownership of refresh/demand/cache state
+
+That would likely improve clarity more than a full rewrite into actors for everything.
+
+## Why This Might Be Worth It Later
+
+The main reasons to push the analysis side further toward an actor are:
+
+- fewer refresh-state mutex interactions
+- clearer lifecycle and demand transitions
+- easier logging and observability of worker decisions
+- easier to test worker behavior as a message-driven state machine
+
+The main reason not to do it yet is that the current design is already working, tested, and reasonably idiomatic for Go.
+
+So the idea is less “the current code is wrong” and more:
+
+- the current analysis worker is already actor-like
+- there is room to make that actor boundary more explicit if the coordination logic grows

--- a/docs/go-backend-runtime-architecture.md
+++ b/docs/go-backend-runtime-architecture.md
@@ -1,0 +1,314 @@
+# Go Backend Runtime Architecture
+
+## Purpose
+
+This document describes how the Go backend operates at runtime after ingest was decoupled from dashboard aggregation.
+
+It focuses on:
+
+- data flow between sim clients, backend, API readers, and dashboard watchers
+- computation performed on the ingest path versus the background aggregation path
+- concurrency, locking, and goroutine structure
+- expected workloads during demos and stress runs
+
+This is a runtime architecture note, not a wire-format contract. For message schema details, see `docs/go-backend-v1-contract.md`.
+
+## High-Level Model
+
+The backend now has two intentionally separate responsibilities:
+
+1. Accept and record simulation events as cheaply as possible.
+2. Compute expensive aggregate dashboard views only when someone is actually watching.
+
+That separation is the key architectural change.
+
+Incoming sim traffic no longer triggers immediate aggregate recomputation. Instead, ingest updates in-memory state and marks the cached dashboard snapshot dirty. A separate background worker decides when to rebuild that snapshot.
+
+## Main Participants
+
+- Rust sim client: optional real simulation producer connected to `/ws/ingest`
+- Fake load clients: Go-written traffic generators used in tests and demos
+- Backend ingest handlers: one websocket handler per connected sim client
+- Backend state store: in-memory authoritative state protected by `sync.RWMutex`
+- Aggregation worker: one backend-owned goroutine that recomputes expensive dashboard snapshots
+- Dashboard websocket clients: browsers connected to `/ws/dashboard`
+- API readers: clients polling `/api/summary` or `/api/sims`
+
+## End-To-End Flow
+
+```mermaid
+flowchart LR
+    RustSim["RustSim or FakeClient"] -->|ws event stream| Ingest["/ws/ingest handler"]
+    Ingest -->|cheap mutations| Store["StateStore"]
+    Ingest -->|mark dirty| Dirty["DirtyFlag"]
+    Dashboard["Dashboard browser"] -->|GET /| Cached["CachedSnapshot"]
+    Dashboard -->|subscribe /ws/dashboard| Demand["DemandTracker"]
+    ApiReader["API reader"] -->|GET /api/summary or /api/sims| Cached
+    ApiReader -->|register demand| Demand
+    Dirty --> Worker["AggregationWorker"]
+    Demand --> Worker
+    Store -->|copy snapshot inputs under RLock| Worker
+    Worker -->|compute aggregates| Cached
+    Worker -->|broadcast latest snapshot| DashboardHub["DashboardHub"]
+    DashboardHub -->|ws snapshot updates| Dashboard
+```
+
+## Client Event Flow
+
+Simulation clients send JSON event envelopes over `/ws/ingest`.
+
+Typical startup sequence:
+
+- `sim_hello`
+- `sim_food_snapshot`
+- then repeated `food_pickup`, `ant_turn_move`, `food_drop`
+
+The fake-client runner mirrors that same pattern. Each fake client runs in its own goroutine, opens one websocket, sends the startup messages, then keeps sending one event per ticker interval.
+
+In practical terms, startup has a burst profile because `sim_food_snapshot` can contain many food positions, and steady-state traffic becomes a high-volume stream of small event messages.
+
+## Ingest Path
+
+Each websocket connection to `/ws/ingest` gets its own request goroutine from the Go HTTP server.
+
+For every received event, the backend does only this:
+
+- decode the envelope and payload
+- update the in-memory store
+- mark the cached snapshot dirty
+
+It does not:
+
+- recompute dashboard aggregates
+- walk all known loose food
+- calculate nearest-neighbor metrics
+- push synchronous dashboard updates
+
+This keeps the ingest path bounded and predictable even when the dashboard math is expensive.
+
+## Store Responsibilities
+
+The state store is the authoritative in-memory model of live sims. It tracks:
+
+- current sims keyed by `sim_id`
+- per-sim metadata such as `ant_count`
+- per-sim event counters such as pickups, drops, and turns
+- current loose-food positions
+- timing inputs used for `elapsed_seconds` and `events_per_second`
+
+Writes take the store write lock and do cheap mutations only:
+
+- `RecordHello`
+- `RecordFoodSnapshot`
+- `RecordDrop`
+- `RecordPickup`
+- `RecordTurnMove`
+
+The store also exposes `DashboardSnapshotData()`, which copies the raw inputs needed for aggregate computation under `RLock` and returns them as a value. Heavy math runs after the lock is released.
+
+## Cached Snapshot Flow
+
+The backend keeps one cached dashboard snapshot in memory. That snapshot contains:
+
+- `summary`
+- `sims`
+
+Readers do not recompute aggregates on demand. They receive the latest cached snapshot immediately.
+
+This applies to:
+
+- `/api/summary`
+- `/api/sims`
+- the initial `/ws/dashboard` message
+- the initial HTML render for `/`
+
+The result is eventual consistency rather than synchronous freshness.
+
+## Demand-Driven Aggregation
+
+Expensive recomputation happens only when there is demand.
+
+Demand sources:
+
+- at least one active `/ws/dashboard` subscriber
+- or a recent `/api/summary` or `/api/sims` read within the API demand TTL
+
+No-demand behavior:
+
+- ingest still records new events
+- dirty state is retained
+- expensive aggregate recomputation does not run
+- cached dashboard/API responses may remain stale until demand resumes
+
+This means the backend can absorb incoming sim traffic without paying analytics cost when nobody is observing the system.
+
+## Aggregation Worker
+
+There is one aggregation worker goroutine for the whole backend process.
+
+Its job is:
+
+- wake when signaled and demand exists
+- check whether recomputation is currently allowed
+- copy snapshot inputs from the store
+- compute derived metrics
+- replace the cached snapshot
+- broadcast the new snapshot to dashboard websocket clients
+
+The worker coalesces multiple incoming dirty signals. If many ingest events arrive before the next recomputation window, the worker still performs only one refresh and uses the latest available store state.
+
+## Adaptive Cadence
+
+The worker is not event-driven in the sense of “compute after every message.” It is demand-driven and cadence-limited.
+
+After a recomputation finishes, the backend schedules the next eligible recomputation using:
+
+- `next_interval = clamp(250ms, last_compute_duration * 3, 5s)`
+
+Implications:
+
+- if aggregate computation is cheap, refreshes can happen frequently
+- if aggregate computation is expensive, refreshes automatically back off
+- the backend avoids piling expensive recomputations on top of each other
+
+This is the main load-management mechanism for expensive analytics.
+
+## Dashboard Flow
+
+The browser dashboard works in two phases.
+
+Phase 1:
+
+- browser requests `GET /`
+- backend serves HTML plus the latest cached summary values
+
+Phase 2:
+
+- browser opens `/ws/dashboard`
+- backend sends the latest cached snapshot immediately
+- backend registers the browser as an active watcher
+- later worker refreshes are broadcast through the dashboard hub
+
+The dashboard therefore sees:
+
+- immediate cached state
+- then eventual updates from the worker
+
+The browser itself performs almost no computation. It simply renders snapshots pushed by the backend.
+
+## API Flow
+
+`/api/summary` and `/api/sims` serve cached data immediately.
+
+They also count as demand. Repeated polling keeps the aggregation worker active, which means API consumers can drive snapshot freshness even without an open dashboard.
+
+So the API has two roles:
+
+- read the current cached view
+- signal that fresh aggregate computation is worth doing
+
+## Parallelism And Synchronization
+
+The backend uses a deliberately small Go concurrency model:
+
+- one goroutine per ingest websocket connection
+- one goroutine for the aggregation worker
+- one goroutine per dashboard websocket connection
+- one `sync.RWMutex` inside the store
+- one `sync.RWMutex` for cached snapshot access
+- one `sync.Mutex` for demand and refresh scheduling state
+- one `sync.Mutex` inside the dashboard hub for subscriber management
+
+This gives a clear split:
+
+- many concurrent I/O producers and consumers
+- one shared mutable store
+- one shared cached snapshot
+- one serialized expensive aggregation pipeline
+
+The design is intentionally not a worker pool. Aggregate computation is kept single-threaded on purpose so refresh work cannot multiply under load.
+
+## Computational Hotspots
+
+The most expensive derived metric is `meanNearestNeighborDistance`, which is quadratic in the number of loose-food positions.
+
+Other nontrivial aggregate work includes:
+
+- flattening all loose-food positions across sims
+- counting occupied cells
+- building sorted or copied per-sim summaries for output
+
+These operations are acceptable in the background worker but were too expensive when previously triggered synchronously from ingest.
+
+## Workload Types
+
+The system now handles two very different workloads.
+
+### Ingest workload
+
+Characteristics:
+
+- many websocket messages
+- high frequency
+- cheap per-event updates
+- bursty startup due to food snapshots
+
+Typical sources:
+
+- real Rust sim instances
+- `cmd/fakeclients` demo and stress runs
+
+### Aggregation workload
+
+Characteristics:
+
+- CPU-heavy
+- data-size dependent
+- mostly driven by loose-food cardinality
+- intentionally throttled by adaptive cadence
+
+Typical triggers:
+
+- an open dashboard in the browser
+- API polling during demos or tests
+
+## Why The New Architecture Matters
+
+Before the refactor, every ingest event immediately recomputed dashboard state. Under heavy load, that meant the backend spent most of its time doing aggregate math instead of accepting new events.
+
+Now the system behaves much better:
+
+- sim traffic updates state quickly
+- aggregate math is amortized and coalesced
+- expensive work only happens when a consumer exists
+- dashboard counts continue to rise under stress instead of freezing near the start
+
+In short, throughput is protected by decoupling ingestion from observation.
+
+## Demo And Stress Interpretation
+
+For a live dashboard demo:
+
+- startup food snapshots create an initial state burst
+- event counters and loose-food metrics should keep changing while the load is running
+- dashboard updates arrive in snapshots, not one per raw event
+
+For a stress run:
+
+- per-sim counts should continue climbing
+- aggregate `events_per_second` should remain plausible
+- stale reads are acceptable briefly, but long stalls under demand indicate trouble
+
+## Current Limits
+
+The current backend is intentionally simple and in-memory only.
+
+Notable limitations:
+
+- no durable persistence
+- no replay or reordering
+- no explicit per-sim sequence-gap tracking in production state
+- no distributed aggregation
+- no incremental nearest-neighbor algorithm yet
+
+Those are future scalability topics. The current design is primarily about correct decoupling, clear concurrency, and reliable live demos under meaningful local load.

--- a/docs/go-backend-runtime-architecture.md
+++ b/docs/go-backend-runtime-architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document describes how the Go backend operates at runtime after ingest was decoupled from dashboard aggregation.
+This document describes how the Go backend operates at runtime.
 
 It focuses on:
 
@@ -11,18 +11,16 @@ It focuses on:
 - concurrency, locking, and goroutine structure
 - expected workloads during demos and stress runs
 
-This is a runtime architecture note, not a wire-format contract. For message schema details, see `docs/go-backend-v1-contract.md`.
+This is a runtime architecture note, not a wire-format contract. For message schema details, see `docs/go-backend-v1-contract.md`. For thoughts on making the analysis side more explicitly actor-shaped, see `docs/go-backend-actor-notes.md`.
 
 ## High-Level Model
 
-The backend now has two intentionally separate responsibilities:
+The backend has two intentionally separate responsibilities:
 
 1. Accept and record simulation events as cheaply as possible.
 2. Compute expensive aggregate dashboard views only when someone is actually watching.
 
-That separation is the key architectural change.
-
-Incoming sim traffic no longer triggers immediate aggregate recomputation. Instead, ingest updates in-memory state and marks the cached dashboard snapshot dirty. A separate background worker decides when to rebuild that snapshot.
+Incoming sim traffic does not trigger immediate aggregate recomputation. Instead, ingest updates in-memory state and marks the cached dashboard snapshot dirty. A separate background worker decides when to rebuild that snapshot.
 
 ## Main Participants
 
@@ -238,7 +236,7 @@ Other nontrivial aggregate work includes:
 - counting occupied cells
 - building sorted or copied per-sim summaries for output
 
-These operations are acceptable in the background worker but were too expensive when previously triggered synchronously from ingest.
+These operations are isolated in the background worker rather than the ingest path because they are significantly more expensive than per-event state updates.
 
 ## Workload Types
 
@@ -272,18 +270,15 @@ Typical triggers:
 - an open dashboard in the browser
 - API polling during demos or tests
 
-## Why The New Architecture Matters
+## Architectural Consequences
 
-Before the refactor, every ingest event immediately recomputed dashboard state. Under heavy load, that meant the backend spent most of its time doing aggregate math instead of accepting new events.
+This architecture has several important properties:
 
-Now the system behaves much better:
-
-- sim traffic updates state quickly
-- aggregate math is amortized and coalesced
+- sim traffic updates state quickly because ingest only performs cheap per-event work
+- aggregate math is amortized and coalesced instead of being repeated for every incoming message
 - expensive work only happens when a consumer exists
-- dashboard counts continue to rise under stress instead of freezing near the start
-
-In short, throughput is protected by decoupling ingestion from observation.
+- dashboard and API views are eventually consistent snapshots rather than per-event synchronous views
+- throughput is protected by separating observation from ingestion
 
 ## Demo And Stress Interpretation
 
@@ -311,4 +306,4 @@ Notable limitations:
 - no distributed aggregation
 - no incremental nearest-neighbor algorithm yet
 
-Those are future scalability topics. The current design is primarily about correct decoupling, clear concurrency, and reliable live demos under meaningful local load.
+Those are future scalability topics. The current design prioritizes clear concurrency boundaries, reliable behavior under meaningful local load, and a small backend that is easy to reason about.

--- a/docs/go-backend-v1-contract.md
+++ b/docs/go-backend-v1-contract.md
@@ -1,0 +1,296 @@
+# Go Backend V1 Contract
+
+## Goal
+
+Define the v1 contract between optional Rust simulation clients and the new Go backend before backend behavior is implemented.
+
+This document is intentionally limited to:
+
+- event schema
+- sim identity
+- aggregate metrics
+- HTTP and WebSocket boundaries
+- backpressure rules
+
+It does not define durable persistence, auth, or production deployment details.
+
+## Backend Scope
+
+The Go service is a standalone backend under `backend/` that:
+
+- accepts simulation events over WebSockets
+- keeps live in-memory state for connected sims
+- exposes HTTP JSON endpoints for current state and aggregate metrics
+- serves a small built-in dashboard
+
+The Rust simulation remains standalone by default and only connects when backend mode is enabled.
+
+## Sim Identity
+
+Each connected sim instance is identified by a client-provided `sim_id`.
+
+V1 rules:
+
+- `sim_id` must be unique for the lifetime of a process
+- the Rust client should generate it at startup
+- the server treats reconnects with the same `sim_id` as replacing the previous live connection
+- the server stores only the current live state for a `sim_id`
+
+Recommended hello payload fields:
+
+- `sim_id`
+- `sim_name`
+- `source` such as `rust-bevy`
+- `session_started_ms`
+- `world_width`
+- `world_height`
+- `ant_count`
+- `food_count`
+
+## Transport
+
+### WebSocket ingest
+
+- Endpoint: `GET /ws/ingest`
+- Client sends JSON messages only
+- Server accepts one logical event envelope per message
+- The first message from a client should be `sim_hello`
+- The connection stays open for streaming simulation events and heartbeats
+
+### HTTP endpoints
+
+Planned v1 endpoints:
+
+- `GET /healthz`
+- `GET /api/sims`
+- `GET /api/sims/{sim_id}`
+- `GET /api/summary`
+- `GET /`
+
+`/` serves the minimal dashboard.
+
+## Event Envelope
+
+All ingest messages use a shared envelope:
+
+```json
+{
+  "type": "food_pickup",
+  "sim_id": "sim-123",
+  "seq": 42,
+  "timestamp_ms": 1735689600000,
+  "payload": {}
+}
+```
+
+Envelope fields:
+
+- `type`: event kind
+- `sim_id`: sim instance identity
+- `seq`: client-local monotonic sequence number
+- `timestamp_ms`: client event time in milliseconds
+- `payload`: event-specific body
+
+V1 ordering assumptions:
+
+- sequence numbers are monotonic per `sim_id`
+- the server does not attempt full replay or reordering
+- if an old event arrives after a newer one for the same `sim_id`, the server may ignore it
+
+## Event Types
+
+### `sim_hello`
+
+Sent once at connection start.
+
+Payload:
+
+```json
+{
+  "sim_name": "gatherers-local",
+  "source": "rust-bevy",
+  "session_started_ms": 1735689600000,
+  "world_width": 1280,
+  "world_height": 720,
+  "ant_count": 26,
+  "food_count": 80
+}
+```
+
+### `sim_heartbeat`
+
+Sent periodically while connected.
+
+Payload:
+
+```json
+{
+  "connected_ant_count": 26,
+  "known_food_count": 80,
+  "dropped_outbound_events": 0
+}
+```
+
+### `food_pickup`
+
+Sent when an ant picks up a loose food item.
+
+Payload:
+
+```json
+{
+  "ant_id": "ant-17",
+  "food_id": "food-33",
+  "x": 412.5,
+  "y": 218.0,
+  "direction_x": -0.91,
+  "direction_y": 0.42,
+  "frame": 884
+}
+```
+
+Server effect:
+
+- mark that food item as no longer loose on the ground
+- update per-sim counters
+
+### `food_drop`
+
+Sent when an ant drops food.
+
+Payload:
+
+```json
+{
+  "ant_id": "ant-17",
+  "food_id": "food-33",
+  "x": 398.0,
+  "y": 227.5,
+  "direction_x": 0.37,
+  "direction_y": -0.93,
+  "frame": 885
+}
+```
+
+Server effect:
+
+- mark that food item as loose on the ground at the provided position
+- update per-sim counters
+
+### `ant_turn_move`
+
+Sent when an ant changes direction. This event carries the ant position at the moment of the direction change.
+
+Payload:
+
+```json
+{
+  "ant_id": "ant-17",
+  "x": 398.0,
+  "y": 227.5,
+  "direction_x": 0.37,
+  "direction_y": -0.93,
+  "frame": 885
+}
+```
+
+V1 deliberately does not stream every ant position every frame by default.
+
+### `sim_goodbye`
+
+Optional best-effort disconnect event.
+
+Payload:
+
+```json
+{
+  "reason": "shutdown"
+}
+```
+
+If it is absent, the server still considers the sim disconnected when the socket closes or heartbeats stop.
+
+## Aggregate State
+
+The backend keeps only in-memory live state for v1.
+
+Per-sim state:
+
+- sim metadata from `sim_hello`
+- connection status
+- last sequence number
+- last heartbeat time
+- pickup count
+- drop count
+- turn/move count
+- current loose-food positions by `food_id`
+
+Global aggregate state:
+
+- currently connected sim count
+- total live event rate
+- aggregate loose-food positions across connected sims
+- clustering metrics computed from loose-food positions
+
+## Clustering Metrics
+
+V1 should show whether food is collecting into piles or staying sparse.
+
+Recommended metrics:
+
+- `loose_food_count`
+- `nearest_neighbor_mean_distance`
+- `occupied_cell_count`
+- `top_5_cells_share`
+
+Definitions:
+
+- use only loose food currently on the ground
+- bucket food into fixed grid cells
+- `top_5_cells_share` means the percentage of loose food contained in the 5 densest cells
+
+These metrics are simple enough for v1 and easy to explain on the dashboard.
+
+## Backpressure Rules
+
+The Rust client must never block the simulation loop on network I/O.
+
+Client-side v1 rule:
+
+- buffer outbound events in a bounded queue
+- if the queue is full, drop new outbound events and increment a local dropped-events counter
+
+Server-side v1 rule:
+
+- each connection is read independently
+- decoded events are pushed into a bounded ingest path
+- if the server cannot accept more events for a connection, it may close that connection rather than silently corrupt aggregate state
+
+This keeps simulation runtime safe on the client side and keeps backend overload visible on the server side.
+
+## Tentative Go Library Direction
+
+Tentative v1 direction:
+
+- `net/http` from the standard library for HTTP
+- a small WebSocket library chosen during implementation review
+- standard `testing` and `httptest` for tests
+
+Library choice should stay open until the first architecture review checkpoint.
+
+## Local Dev Expectations
+
+Local v1 flow:
+
+1. run the Go server
+2. run fake Go clients first for standalone backend testing
+3. later run the Rust sim with backend mode enabled
+4. inspect `/api/*` endpoints and the built-in dashboard
+
+## Non-Goals For V1
+
+- database persistence
+- auth or multi-user security
+- historical replay
+- exactly-once delivery
+- cross-process clustering jobs

--- a/docs/go-backend-v1-contract.md
+++ b/docs/go-backend-v1-contract.md
@@ -47,6 +47,8 @@ Recommended hello payload fields:
 - `ant_count`
 - `food_count`
 
+Immediately after `sim_hello`, the client may send a startup snapshot message containing all currently loose food positions. This gives the backend an initial world view without waiting for later pickup/drop events.
+
 ## Transport
 
 ### WebSocket ingest
@@ -116,6 +118,26 @@ Payload:
   "food_count": 80
 }
 ```
+
+### `sim_food_snapshot`
+
+Sent once immediately after `sim_hello` to seed the backend with the loose food currently on the ground.
+
+Payload:
+
+```json
+{
+  "foods": [
+    { "food_id": "food-1", "x": 412.5, "y": 218.0 },
+    { "food_id": "food-2", "x": 398.0, "y": 227.5 }
+  ]
+}
+```
+
+Server effect:
+
+- replace the sim's currently known loose-food positions with the provided snapshot
+- do not count the snapshot itself as pickup/drop activity
 
 ### `sim_heartbeat`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod boundary;
 pub mod collision;
 pub mod config;
+pub mod net;
 pub mod spatial_index;
 pub mod ui;
 
@@ -12,6 +13,7 @@ use rand::Rng;
 pub use boundary::{BoundaryPlugin, BoundaryWrap, Bounding};
 pub use collision::{Collidable, CollisionPlugin, HitEvent};
 pub use config::{Colors, Config, SimulationSettings};
+pub use net::{BackendClientConfig, BackendClientPlugin, BackendSimEvent, PendingBackendEvents};
 pub use spatial_index::SpatialIndex;
 pub use ui::UiPlugin;
 
@@ -59,6 +61,7 @@ pub fn gatherer_movement(
 
 pub fn ant_hits_system(
     mut ant_hits: MessageReader<HitEvent<Food, Ant>>,
+    mut backend_events: MessageWriter<BackendSimEvent>,
     mut commands: Commands,
     mut ant_query: Query<
         (&mut Velocity, Option<&Children>, &Transform),
@@ -100,6 +103,25 @@ pub fn ant_hits_system(
                         + rng.random_range(-Config::TURN_ANGLE_RANGE..Config::TURN_ANGLE_RANGE);
                     let new_direction = Vec2::new(angle.cos(), angle.sin());
                     *velocity = Velocity(new_direction);
+                    let ant_id = ant.to_bits().to_string();
+                    let food_id = carried_food.to_bits().to_string();
+                    backend_events.write(BackendSimEvent::FoodDrop {
+                        ant_id: ant_id.clone(),
+                        food_id,
+                        x: ant_transform.translation.x,
+                        y: ant_transform.translation.y,
+                        direction_x: new_direction.x,
+                        direction_y: new_direction.y,
+                        frame: 0,
+                    });
+                    backend_events.write(BackendSimEvent::AntTurnMove {
+                        ant_id,
+                        x: ant_transform.translation.x,
+                        y: ant_transform.translation.y,
+                        direction_x: new_direction.x,
+                        direction_y: new_direction.y,
+                        frame: 0,
+                    });
                 } else {
                     warn!("[ant_hits_system] There is Some(carrying) but carrying.is_empty - how come?");
                 }
@@ -124,6 +146,25 @@ pub fn ant_hits_system(
                     + rng.random_range(-Config::TURN_ANGLE_RANGE..Config::TURN_ANGLE_RANGE);
                 let new_direction = Vec2::new(angle.cos(), angle.sin());
                 *velocity = Velocity(new_direction);
+                let ant_id = ant.to_bits().to_string();
+                let food_id = food.to_bits().to_string();
+                backend_events.write(BackendSimEvent::FoodPickup {
+                    ant_id: ant_id.clone(),
+                    food_id,
+                    x: ant_transform.translation.x,
+                    y: ant_transform.translation.y,
+                    direction_x: new_direction.x,
+                    direction_y: new_direction.y,
+                    frame: 0,
+                });
+                backend_events.write(BackendSimEvent::AntTurnMove {
+                    ant_id,
+                    x: ant_transform.translation.x,
+                    y: ant_transform.translation.y,
+                    direction_x: new_direction.x,
+                    direction_y: new_direction.y,
+                    frame: 0,
+                });
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ fn main() {
         }))
         .add_plugins(BoundaryPlugin)
         .add_plugins(CollisionPlugin::<Food, Ant>::new())
+        .add_plugins(BackendClientPlugin)
         .add_plugins(UiPlugin)
         .add_plugins(FrameTimeDiagnosticsPlugin::default())
         .add_plugins(LogDiagnosticsPlugin::default())

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,352 @@
+use std::collections::VecDeque;
+
+use bevy::{prelude::*, window::PrimaryWindow};
+use ewebsock::{Options, WsEvent, WsMessage, WsReceiver, WsSender};
+use log::{error, warn};
+use serde::Serialize;
+
+use crate::{Ant, Food};
+
+pub struct BackendClientPlugin;
+
+impl Plugin for BackendClientPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<BackendClientConfig>()
+            .init_resource::<PendingBackendEvents>()
+            .init_resource::<BackendSequence>()
+            .add_message::<BackendSimEvent>()
+            .insert_non_send_resource(BackendConnectionState::default())
+            .add_systems(
+                PostUpdate,
+                (
+                    queue_backend_hello_event,
+                    collect_backend_events,
+                    flush_backend_events,
+                )
+                    .chain(),
+            );
+    }
+}
+
+#[derive(Resource, Clone, Debug)]
+pub struct BackendClientConfig {
+    pub url: Option<String>,
+    pub sim_id: String,
+}
+
+impl Default for BackendClientConfig {
+    fn default() -> Self {
+        let url = std::env::var("GATHERERS_BACKEND_WS_URL").ok();
+        Self {
+            url,
+            sim_id: format!("sim-{}", rand::random::<u64>()),
+        }
+    }
+}
+
+impl BackendClientConfig {
+    pub fn enabled(url: String, sim_id: String) -> Self {
+        Self {
+            url: Some(url),
+            sim_id,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.url.is_some()
+    }
+}
+
+#[derive(Resource, Default, Debug)]
+pub struct PendingBackendEvents {
+    queued: VecDeque<String>,
+}
+
+impl PendingBackendEvents {
+    pub fn queued_json_messages(&self) -> Vec<String> {
+        self.queued.iter().cloned().collect()
+    }
+
+    fn push(&mut self, message: String) {
+        self.queued.push_back(message);
+    }
+
+    fn pop(&mut self) -> Option<String> {
+        self.queued.pop_front()
+    }
+}
+
+#[derive(Resource, Default)]
+struct BackendSequence(u64);
+
+#[derive(Default)]
+struct BackendConnectionState {
+    sender: Option<WsSender>,
+    receiver: Option<WsReceiver>,
+    opened: bool,
+    hello_queued: bool,
+}
+
+#[derive(Message, Clone, Debug)]
+pub enum BackendSimEvent {
+    FoodPickup {
+        ant_id: String,
+        food_id: String,
+        x: f32,
+        y: f32,
+        direction_x: f32,
+        direction_y: f32,
+        frame: u64,
+    },
+    FoodDrop {
+        ant_id: String,
+        food_id: String,
+        x: f32,
+        y: f32,
+        direction_x: f32,
+        direction_y: f32,
+        frame: u64,
+    },
+    AntTurnMove {
+        ant_id: String,
+        x: f32,
+        y: f32,
+        direction_x: f32,
+        direction_y: f32,
+        frame: u64,
+    },
+}
+
+#[derive(Serialize)]
+struct EventEnvelope<T: Serialize> {
+    #[serde(rename = "type")]
+    event_type: &'static str,
+    sim_id: String,
+    seq: u64,
+    timestamp_ms: u64,
+    payload: T,
+}
+
+#[derive(Serialize)]
+struct HelloPayload {
+    sim_name: String,
+    source: &'static str,
+    session_started_ms: u64,
+    world_width: f32,
+    world_height: f32,
+    ant_count: usize,
+    food_count: usize,
+}
+
+#[derive(Serialize)]
+struct FoodEventPayload {
+    ant_id: String,
+    food_id: String,
+    x: f32,
+    y: f32,
+    direction_x: f32,
+    direction_y: f32,
+    frame: u64,
+}
+
+#[derive(Serialize)]
+struct TurnMovePayload {
+    ant_id: String,
+    x: f32,
+    y: f32,
+    direction_x: f32,
+    direction_y: f32,
+    frame: u64,
+}
+
+fn queue_backend_hello_event(
+    config: Res<BackendClientConfig>,
+    mut pending: ResMut<PendingBackendEvents>,
+    mut sequence: ResMut<BackendSequence>,
+    mut connection: NonSendMut<BackendConnectionState>,
+    ant_query: Query<Entity, With<Ant>>,
+    food_query: Query<Entity, With<Food>>,
+    window_query: Query<&Window, With<PrimaryWindow>>,
+) {
+    if !config.is_enabled() || connection.hello_queued {
+        return;
+    }
+
+    let (world_width, world_height) = match window_query.single() {
+        Ok(window) => (window.width(), window.height()),
+        Err(_) => (0.0, 0.0),
+    };
+
+    let envelope = EventEnvelope {
+        event_type: "sim_hello",
+        sim_id: config.sim_id.clone(),
+        seq: next_sequence(&mut sequence),
+        timestamp_ms: 0,
+        payload: HelloPayload {
+            sim_name: config.sim_id.clone(),
+            source: "rust-bevy",
+            session_started_ms: 0,
+            world_width,
+            world_height,
+            ant_count: ant_query.iter().count(),
+            food_count: food_query.iter().count(),
+        },
+    };
+
+    match serde_json::to_string(&envelope) {
+        Ok(json) => {
+            pending.push(json);
+            connection.hello_queued = true;
+        }
+        Err(err) => error!("Failed to serialize sim_hello event: {err}"),
+    }
+}
+
+fn collect_backend_events(
+    config: Res<BackendClientConfig>,
+    mut pending: ResMut<PendingBackendEvents>,
+    mut sequence: ResMut<BackendSequence>,
+    mut events: MessageReader<BackendSimEvent>,
+) {
+    if !config.is_enabled() {
+        return;
+    }
+
+    for event in events.read() {
+        let serialized = match event {
+            BackendSimEvent::FoodPickup {
+                ant_id,
+                food_id,
+                x,
+                y,
+                direction_x,
+                direction_y,
+                frame,
+            } => serde_json::to_string(&EventEnvelope {
+                event_type: "food_pickup",
+                sim_id: config.sim_id.clone(),
+                seq: next_sequence(&mut sequence),
+                timestamp_ms: 0,
+                payload: FoodEventPayload {
+                    ant_id: ant_id.clone(),
+                    food_id: food_id.clone(),
+                    x: *x,
+                    y: *y,
+                    direction_x: *direction_x,
+                    direction_y: *direction_y,
+                    frame: *frame,
+                },
+            }),
+            BackendSimEvent::FoodDrop {
+                ant_id,
+                food_id,
+                x,
+                y,
+                direction_x,
+                direction_y,
+                frame,
+            } => serde_json::to_string(&EventEnvelope {
+                event_type: "food_drop",
+                sim_id: config.sim_id.clone(),
+                seq: next_sequence(&mut sequence),
+                timestamp_ms: 0,
+                payload: FoodEventPayload {
+                    ant_id: ant_id.clone(),
+                    food_id: food_id.clone(),
+                    x: *x,
+                    y: *y,
+                    direction_x: *direction_x,
+                    direction_y: *direction_y,
+                    frame: *frame,
+                },
+            }),
+            BackendSimEvent::AntTurnMove {
+                ant_id,
+                x,
+                y,
+                direction_x,
+                direction_y,
+                frame,
+            } => serde_json::to_string(&EventEnvelope {
+                event_type: "ant_turn_move",
+                sim_id: config.sim_id.clone(),
+                seq: next_sequence(&mut sequence),
+                timestamp_ms: 0,
+                payload: TurnMovePayload {
+                    ant_id: ant_id.clone(),
+                    x: *x,
+                    y: *y,
+                    direction_x: *direction_x,
+                    direction_y: *direction_y,
+                    frame: *frame,
+                },
+            }),
+        };
+
+        match serialized {
+            Ok(json) => pending.push(json),
+            Err(err) => error!("Failed to serialize backend event: {err}"),
+        }
+    }
+}
+
+fn flush_backend_events(
+    config: Res<BackendClientConfig>,
+    mut pending: ResMut<PendingBackendEvents>,
+    mut connection: NonSendMut<BackendConnectionState>,
+) {
+    if !config.is_enabled() {
+        return;
+    }
+
+    if connection.sender.is_none() {
+        let Some(url) = &config.url else {
+            return;
+        };
+
+        match ewebsock::connect(url.clone(), Options::default()) {
+            Ok((sender, receiver)) => {
+                connection.sender = Some(sender);
+                connection.receiver = Some(receiver);
+                connection.opened = false;
+            }
+            Err(err) => {
+                warn!("Failed to connect backend websocket client: {err}");
+                return;
+            }
+        }
+    }
+
+    loop {
+        let Some(event) = connection.receiver.as_ref().and_then(|receiver| receiver.try_recv()) else {
+            break;
+        };
+
+        match event {
+            WsEvent::Opened => connection.opened = true,
+            WsEvent::Closed => {
+                connection.sender = None;
+                connection.receiver = None;
+                connection.opened = false;
+                return;
+            }
+            WsEvent::Error(err) => warn!("Backend websocket error: {err}"),
+            WsEvent::Message(_) => {}
+        }
+    }
+
+    if !connection.opened {
+        return;
+    }
+
+    if let Some(sender) = &mut connection.sender {
+        while let Some(message) = pending.pop() {
+            sender.send(WsMessage::Text(message));
+        }
+    }
+}
+
+fn next_sequence(sequence: &mut BackendSequence) -> u64 {
+    sequence.0 += 1;
+    sequence.0
+}

--- a/src/net.rs
+++ b/src/net.rs
@@ -20,6 +20,7 @@ impl Plugin for BackendClientPlugin {
                 PostUpdate,
                 (
                     queue_backend_hello_event,
+                    queue_backend_food_snapshot_event,
                     collect_backend_events,
                     flush_backend_events,
                 )
@@ -85,6 +86,7 @@ struct BackendConnectionState {
     receiver: Option<WsReceiver>,
     opened: bool,
     hello_queued: bool,
+    food_snapshot_queued: bool,
 }
 
 #[derive(Message, Clone, Debug)]
@@ -136,6 +138,18 @@ struct HelloPayload {
     world_height: f32,
     ant_count: usize,
     food_count: usize,
+}
+
+#[derive(Serialize)]
+struct FoodSnapshotPayload {
+    foods: Vec<StartupFoodPayload>,
+}
+
+#[derive(Serialize)]
+struct StartupFoodPayload {
+    food_id: String,
+    x: f32,
+    y: f32,
 }
 
 #[derive(Serialize)]
@@ -199,6 +213,43 @@ fn queue_backend_hello_event(
             connection.hello_queued = true;
         }
         Err(err) => error!("Failed to serialize sim_hello event: {err}"),
+    }
+}
+
+fn queue_backend_food_snapshot_event(
+    config: Res<BackendClientConfig>,
+    mut pending: ResMut<PendingBackendEvents>,
+    mut sequence: ResMut<BackendSequence>,
+    mut connection: NonSendMut<BackendConnectionState>,
+    food_query: Query<(Entity, &Transform), (With<Food>, Without<ChildOf>)>,
+) {
+    if !config.is_enabled() || !connection.hello_queued || connection.food_snapshot_queued {
+        return;
+    }
+
+    let foods = food_query
+        .iter()
+        .map(|(entity, transform)| StartupFoodPayload {
+            food_id: entity.to_bits().to_string(),
+            x: transform.translation.x,
+            y: transform.translation.y,
+        })
+        .collect();
+
+    let envelope = EventEnvelope {
+        event_type: "sim_food_snapshot",
+        sim_id: config.sim_id.clone(),
+        seq: next_sequence(&mut sequence),
+        timestamp_ms: 0,
+        payload: FoodSnapshotPayload { foods },
+    };
+
+    match serde_json::to_string(&envelope) {
+        Ok(json) => {
+            pending.push(json);
+            connection.food_snapshot_queued = true;
+        }
+        Err(err) => error!("Failed to serialize sim_food_snapshot event: {err}"),
     }
 }
 

--- a/tests/backend_client_tests.rs
+++ b/tests/backend_client_tests.rs
@@ -80,3 +80,63 @@ fn test_pickup_collision_queues_backend_messages() {
         .is_some_and(|children| !children.is_empty());
     assert!(has_children, "expected ant to pick up food in the simulation too");
 }
+
+#[test]
+fn test_startup_queues_food_snapshot_after_hello() {
+    let mut app = App::new();
+
+    app.add_plugins(MinimalPlugins)
+        .insert_resource(BackendClientConfig::enabled(
+            "ws://localhost:8080/ws/ingest".to_string(),
+            "sim-startup".to_string(),
+        ))
+        .add_plugins(BackendClientPlugin);
+
+    let world = app.world_mut();
+    world.spawn((
+        Food,
+        Transform::from_translation(Vec3::new(10.0, 20.0, 0.0)),
+    ));
+    world.spawn((
+        Food,
+        Transform::from_translation(Vec3::new(30.0, 40.0, 0.0)),
+    ));
+
+    app.update();
+
+    let queued = app
+        .world()
+        .resource::<PendingBackendEvents>()
+        .queued_json_messages();
+
+    assert!(
+        queued.len() >= 2,
+        "expected sim_hello and sim_food_snapshot startup messages, got {:?}",
+        queued
+    );
+    assert!(
+        queued[0].contains("\"type\":\"sim_hello\""),
+        "expected first startup message to be sim_hello, got {:?}",
+        queued
+    );
+    assert!(
+        queued[1].contains("\"type\":\"sim_food_snapshot\""),
+        "expected second startup message to be sim_food_snapshot, got {:?}",
+        queued
+    );
+    assert!(
+        queued[1].contains("\"food_id\""),
+        "expected startup food snapshot to include food ids, got {:?}",
+        queued
+    );
+    assert!(
+        queued[1].contains("\"x\":10.0") && queued[1].contains("\"y\":20.0"),
+        "expected startup food snapshot to include first food position, got {:?}",
+        queued
+    );
+    assert!(
+        queued[1].contains("\"x\":30.0") && queued[1].contains("\"y\":40.0"),
+        "expected startup food snapshot to include second food position, got {:?}",
+        queued
+    );
+}

--- a/tests/backend_client_tests.rs
+++ b/tests/backend_client_tests.rs
@@ -1,0 +1,82 @@
+use an_gatherers::collision::{initialize_hittables, update_hittable_positions};
+use an_gatherers::spatial_index::SpatialIndex;
+use an_gatherers::*;
+use bevy::prelude::*;
+
+#[test]
+fn test_pickup_collision_queues_backend_messages() {
+    let mut app = App::new();
+
+    app.add_plugins(MinimalPlugins)
+        .init_resource::<SpatialIndex>()
+        .add_message::<HitEvent<Food, Ant>>()
+        .insert_resource(SimulationSettings::default())
+        .insert_resource(BackendClientConfig::enabled(
+            "ws://localhost:8080/ws/ingest".to_string(),
+            "sim-test".to_string(),
+        ))
+        .add_plugins(BackendClientPlugin)
+        .add_systems(Startup, initialize_hittables::<Food>)
+        .add_systems(Update, update_hittable_positions::<Food>)
+        .add_systems(Update, gatherer_movement)
+        .add_systems(
+            Update,
+            (debug_collision_system::<Food, Ant>, ant_hits_system)
+                .chain()
+                .after(gatherer_movement),
+        );
+
+    let world = app.world_mut();
+    let ant = world
+        .spawn((
+            Ant,
+            Velocity(Vec2::new(1.0, 0.0)),
+            Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+            Bounding::from_radius(10.0),
+            Collidable,
+        ))
+        .id();
+
+    let food = world
+        .spawn((
+            Food,
+            Transform::from_translation(Vec3::new(5.0, 0.0, 0.0)),
+            Bounding::from_radius(5.0),
+            Collidable,
+        ))
+        .id();
+
+    world
+        .resource_mut::<SpatialIndex>()
+        .update(food, Vec2::new(5.0, 0.0));
+
+    app.update();
+
+    let queued = app
+        .world()
+        .resource::<PendingBackendEvents>()
+        .queued_json_messages();
+
+    assert!(
+        queued.iter().any(|msg| msg.contains("\"type\":\"food_pickup\"")),
+        "expected a food_pickup backend message after collision, got {:?}",
+        queued
+    );
+    assert!(
+        queued.iter().any(|msg| msg.contains("\"type\":\"ant_turn_move\"")),
+        "expected an ant_turn_move backend message after collision, got {:?}",
+        queued
+    );
+    assert!(
+        queued.iter().all(|msg| msg.contains("\"sim_id\":\"sim-test\"")),
+        "expected queued backend messages to include the configured sim_id, got {:?}",
+        queued
+    );
+
+    let has_children = app
+        .world()
+        .entity(ant)
+        .get::<Children>()
+        .is_some_and(|children| !children.is_empty());
+    assert!(has_children, "expected ant to pick up food in the simulation too");
+}

--- a/tests/simulation_tests.rs
+++ b/tests/simulation_tests.rs
@@ -121,6 +121,7 @@ fn create_test_app_with_dt(frame_ms: u64) -> App {
     app.add_plugins(MinimalPlugins)
         .init_resource::<SpatialIndex>()
         .add_message::<HitEvent<Food, Ant>>()
+        .add_message::<BackendSimEvent>()
         .insert_resource(SimulationSettings::default())
         .insert_resource(TestEventCollector::default())
         .insert_resource(Time::<()>::default())


### PR DESCRIPTION
## Summary
- add a standalone Go backend that ingests simulation events over websockets, keeps live in-memory state for connected sims, and serves both JSON APIs and a built-in realtime dashboard
- connect the Rust sim and the Go fake-client load generator to the same event model, including startup food snapshots, pickup/drop/move events, and per-sim ant metadata, so the backend starts with an initial world view and can be exercised under realistic load
- keep the backend responsive under heavy traffic by decoupling ingest from expensive dashboard aggregation: incoming events update state immediately, while cached dashboard snapshots are recomputed in a demand-driven background worker and streamed to dashboard watchers
- document the protocol, local workflows, and runtime architecture so the data flow between sim clients, backend state, cached aggregates, APIs, and dashboard updates is easy to understand

## Test Plan
- [x] `cd backend && go test ./... -count=1`
- [x] `cd backend && go test -race ./... -count=1`
- [x] `cd backend && go test ./internal/server -run TestStressHundredFakeClientsDeliversExactEventTotals -count=1`
- [x] manual demo: run the backend on `:18080`, drive `cmd/fakeclients` with 100 clients, and confirm the dashboard/API counts keep rising under load instead of stalling near startup

Made with [Cursor](https://cursor.com)