### PR TITLE
feat: add rust backend parity backend

### DIFF
--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -12,6 +12,12 @@ name = "gatherers-backend-rust"
 path = "src/main.rs"
 
 [dependencies]
+axum = { version = "0.8", features = ["ws"] }
+futures-util = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync"] }
+
+[dev-dependencies]
+tokio-tungstenite = "0.28"
+tower = { version = "0.5", features = ["util"] }

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gatherers-backend-rust"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "gatherers_backend_rust"
+path = "src/lib.rs"
+
+[[bin]]
+name = "gatherers-backend-rust"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -19,5 +19,6 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync"] }
 
 [dev-dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio-tungstenite = "0.28"
 tower = { version = "0.5", features = ["util"] }

--- a/backend-rust/README.md
+++ b/backend-rust/README.md
@@ -1,0 +1,97 @@
+# Rust Backend
+
+This directory contains the standalone Rust backend built to compare against the Go backend under the same HTTP and WebSocket contract.
+
+## Current scope
+
+- same JSON event envelope as `docs/go-backend-v1-contract.md`
+- `GET /healthz`
+- `GET /api/summary`
+- `GET /api/sims`
+- `GET /`
+- `GET /ws/ingest`
+- `GET /ws/dashboard`
+- in-memory state only
+- cached snapshot behavior with eventual consistency
+
+## Run locally
+
+```bash
+cd backend-rust
+cargo run
+```
+
+Use a custom bind address:
+
+```bash
+cd backend-rust
+GATHERERS_BACKEND_RUST_ADDR=127.0.0.1:18082 cargo run
+```
+
+## Run the Rust test suite
+
+```bash
+cd backend-rust
+cargo test
+```
+
+## Reuse Go black-box tests against Rust
+
+Start the Rust backend first:
+
+```bash
+cd backend-rust
+GATHERERS_BACKEND_RUST_ADDR=127.0.0.1:18082 cargo run
+```
+
+Then point the Go tests at it:
+
+```bash
+cd backend
+GATHERERS_BACKEND_BASE_URL=http://127.0.0.1:18082 \
+go test ./internal/server -run TestSummaryReflectsEventsIngestedOverWebSocket -count=1
+```
+
+Examples that were verified unchanged against Rust:
+
+```bash
+cd backend
+GATHERERS_BACKEND_BASE_URL=http://127.0.0.1:18082 \
+go test ./internal/server -run TestDashboardPageBootstrapsRealtimeWebsocketUi -count=1
+```
+
+```bash
+cd backend
+GATHERERS_BACKEND_BASE_URL=http://127.0.0.1:18082 \
+go test ./internal/server -run TestFakeClientsPopulatePerSimSummaries -count=1
+```
+
+```bash
+cd backend
+GATHERERS_BACKEND_BASE_URL=http://127.0.0.1:18082 \
+go test ./internal/server -run TestStressHundredFakeClientsDeliversExactEventTotals -count=1
+```
+
+For tests that require a pristine initial snapshot, use a fresh Rust backend process per Go test invocation. The external-base-URL mode shares one backend process, so state persists across tests within that process.
+
+## Breakpoint wrapper against Rust
+
+```bash
+cd backend
+GATHERERS_BACKEND_BASE_URL=http://127.0.0.1:18082 \
+GATHERERS_FIND_BREAKPOINT=1 \
+GATHERERS_BREAKPOINT_START_CLIENTS=2 \
+GATHERERS_BREAKPOINT_MAX_CLIENTS=4 \
+GATHERERS_BREAKPOINT_STEP=2 \
+GATHERERS_BREAKPOINT_ACTIVITY_TRIPLETS=4 \
+GATHERERS_BREAKPOINT_SEND_TIMEOUT=3s \
+GATHERERS_BREAKPOINT_SETTLE_TIMEOUT=3s \
+GATHERERS_BREAKPOINT_TEST_TIMEOUT=10s \
+go test ./internal/server -run TestFindBreakpointUnderRampLoad -count=1 -v
+```
+
+## Raw TCP later
+
+Raw TCP ingest is intentionally deferred.
+
+The current transport-independent seam is `src/ingest.rs`, where decoded envelopes are handed to shared state/update logic. When native-only TCP is added later, it should reuse the same envelope types and ingest core, changing only the framing layer.

--- a/backend-rust/src/app.rs
+++ b/backend-rust/src/app.rs
@@ -2,7 +2,7 @@ use std::sync::{
     Arc, Once, RwLock,
     atomic::{AtomicBool, Ordering},
 };
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use axum::{
     Json, Router,
@@ -20,9 +20,12 @@ use tokio::sync::{Mutex, Notify, broadcast};
 use crate::{
     dashboard::render_dashboard,
     ingest::handle_ingest_event,
-    protocol::EventEnvelope,
-    store::Store,
-    summary::{CachedSnapshot, SimSummaryResponse, SummaryResponse},
+    protocol::{EventEnvelope, EventPayload},
+    store::{EventOutcome, Store},
+    summary::{
+        AnalyticsMetaResponse, CachedAnalyticsSnapshot, CachedLiveSnapshot, CachedSnapshot,
+        SimSummaryResponse, SummaryResponse,
+    },
 };
 
 #[derive(Clone)]
@@ -32,9 +35,10 @@ pub struct AppState {
 
 struct AppStateInner {
     store: Store,
-    snapshot: RwLock<CachedSnapshot>,
+    live_snapshot: RwLock<LiveCacheState>,
+    analytics_snapshot: RwLock<CachedAnalyticsSnapshot>,
     refresh: Mutex<RefreshState>,
-    dirty: AtomicBool,
+    analytics_dirty: AtomicBool,
     last_snapshot_copy_micros: std::sync::atomic::AtomicU64,
     last_snapshot_compute_micros: std::sync::atomic::AtomicU64,
     refresh_signal: Notify,
@@ -47,6 +51,13 @@ struct RefreshState {
     dashboard_watchers: usize,
     last_api_demand_at: Option<Instant>,
     next_eligible_at: Option<Instant>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct LiveCacheState {
+    snapshot: CachedLiveSnapshot,
+    started_at: Option<Instant>,
+    total_events: usize,
 }
 
 #[derive(Clone, Copy)]
@@ -78,13 +89,14 @@ impl AppState {
         Self {
             inner: Arc::new(AppStateInner {
                 store: Store::default(),
-                snapshot: RwLock::new(CachedSnapshot::default()),
+                live_snapshot: RwLock::new(LiveCacheState::default()),
+                analytics_snapshot: RwLock::new(CachedAnalyticsSnapshot::default()),
                 refresh: Mutex::new(RefreshState {
                     dashboard_watchers: 0,
                     last_api_demand_at: None,
                     next_eligible_at: None,
                 }),
-                dirty: AtomicBool::new(false),
+                analytics_dirty: AtomicBool::new(false),
                 last_snapshot_copy_micros: std::sync::atomic::AtomicU64::new(0),
                 last_snapshot_compute_micros: std::sync::atomic::AtomicU64::new(0),
                 refresh_signal: Notify::new(),
@@ -96,22 +108,44 @@ impl AppState {
     }
 
     pub fn apply_event(&self, envelope: EventEnvelope) -> Result<(), String> {
-        self.inner
-            .store
-            .apply_event(&envelope)?;
-
-        self.inner.dirty.store(true, Ordering::SeqCst);
-        self.ensure_worker();
-        self.signal_refresh();
+        let analytics_affected = event_affects_analytics(&envelope);
+        let outcome = self.inner.store.apply_event(&envelope)?;
+        self.apply_live_event(&envelope, &outcome);
+        let _ = self.inner.dashboard_tx.send(self.current_snapshot());
+        if analytics_affected {
+            self.mark_analytics_stale();
+            self.inner.analytics_dirty.store(true, Ordering::SeqCst);
+            self.ensure_worker();
+            self.signal_refresh();
+        }
         Ok(())
     }
 
     fn current_snapshot(&self) -> CachedSnapshot {
-        self.inner
-            .snapshot
+        let live_snapshot = self
+            .inner
+            .live_snapshot
             .read()
-            .expect("snapshot lock poisoned")
-            .clone()
+            .expect("live snapshot lock poisoned")
+            .snapshot
+            .clone();
+        let mut analytics_snapshot = self
+            .inner
+            .analytics_snapshot
+            .read()
+            .expect("analytics snapshot lock poisoned")
+            .clone();
+        analytics_snapshot.analytics_meta.age_seconds =
+            analytics_age_seconds(analytics_snapshot.analytics_meta.computed_at_ms);
+
+        CachedSnapshot {
+            summary: SummaryResponse {
+                live_summary: live_snapshot.live_summary,
+                analytics_summary: analytics_snapshot.analytics_summary,
+                analytics_meta: analytics_snapshot.analytics_meta,
+            },
+            sims: live_snapshot.sims,
+        }
     }
 
     async fn register_api_demand(&self) {
@@ -155,6 +189,61 @@ impl AppState {
         self.inner.refresh_signal.notify_one();
     }
 
+    fn apply_live_event(&self, envelope: &EventEnvelope, outcome: &EventOutcome) {
+        let mut live_cache = self
+            .inner
+            .live_snapshot
+            .write()
+            .expect("live snapshot lock poisoned");
+
+        let sim = live_cache.sim_summary_mut(&envelope.sim_id);
+        let previous_loose_food = sim.loose_food_count;
+
+        match &envelope.payload {
+            EventPayload::SimHello(payload) => {
+                sim.ant_count = payload.ant_count;
+            }
+            EventPayload::SimFoodSnapshot(_) => {}
+            EventPayload::FoodPickup(_) => {
+                sim.pickup_count += 1;
+            }
+            EventPayload::FoodDrop(_) => {
+                sim.drop_count += 1;
+            }
+            EventPayload::AntTurnMove(_) => {
+                sim.turn_move_count += 1;
+            }
+            EventPayload::SimHeartbeat(_) | EventPayload::SimGoodbye(_) => {}
+        }
+        sim.loose_food_count = outcome.sim_loose_food_count;
+        let loose_food_delta = sim.loose_food_count as isize - previous_loose_food as isize;
+
+        live_cache.total_events += 1;
+        if live_cache.started_at.is_none() {
+            live_cache.started_at = Some(Instant::now());
+        }
+        live_cache.snapshot.live_summary.connected_sim_count = live_cache.snapshot.sims.len();
+        live_cache.snapshot.live_summary.loose_food_count = live_cache
+            .snapshot
+            .live_summary
+            .loose_food_count
+            .saturating_add_signed(loose_food_delta);
+        let (elapsed_seconds, events_per_second) = live_cache.metrics();
+        live_cache.snapshot.live_summary.elapsed_seconds = elapsed_seconds;
+        live_cache.snapshot.live_summary.events_per_second = events_per_second;
+    }
+
+    fn mark_analytics_stale(&self) {
+        let mut analytics_snapshot = self
+            .inner
+            .analytics_snapshot
+            .write()
+            .expect("analytics snapshot lock poisoned");
+        analytics_snapshot.analytics_meta.is_stale = true;
+        analytics_snapshot.analytics_meta.age_seconds =
+            analytics_age_seconds(analytics_snapshot.analytics_meta.computed_at_ms);
+    }
+
     async fn run_refresh_worker(self) {
         loop {
             self.inner.refresh_signal.notified().await;
@@ -174,32 +263,41 @@ impl AppState {
                     }
                 }
 
-                if !self.inner.dirty.swap(false, Ordering::SeqCst) {
+                if !self.inner.analytics_dirty.swap(false, Ordering::SeqCst) {
                     continue;
                 }
 
                 let copy_started = Instant::now();
-                let snapshot_data = self.inner.store.snapshot_data();
+                let analytics_input = self.inner.store.analytics_input_data();
                 self.inner
                     .last_snapshot_copy_micros
                     .store(copy_started.elapsed().as_micros() as u64, Ordering::SeqCst);
                 let compute_started = Instant::now();
-                let snapshot = tokio::task::spawn_blocking(move || snapshot_data.into_cached_snapshot())
+                let analytics_summary =
+                    tokio::task::spawn_blocking(move || analytics_input.summary())
                     .await
-                    .expect("snapshot compute task should join");
+                    .expect("analytics compute task should join");
                 let compute_duration = compute_started.elapsed();
                 self.inner
                     .last_snapshot_compute_micros
                     .store(compute_duration.as_micros() as u64, Ordering::SeqCst);
                 {
-                    let mut snapshot_guard = self
+                    let stale_again = self.inner.analytics_dirty.load(Ordering::SeqCst);
+                    let mut analytics_guard = self
                         .inner
-                        .snapshot
+                        .analytics_snapshot
                         .write()
-                        .expect("snapshot lock poisoned");
-                    *snapshot_guard = snapshot.clone();
+                        .expect("analytics snapshot lock poisoned");
+                    *analytics_guard = CachedAnalyticsSnapshot {
+                        analytics_summary,
+                        analytics_meta: AnalyticsMetaResponse {
+                            computed_at_ms: unix_timestamp_ms(),
+                            age_seconds: 0.0,
+                            is_stale: stale_again,
+                        },
+                    };
                 }
-                let _ = self.inner.dashboard_tx.send(snapshot);
+                let _ = self.inner.dashboard_tx.send(self.current_snapshot());
                 let mut refresh = self.inner.refresh.lock().await;
                 refresh.next_eligible_at =
                     Some(Instant::now() + self.adaptive_refresh_interval(compute_duration));
@@ -209,7 +307,9 @@ impl AppState {
 
     async fn next_refresh_plan(&self, now: Instant) -> Option<Duration> {
         let refresh = self.inner.refresh.lock().await;
-        if !self.has_demand_locked(&refresh, now) || !self.inner.dirty.load(Ordering::SeqCst) {
+        if !self.has_demand_locked(&refresh, now)
+            || !self.inner.analytics_dirty.load(Ordering::SeqCst)
+        {
             return None;
         }
         match refresh.next_eligible_at {
@@ -239,6 +339,57 @@ impl AppState {
         }
         interval
     }
+}
+
+impl LiveCacheState {
+    fn sim_summary_mut(&mut self, sim_id: &str) -> &mut SimSummaryResponse {
+        if let Some(index) = self.snapshot.sims.iter().position(|sim| sim.sim_id == sim_id) {
+            return &mut self.snapshot.sims[index];
+        }
+        self.snapshot.sims.push(SimSummaryResponse {
+            sim_id: sim_id.to_string(),
+            ..SimSummaryResponse::default()
+        });
+        self.snapshot.sims.last_mut().expect("new sim summary")
+    }
+
+    fn metrics(&self) -> (f64, f64) {
+        let Some(started_at) = self.started_at else {
+            return (0.0, 0.0);
+        };
+        let elapsed_seconds = started_at.elapsed().as_secs_f64();
+        if elapsed_seconds <= 0.0 {
+            return (0.0, 0.0);
+        }
+        (elapsed_seconds, self.total_events as f64 / elapsed_seconds)
+    }
+}
+
+fn event_affects_analytics(envelope: &EventEnvelope) -> bool {
+    matches!(
+        envelope.payload,
+        EventPayload::SimFoodSnapshot(_)
+            | EventPayload::FoodPickup(_)
+            | EventPayload::FoodDrop(_)
+    )
+}
+
+fn unix_timestamp_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_millis() as i64
+}
+
+fn analytics_age_seconds(computed_at_ms: i64) -> f64 {
+    if computed_at_ms <= 0 {
+        return 0.0;
+    }
+    let now_ms = unix_timestamp_ms();
+    if now_ms <= computed_at_ms {
+        return 0.0;
+    }
+    (now_ms - computed_at_ms) as f64 / 1000.0
 }
 
 pub fn build_router() -> Router {
@@ -321,17 +472,23 @@ async fn handle_dashboard_socket(state: AppState, mut socket: WebSocket) {
     }
 
     let mut receiver = state.add_dashboard_watcher().await;
-    while let Ok(snapshot) = receiver.recv().await {
-        if socket
-            .send(Message::Text(
-                serde_json::to_string(&snapshot)
-                    .expect("dashboard snapshot json")
-                    .into(),
-            ))
-            .await
-            .is_err()
-        {
-            break;
+    loop {
+        match receiver.recv().await {
+            Ok(snapshot) => {
+                if socket
+                    .send(Message::Text(
+                        serde_json::to_string(&snapshot)
+                            .expect("dashboard snapshot json")
+                            .into(),
+                    ))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(broadcast::error::RecvError::Closed) => break,
         }
     }
     state.remove_dashboard_watcher().await;
@@ -343,6 +500,8 @@ mod tests {
         sync::{Arc, atomic::Ordering},
         time::{Duration, Instant},
     };
+
+    use serde_json::Value;
 
     use super::{AppState, RefreshTuning};
     use crate::protocol::{
@@ -656,7 +815,8 @@ mod tests {
             .expect("food drop should be accepted");
 
         state.register_api_demand().await;
-        wait_for_loose_food_count(&state, 1).await;
+        wait_for_live_loose_food_count(&state, 1).await;
+        wait_for_analytics_occupied_cells(&state, 1).await;
 
         tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -679,10 +839,17 @@ mod tests {
             .expect("second food drop should be accepted");
 
         tokio::time::sleep(Duration::from_millis(20)).await;
-        assert_eq!(state.current_snapshot().summary.loose_food_count, 1);
+        let stale_snapshot = current_snapshot_json(&state);
+        assert_eq!(stale_snapshot["summary"]["live_summary"]["loose_food_count"], 2);
+        assert_eq!(
+            stale_snapshot["summary"]["analytics_summary"]["occupied_cell_count"],
+            1
+        );
+        assert_eq!(stale_snapshot["summary"]["analytics_meta"]["is_stale"], true);
 
         state.register_api_demand().await;
-        wait_for_loose_food_count(&state, 2).await;
+        wait_for_live_loose_food_count(&state, 2).await;
+        wait_for_analytics_occupied_cells(&state, 1).await;
     }
 
     #[tokio::test]
@@ -730,7 +897,8 @@ mod tests {
             .expect("initial food drop should be accepted");
 
         state.register_api_demand().await;
-        wait_for_loose_food_count(&state, 1).await;
+        wait_for_live_loose_food_count(&state, 1).await;
+        wait_for_analytics_occupied_cells(&state, 1).await;
 
         state
             .apply_event(EventEnvelope {
@@ -751,24 +919,181 @@ mod tests {
             .expect("second food drop should be accepted");
 
         tokio::time::sleep(Duration::from_millis(20)).await;
-        assert_eq!(state.current_snapshot().summary.loose_food_count, 1);
+        let stale_snapshot = current_snapshot_json(&state);
+        assert_eq!(stale_snapshot["summary"]["live_summary"]["loose_food_count"], 2);
+        assert_eq!(
+            stale_snapshot["summary"]["analytics_summary"]["occupied_cell_count"],
+            1
+        );
+        assert_eq!(stale_snapshot["summary"]["analytics_meta"]["is_stale"], true);
 
-        wait_for_loose_food_count(&state, 2).await;
+        wait_for_live_loose_food_count(&state, 2).await;
+        wait_for_analytics_occupied_cells(&state, 1).await;
     }
 
-    async fn wait_for_loose_food_count(state: &AppState, expected: usize) {
+    async fn wait_for_live_loose_food_count(state: &AppState, expected: usize) {
         let deadline = tokio::time::Instant::now() + Duration::from_millis(250);
         loop {
-            let snapshot = state.current_snapshot();
-            if snapshot.summary.loose_food_count == expected {
+            let snapshot = current_snapshot_json(state);
+            if snapshot["summary"]["live_summary"]["loose_food_count"] == expected {
                 return;
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "expected loose_food_count={expected}, last snapshot was {:?}",
-                snapshot.summary
+                "expected live loose_food_count={expected}, last snapshot was {snapshot:?}"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
+    }
+
+    async fn wait_for_analytics_occupied_cells(state: &AppState, expected: usize) {
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(250);
+        loop {
+            let snapshot = current_snapshot_json(state);
+            if snapshot["summary"]["analytics_summary"]["occupied_cell_count"] == expected {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "expected analytics occupied_cell_count={expected}, last snapshot was {snapshot:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    fn current_snapshot_json(state: &AppState) -> Value {
+        serde_json::to_value(state.current_snapshot()).expect("snapshot json")
+    }
+
+    #[tokio::test]
+    async fn duplicate_food_drop_does_not_inflate_live_loose_food_count() {
+        let state = AppState::new();
+        state
+            .apply_event(EventEnvelope {
+                event_type: "sim_hello".into(),
+                sim_id: "sim-dup".into(),
+                seq: 1,
+                timestamp_ms: 0,
+                payload: EventPayload::SimHello(HelloPayload {
+                    sim_name: "sim-dup".into(),
+                    source: "test".into(),
+                    session_started_ms: 0,
+                    world_width: 1280.0,
+                    world_height: 720.0,
+                    ant_count: 1,
+                    food_count: 0,
+                }),
+            })
+            .expect("sim_hello");
+        state
+            .apply_event(EventEnvelope {
+                event_type: "food_drop".into(),
+                sim_id: "sim-dup".into(),
+                seq: 2,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodDrop(crate::protocol::FoodDropPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-1".into(),
+                    x: 10.0,
+                    y: 20.0,
+                    direction_x: Some(0.0),
+                    direction_y: Some(1.0),
+                    frame: Some(1),
+                }),
+            })
+            .expect("first food_drop");
+        state
+            .apply_event(EventEnvelope {
+                event_type: "food_drop".into(),
+                sim_id: "sim-dup".into(),
+                seq: 3,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodDrop(crate::protocol::FoodDropPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-1".into(),
+                    x: 30.0,
+                    y: 40.0,
+                    direction_x: Some(0.0),
+                    direction_y: Some(1.0),
+                    frame: Some(2),
+                }),
+            })
+            .expect("duplicate food_drop");
+
+        let snapshot = current_snapshot_json(&state);
+        assert_eq!(
+            snapshot["summary"]["live_summary"]["loose_food_count"], 1,
+            "duplicate food_drop with same food_id should not inflate live loose_food_count"
+        );
+        assert_eq!(
+            snapshot["sims"][0]["loose_food_count"], 1,
+            "per-sim loose_food_count should match store truth after duplicate food_drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn pickup_of_missing_food_does_not_deflate_live_loose_food_count() {
+        let state = AppState::new();
+        state
+            .apply_event(EventEnvelope {
+                event_type: "sim_hello".into(),
+                sim_id: "sim-miss".into(),
+                seq: 1,
+                timestamp_ms: 0,
+                payload: EventPayload::SimHello(HelloPayload {
+                    sim_name: "sim-miss".into(),
+                    source: "test".into(),
+                    session_started_ms: 0,
+                    world_width: 1280.0,
+                    world_height: 720.0,
+                    ant_count: 1,
+                    food_count: 0,
+                }),
+            })
+            .expect("sim_hello");
+        state
+            .apply_event(EventEnvelope {
+                event_type: "food_drop".into(),
+                sim_id: "sim-miss".into(),
+                seq: 2,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodDrop(crate::protocol::FoodDropPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-1".into(),
+                    x: 10.0,
+                    y: 20.0,
+                    direction_x: Some(0.0),
+                    direction_y: Some(1.0),
+                    frame: Some(1),
+                }),
+            })
+            .expect("food_drop");
+        state
+            .apply_event(EventEnvelope {
+                event_type: "food_pickup".into(),
+                sim_id: "sim-miss".into(),
+                seq: 3,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodPickup(crate::protocol::FoodPickupPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-nonexistent".into(),
+                    x: Some(50.0),
+                    y: Some(50.0),
+                    direction_x: Some(1.0),
+                    direction_y: Some(0.0),
+                    frame: Some(2),
+                }),
+            })
+            .expect("pickup of missing food");
+
+        let snapshot = current_snapshot_json(&state);
+        assert_eq!(
+            snapshot["summary"]["live_summary"]["loose_food_count"], 1,
+            "pickup of non-existent food should not deflate live loose_food_count"
+        );
+        assert_eq!(
+            snapshot["sims"][0]["loose_food_count"], 1,
+            "per-sim loose_food_count should match store truth after pickup of missing food"
+        );
     }
 }

--- a/backend-rust/src/app.rs
+++ b/backend-rust/src/app.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{
+    Arc, RwLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 use axum::{
     Json, Router,
@@ -11,7 +14,7 @@ use axum::{
 };
 use futures_util::StreamExt;
 use tokio::net::TcpListener;
-use tokio::sync::broadcast;
+use tokio::sync::{Mutex, broadcast};
 
 use crate::{
     dashboard::render_dashboard,
@@ -29,15 +32,11 @@ pub struct AppState {
 struct AppStateInner {
     store: RwLock<Store>,
     snapshot: RwLock<CachedSnapshot>,
-    refresh: Mutex<RefreshState>,
+    refresh: Mutex<()>,
+    dirty: AtomicBool,
+    demand_seen: AtomicBool,
+    refresh_in_flight: AtomicBool,
     dashboard_tx: broadcast::Sender<CachedSnapshot>,
-}
-
-#[derive(Default)]
-struct RefreshState {
-    dirty: bool,
-    demand_seen: bool,
-    refresh_in_flight: bool,
 }
 
 impl AppState {
@@ -47,7 +46,10 @@ impl AppState {
             inner: Arc::new(AppStateInner {
                 store: RwLock::new(Store::default()),
                 snapshot: RwLock::new(CachedSnapshot::default()),
-                refresh: Mutex::new(RefreshState::default()),
+                refresh: Mutex::new(()),
+                dirty: AtomicBool::new(false),
+                demand_seen: AtomicBool::new(false),
+                refresh_in_flight: AtomicBool::new(false),
                 dashboard_tx,
             }),
         }
@@ -60,19 +62,8 @@ impl AppState {
             .expect("store lock poisoned")
             .apply_event(&envelope)?;
 
-        let should_spawn = {
-            let mut refresh = self.inner.refresh.lock().expect("refresh lock poisoned");
-            refresh.dirty = true;
-            if refresh.demand_seen && !refresh.refresh_in_flight {
-                refresh.refresh_in_flight = true;
-                true
-            } else {
-                false
-            }
-        };
-        if should_spawn {
-            self.spawn_refresh();
-        }
+        self.inner.dirty.store(true, Ordering::SeqCst);
+        self.try_spawn_refresh();
         Ok(())
     }
 
@@ -84,32 +75,22 @@ impl AppState {
             .clone()
     }
 
-    fn register_api_demand(&self) {
-        let should_spawn = {
-            let mut refresh = self.inner.refresh.lock().expect("refresh lock poisoned");
-            refresh.demand_seen = true;
-            if refresh.dirty && !refresh.refresh_in_flight {
-                refresh.refresh_in_flight = true;
-                true
-            } else {
-                false
-            }
-        };
-
-        if should_spawn {
-            self.spawn_refresh();
-        }
+    async fn register_api_demand(&self) {
+        let _refresh_gate = self.inner.refresh.lock().await;
+        self.inner.demand_seen.store(true, Ordering::SeqCst);
+        self.try_spawn_refresh();
     }
 
-    fn add_dashboard_watcher(&self) -> broadcast::Receiver<CachedSnapshot> {
+    async fn add_dashboard_watcher(&self) -> broadcast::Receiver<CachedSnapshot> {
         let receiver = self.inner.dashboard_tx.subscribe();
-        self.register_api_demand();
+        self.register_api_demand().await;
         receiver
     }
 
     fn spawn_refresh(&self) {
         let state = self.clone();
         tokio::spawn(async move {
+            state.inner.dirty.store(false, Ordering::SeqCst);
             let snapshot_data = {
                 state
                     .inner
@@ -128,10 +109,27 @@ impl AppState {
                 *snapshot_guard = snapshot.clone();
             }
             let _ = state.inner.dashboard_tx.send(snapshot);
-            let mut refresh = state.inner.refresh.lock().expect("refresh lock poisoned");
-            refresh.dirty = false;
-            refresh.refresh_in_flight = false;
+            state
+                .inner
+                .refresh_in_flight
+                .store(false, Ordering::SeqCst);
+            state.try_spawn_refresh();
         });
+    }
+
+    fn try_spawn_refresh(&self) {
+        if !self.inner.dirty.load(Ordering::SeqCst) || !self.inner.demand_seen.load(Ordering::SeqCst)
+        {
+            return;
+        }
+        if self
+            .inner
+            .refresh_in_flight
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            self.spawn_refresh();
+        }
     }
 }
 
@@ -161,13 +159,13 @@ async fn healthz() -> impl IntoResponse {
 
 async fn summary(State(state): State<AppState>) -> Json<SummaryResponse> {
     let snapshot = state.current_snapshot();
-    state.register_api_demand();
+    state.register_api_demand().await;
     Json(snapshot.summary)
 }
 
 async fn sims(State(state): State<AppState>) -> Json<Vec<SimSummaryResponse>> {
     let snapshot = state.current_snapshot();
-    state.register_api_demand();
+    state.register_api_demand().await;
     Json(snapshot.sims)
 }
 
@@ -194,7 +192,7 @@ async fn handle_ingest_socket(state: AppState, mut socket: WebSocket) {
         let Ok(event) = serde_json::from_str::<EventEnvelope>(&text) else {
             continue;
         };
-        if handle_ingest_event(&state, event).is_err() {
+        if handle_ingest_event(&state, event).await.is_err() {
             return;
         }
     }
@@ -214,7 +212,7 @@ async fn handle_dashboard_socket(state: AppState, mut socket: WebSocket) {
         return;
     }
 
-    let mut receiver = state.add_dashboard_watcher();
+    let mut receiver = state.add_dashboard_watcher().await;
     while let Ok(snapshot) = receiver.recv().await {
         if socket
             .send(Message::Text(
@@ -280,7 +278,7 @@ mod tests {
             })
             .expect("sim_food_snapshot should be accepted");
 
-        state.register_api_demand();
+        state.register_api_demand().await;
 
         let blocked_for = tokio::task::spawn_blocking({
             let state = state.clone();
@@ -315,6 +313,36 @@ mod tests {
             blocked_for < Duration::from_millis(25),
             "expected refresh to release the store lock quickly, but writes were blocked for {:?}",
             blocked_for
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn refresh_coordination_contention_does_not_block_runtime_progress() {
+        let state = AppState::new();
+        let refresh_guard = state.inner.refresh.lock().await;
+
+        let contender = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state.register_api_demand().await;
+            })
+        };
+
+        tokio::task::yield_now().await;
+
+        let ticked = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        });
+
+        let runtime_made_progress = tokio::time::timeout(Duration::from_millis(60), ticked)
+            .await
+            .is_ok();
+        drop(refresh_guard);
+        contender.await.expect("contender task should join");
+
+        assert!(
+            runtime_made_progress,
+            "refresh coordination contention should not block unrelated async progress"
         );
     }
 }

--- a/backend-rust/src/app.rs
+++ b/backend-rust/src/app.rs
@@ -1,0 +1,228 @@
+use std::sync::{Arc, Mutex, RwLock};
+
+use axum::{
+    Json, Router,
+    extract::{
+        State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
+    response::{Html, IntoResponse},
+    routing::get,
+};
+use futures_util::StreamExt;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+
+use crate::{
+    dashboard::render_dashboard,
+    ingest::handle_ingest_event,
+    protocol::EventEnvelope,
+    store::Store,
+    summary::{CachedSnapshot, SimSummaryResponse, SummaryResponse},
+};
+
+#[derive(Clone)]
+pub struct AppState {
+    inner: Arc<AppStateInner>,
+}
+
+struct AppStateInner {
+    store: RwLock<Store>,
+    snapshot: RwLock<CachedSnapshot>,
+    refresh: Mutex<RefreshState>,
+    dashboard_tx: broadcast::Sender<CachedSnapshot>,
+}
+
+#[derive(Default)]
+struct RefreshState {
+    dirty: bool,
+    demand_seen: bool,
+    refresh_in_flight: bool,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        let (dashboard_tx, _) = broadcast::channel(32);
+        Self {
+            inner: Arc::new(AppStateInner {
+                store: RwLock::new(Store::default()),
+                snapshot: RwLock::new(CachedSnapshot::default()),
+                refresh: Mutex::new(RefreshState::default()),
+                dashboard_tx,
+            }),
+        }
+    }
+
+    pub fn apply_event(&self, envelope: EventEnvelope) -> Result<(), String> {
+        self.inner
+            .store
+            .write()
+            .expect("store lock poisoned")
+            .apply_event(&envelope)?;
+
+        let should_spawn = {
+            let mut refresh = self.inner.refresh.lock().expect("refresh lock poisoned");
+            refresh.dirty = true;
+            if refresh.demand_seen && !refresh.refresh_in_flight {
+                refresh.refresh_in_flight = true;
+                true
+            } else {
+                false
+            }
+        };
+        if should_spawn {
+            self.spawn_refresh();
+        }
+        Ok(())
+    }
+
+    fn current_snapshot(&self) -> CachedSnapshot {
+        self.inner
+            .snapshot
+            .read()
+            .expect("snapshot lock poisoned")
+            .clone()
+    }
+
+    fn register_api_demand(&self) {
+        let should_spawn = {
+            let mut refresh = self.inner.refresh.lock().expect("refresh lock poisoned");
+            refresh.demand_seen = true;
+            if refresh.dirty && !refresh.refresh_in_flight {
+                refresh.refresh_in_flight = true;
+                true
+            } else {
+                false
+            }
+        };
+
+        if should_spawn {
+            self.spawn_refresh();
+        }
+    }
+
+    fn add_dashboard_watcher(&self) -> broadcast::Receiver<CachedSnapshot> {
+        let receiver = self.inner.dashboard_tx.subscribe();
+        self.register_api_demand();
+        receiver
+    }
+
+    fn spawn_refresh(&self) {
+        let state = self.clone();
+        tokio::spawn(async move {
+            let snapshot = state
+                .inner
+                .store
+                .read()
+                .expect("store lock poisoned")
+                .snapshot();
+            {
+                let mut snapshot_guard = state
+                    .inner
+                    .snapshot
+                    .write()
+                    .expect("snapshot lock poisoned");
+                *snapshot_guard = snapshot.clone();
+            }
+            let _ = state.inner.dashboard_tx.send(snapshot);
+            let mut refresh = state.inner.refresh.lock().expect("refresh lock poisoned");
+            refresh.dirty = false;
+            refresh.refresh_in_flight = false;
+        });
+    }
+}
+
+pub fn build_router() -> Router {
+    build_router_with_state(AppState::new())
+}
+
+pub async fn serve(addr: &str) -> std::io::Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, build_router()).await
+}
+
+pub fn build_router_with_state(state: AppState) -> Router {
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/api/summary", get(summary))
+        .route("/api/sims", get(sims))
+        .route("/ws/ingest", get(ingest_ws))
+        .route("/ws/dashboard", get(dashboard_ws))
+        .route("/", get(dashboard))
+        .with_state(state)
+}
+
+async fn healthz() -> impl IntoResponse {
+    "ok"
+}
+
+async fn summary(State(state): State<AppState>) -> Json<SummaryResponse> {
+    let snapshot = state.current_snapshot();
+    state.register_api_demand();
+    Json(snapshot.summary)
+}
+
+async fn sims(State(state): State<AppState>) -> Json<Vec<SimSummaryResponse>> {
+    let snapshot = state.current_snapshot();
+    state.register_api_demand();
+    Json(snapshot.sims)
+}
+
+async fn dashboard(State(state): State<AppState>) -> Html<String> {
+    Html(render_dashboard(&state.current_snapshot()))
+}
+
+async fn ingest_ws(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_ingest_socket(state, socket))
+}
+
+async fn dashboard_ws(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_dashboard_socket(state, socket))
+}
+
+async fn handle_ingest_socket(state: AppState, mut socket: WebSocket) {
+    while let Some(message_result) = socket.next().await {
+        let Ok(message) = message_result else {
+            return;
+        };
+        let Message::Text(text) = message else {
+            continue;
+        };
+        let Ok(event) = serde_json::from_str::<EventEnvelope>(&text) else {
+            continue;
+        };
+        if handle_ingest_event(&state, event).is_err() {
+            return;
+        }
+    }
+}
+
+async fn handle_dashboard_socket(state: AppState, mut socket: WebSocket) {
+    let initial = state.current_snapshot();
+    if socket
+        .send(Message::Text(
+            serde_json::to_string(&initial)
+                .expect("dashboard snapshot json")
+                .into(),
+        ))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let mut receiver = state.add_dashboard_watcher();
+    while let Ok(snapshot) = receiver.recv().await {
+        if socket
+            .send(Message::Text(
+                serde_json::to_string(&snapshot)
+                    .expect("dashboard snapshot json")
+                    .into(),
+            ))
+            .await
+            .is_err()
+        {
+            return;
+        }
+    }
+}

--- a/backend-rust/src/app.rs
+++ b/backend-rust/src/app.rs
@@ -1,8 +1,8 @@
 use std::sync::{
-    Arc, RwLock,
+    Arc, Once, RwLock,
     atomic::{AtomicBool, Ordering},
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use axum::{
     Json, Router,
@@ -15,7 +15,7 @@ use axum::{
 };
 use futures_util::StreamExt;
 use tokio::net::TcpListener;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, Notify, broadcast};
 
 use crate::{
     dashboard::render_dashboard,
@@ -33,28 +33,63 @@ pub struct AppState {
 struct AppStateInner {
     store: Store,
     snapshot: RwLock<CachedSnapshot>,
-    refresh: Mutex<()>,
+    refresh: Mutex<RefreshState>,
     dirty: AtomicBool,
-    demand_seen: AtomicBool,
-    refresh_in_flight: AtomicBool,
     last_snapshot_copy_micros: std::sync::atomic::AtomicU64,
     last_snapshot_compute_micros: std::sync::atomic::AtomicU64,
+    refresh_signal: Notify,
+    worker_once: Once,
+    tuning: RefreshTuning,
     dashboard_tx: broadcast::Sender<CachedSnapshot>,
+}
+
+struct RefreshState {
+    dashboard_watchers: usize,
+    last_api_demand_at: Option<Instant>,
+    next_eligible_at: Option<Instant>,
+}
+
+#[derive(Clone, Copy)]
+struct RefreshTuning {
+    min_refresh_interval: Duration,
+    max_refresh_interval: Duration,
+    refresh_multiplier: u32,
+    api_demand_ttl: Duration,
+}
+
+impl Default for RefreshTuning {
+    fn default() -> Self {
+        Self {
+            min_refresh_interval: Duration::from_millis(250),
+            max_refresh_interval: Duration::from_secs(5),
+            refresh_multiplier: 3,
+            api_demand_ttl: Duration::from_secs(10),
+        }
+    }
 }
 
 impl AppState {
     pub fn new() -> Self {
+        Self::new_with_tuning(RefreshTuning::default())
+    }
+
+    fn new_with_tuning(tuning: RefreshTuning) -> Self {
         let (dashboard_tx, _) = broadcast::channel(32);
         Self {
             inner: Arc::new(AppStateInner {
                 store: Store::default(),
                 snapshot: RwLock::new(CachedSnapshot::default()),
-                refresh: Mutex::new(()),
+                refresh: Mutex::new(RefreshState {
+                    dashboard_watchers: 0,
+                    last_api_demand_at: None,
+                    next_eligible_at: None,
+                }),
                 dirty: AtomicBool::new(false),
-                demand_seen: AtomicBool::new(false),
-                refresh_in_flight: AtomicBool::new(false),
                 last_snapshot_copy_micros: std::sync::atomic::AtomicU64::new(0),
                 last_snapshot_compute_micros: std::sync::atomic::AtomicU64::new(0),
+                refresh_signal: Notify::new(),
+                worker_once: Once::new(),
+                tuning,
                 dashboard_tx,
             }),
         }
@@ -66,7 +101,8 @@ impl AppState {
             .apply_event(&envelope)?;
 
         self.inner.dirty.store(true, Ordering::SeqCst);
-        self.try_spawn_refresh();
+        self.ensure_worker();
+        self.signal_refresh();
         Ok(())
     }
 
@@ -79,70 +115,129 @@ impl AppState {
     }
 
     async fn register_api_demand(&self) {
-        let _refresh_gate = self.inner.refresh.lock().await;
-        self.inner.demand_seen.store(true, Ordering::SeqCst);
-        self.try_spawn_refresh();
+        let mut refresh = self.inner.refresh.lock().await;
+        refresh.last_api_demand_at = Some(Instant::now());
+        drop(refresh);
+        self.ensure_worker();
+        self.signal_refresh();
     }
 
     async fn add_dashboard_watcher(&self) -> broadcast::Receiver<CachedSnapshot> {
         let receiver = self.inner.dashboard_tx.subscribe();
-        self.register_api_demand().await;
+        let mut refresh = self.inner.refresh.lock().await;
+        refresh.dashboard_watchers += 1;
+        drop(refresh);
+        self.ensure_worker();
+        self.signal_refresh();
         receiver
+    }
+
+    async fn remove_dashboard_watcher(&self) {
+        let mut refresh = self.inner.refresh.lock().await;
+        refresh.dashboard_watchers = refresh.dashboard_watchers.saturating_sub(1);
     }
 
     fn spawn_refresh(&self) {
         let state = self.clone();
         tokio::spawn(async move {
-            state.inner.dirty.store(false, Ordering::SeqCst);
-            let copy_started = Instant::now();
-            let snapshot_data = {
-                state
-                    .inner
-                    .store
-                    .snapshot_data()
-            };
-            state
-                .inner
-                .last_snapshot_copy_micros
-                .store(copy_started.elapsed().as_micros() as u64, Ordering::SeqCst);
-            let compute_started = Instant::now();
-            let snapshot = tokio::task::spawn_blocking(move || snapshot_data.into_cached_snapshot())
-                .await
-                .expect("snapshot compute task should join");
-            state
-                .inner
-                .last_snapshot_compute_micros
-                .store(compute_started.elapsed().as_micros() as u64, Ordering::SeqCst);
-            {
-                let mut snapshot_guard = state
-                    .inner
-                    .snapshot
-                    .write()
-                    .expect("snapshot lock poisoned");
-                *snapshot_guard = snapshot.clone();
-            }
-            let _ = state.inner.dashboard_tx.send(snapshot);
-            state
-                .inner
-                .refresh_in_flight
-                .store(false, Ordering::SeqCst);
-            state.try_spawn_refresh();
+            state.run_refresh_worker().await;
         });
     }
 
-    fn try_spawn_refresh(&self) {
-        if !self.inner.dirty.load(Ordering::SeqCst) || !self.inner.demand_seen.load(Ordering::SeqCst)
-        {
-            return;
+    fn ensure_worker(&self) {
+        let state = self.clone();
+        self.inner.worker_once.call_once(move || {
+            state.spawn_refresh();
+        });
+    }
+
+    fn signal_refresh(&self) {
+        self.inner.refresh_signal.notify_one();
+    }
+
+    async fn run_refresh_worker(self) {
+        loop {
+            self.inner.refresh_signal.notified().await;
+            loop {
+                let now = Instant::now();
+                let plan = self.next_refresh_plan(now).await;
+                let Some(delay) = plan else {
+                    break;
+                };
+
+                if !delay.is_zero() {
+                    tokio::select! {
+                        _ = tokio::time::sleep(delay) => {}
+                        _ = self.inner.refresh_signal.notified() => {
+                            continue;
+                        }
+                    }
+                }
+
+                if !self.inner.dirty.swap(false, Ordering::SeqCst) {
+                    continue;
+                }
+
+                let copy_started = Instant::now();
+                let snapshot_data = self.inner.store.snapshot_data();
+                self.inner
+                    .last_snapshot_copy_micros
+                    .store(copy_started.elapsed().as_micros() as u64, Ordering::SeqCst);
+                let compute_started = Instant::now();
+                let snapshot = tokio::task::spawn_blocking(move || snapshot_data.into_cached_snapshot())
+                    .await
+                    .expect("snapshot compute task should join");
+                let compute_duration = compute_started.elapsed();
+                self.inner
+                    .last_snapshot_compute_micros
+                    .store(compute_duration.as_micros() as u64, Ordering::SeqCst);
+                {
+                    let mut snapshot_guard = self
+                        .inner
+                        .snapshot
+                        .write()
+                        .expect("snapshot lock poisoned");
+                    *snapshot_guard = snapshot.clone();
+                }
+                let _ = self.inner.dashboard_tx.send(snapshot);
+                let mut refresh = self.inner.refresh.lock().await;
+                refresh.next_eligible_at =
+                    Some(Instant::now() + self.adaptive_refresh_interval(compute_duration));
+            }
         }
-        if self
-            .inner
-            .refresh_in_flight
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
-        {
-            self.spawn_refresh();
+    }
+
+    async fn next_refresh_plan(&self, now: Instant) -> Option<Duration> {
+        let refresh = self.inner.refresh.lock().await;
+        if !self.has_demand_locked(&refresh, now) || !self.inner.dirty.load(Ordering::SeqCst) {
+            return None;
         }
+        match refresh.next_eligible_at {
+            Some(next) if next > now => Some(next.duration_since(now)),
+            _ => Some(Duration::ZERO),
+        }
+    }
+
+    fn has_demand_locked(&self, refresh: &RefreshState, now: Instant) -> bool {
+        if refresh.dashboard_watchers > 0 {
+            return true;
+        }
+        refresh
+            .last_api_demand_at
+            .map(|at| now.duration_since(at) <= self.inner.tuning.api_demand_ttl)
+            .unwrap_or(false)
+    }
+
+    fn adaptive_refresh_interval(&self, compute_duration: Duration) -> Duration {
+        let mut interval =
+            compute_duration.saturating_mul(self.inner.tuning.refresh_multiplier);
+        if interval < self.inner.tuning.min_refresh_interval {
+            interval = self.inner.tuning.min_refresh_interval;
+        }
+        if interval > self.inner.tuning.max_refresh_interval {
+            interval = self.inner.tuning.max_refresh_interval;
+        }
+        interval
     }
 }
 
@@ -236,9 +331,10 @@ async fn handle_dashboard_socket(state: AppState, mut socket: WebSocket) {
             .await
             .is_err()
         {
-            return;
+            break;
         }
     }
+    state.remove_dashboard_watcher().await;
 }
 
 #[cfg(test)]
@@ -248,7 +344,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use super::AppState;
+    use super::{AppState, RefreshTuning};
     use crate::protocol::{
         EventEnvelope, EventPayload, FoodSnapshotPayload, HelloPayload, StartupFoodPayload,
     };
@@ -361,8 +457,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn unrelated_sim_writes_do_not_block_on_global_store_contention() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unrelated_sim_writes_do_not_block_on_global_store_contention() {
         let state = AppState::new();
         state
             .apply_event(EventEnvelope {
@@ -513,5 +609,166 @@ mod tests {
             runtime_made_progress,
             "heavy refresh compute should not starve unrelated runtime progress"
         );
+    }
+
+    #[tokio::test]
+    async fn api_demand_expires_before_later_dirty_events_refresh_snapshot() {
+        let state = AppState::new_with_tuning(RefreshTuning {
+            min_refresh_interval: Duration::ZERO,
+            max_refresh_interval: Duration::ZERO,
+            refresh_multiplier: 1,
+            api_demand_ttl: Duration::from_millis(30),
+        });
+
+        state
+            .apply_event(EventEnvelope {
+                event_type: "sim_hello".into(),
+                sim_id: "sim-demand-expiry".into(),
+                seq: 1,
+                timestamp_ms: 0,
+                payload: EventPayload::SimHello(HelloPayload {
+                    sim_name: "sim-demand-expiry".into(),
+                    source: "test".into(),
+                    session_started_ms: 0,
+                    world_width: 1280.0,
+                    world_height: 720.0,
+                    ant_count: 26,
+                    food_count: 1,
+                }),
+            })
+            .expect("sim hello should be accepted");
+        state
+            .apply_event(EventEnvelope {
+                event_type: "food_drop".into(),
+                sim_id: "sim-demand-expiry".into(),
+                seq: 2,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodDrop(crate::protocol::FoodDropPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-1".into(),
+                    x: 1.0,
+                    y: 1.0,
+                    direction_x: Some(0.0),
+                    direction_y: Some(1.0),
+                    frame: Some(2),
+                }),
+            })
+            .expect("food drop should be accepted");
+
+        state.register_api_demand().await;
+        wait_for_loose_food_count(&state, 1).await;
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        state
+            .apply_event(EventEnvelope {
+                event_type: "food_drop".into(),
+                sim_id: "sim-demand-expiry".into(),
+                seq: 3,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodDrop(crate::protocol::FoodDropPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-2".into(),
+                    x: 2.0,
+                    y: 2.0,
+                    direction_x: Some(0.0),
+                    direction_y: Some(1.0),
+                    frame: Some(3),
+                }),
+            })
+            .expect("second food drop should be accepted");
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(state.current_snapshot().summary.loose_food_count, 1);
+
+        state.register_api_demand().await;
+        wait_for_loose_food_count(&state, 2).await;
+    }
+
+    #[tokio::test]
+    async fn active_demand_refreshes_are_cadence_limited() {
+        let state = AppState::new_with_tuning(RefreshTuning {
+            min_refresh_interval: Duration::from_millis(60),
+            max_refresh_interval: Duration::from_millis(60),
+            refresh_multiplier: 1,
+            api_demand_ttl: Duration::from_secs(1),
+        });
+
+        state
+            .apply_event(EventEnvelope {
+                event_type: "sim_hello".into(),
+                sim_id: "sim-cadence".into(),
+                seq: 1,
+                timestamp_ms: 0,
+                payload: EventPayload::SimHello(HelloPayload {
+                    sim_name: "sim-cadence".into(),
+                    source: "test".into(),
+                    session_started_ms: 0,
+                    world_width: 1280.0,
+                    world_height: 720.0,
+                    ant_count: 26,
+                    food_count: 1,
+                }),
+            })
+            .expect("sim hello should be accepted");
+        state
+            .apply_event(EventEnvelope {
+                event_type: "food_drop".into(),
+                sim_id: "sim-cadence".into(),
+                seq: 2,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodDrop(crate::protocol::FoodDropPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-1".into(),
+                    x: 1.0,
+                    y: 1.0,
+                    direction_x: Some(0.0),
+                    direction_y: Some(1.0),
+                    frame: Some(2),
+                }),
+            })
+            .expect("initial food drop should be accepted");
+
+        state.register_api_demand().await;
+        wait_for_loose_food_count(&state, 1).await;
+
+        state
+            .apply_event(EventEnvelope {
+                event_type: "food_drop".into(),
+                sim_id: "sim-cadence".into(),
+                seq: 3,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodDrop(crate::protocol::FoodDropPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-2".into(),
+                    x: 2.0,
+                    y: 2.0,
+                    direction_x: Some(0.0),
+                    direction_y: Some(1.0),
+                    frame: Some(3),
+                }),
+            })
+            .expect("second food drop should be accepted");
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(state.current_snapshot().summary.loose_food_count, 1);
+
+        wait_for_loose_food_count(&state, 2).await;
+    }
+
+    async fn wait_for_loose_food_count(state: &AppState, expected: usize) {
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(250);
+        loop {
+            let snapshot = state.current_snapshot();
+            if snapshot.summary.loose_food_count == expected {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "expected loose_food_count={expected}, last snapshot was {:?}",
+                snapshot.summary
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 }

--- a/backend-rust/src/app.rs
+++ b/backend-rust/src/app.rs
@@ -2,6 +2,7 @@ use std::sync::{
     Arc, RwLock,
     atomic::{AtomicBool, Ordering},
 };
+use std::time::Instant;
 
 use axum::{
     Json, Router,
@@ -36,6 +37,8 @@ struct AppStateInner {
     dirty: AtomicBool,
     demand_seen: AtomicBool,
     refresh_in_flight: AtomicBool,
+    last_snapshot_copy_micros: std::sync::atomic::AtomicU64,
+    last_snapshot_compute_micros: std::sync::atomic::AtomicU64,
     dashboard_tx: broadcast::Sender<CachedSnapshot>,
 }
 
@@ -50,6 +53,8 @@ impl AppState {
                 dirty: AtomicBool::new(false),
                 demand_seen: AtomicBool::new(false),
                 refresh_in_flight: AtomicBool::new(false),
+                last_snapshot_copy_micros: std::sync::atomic::AtomicU64::new(0),
+                last_snapshot_compute_micros: std::sync::atomic::AtomicU64::new(0),
                 dashboard_tx,
             }),
         }
@@ -89,13 +94,25 @@ impl AppState {
         let state = self.clone();
         tokio::spawn(async move {
             state.inner.dirty.store(false, Ordering::SeqCst);
+            let copy_started = Instant::now();
             let snapshot_data = {
                 state
                     .inner
                     .store
                     .snapshot_data()
             };
-            let snapshot = snapshot_data.into_cached_snapshot();
+            state
+                .inner
+                .last_snapshot_copy_micros
+                .store(copy_started.elapsed().as_micros() as u64, Ordering::SeqCst);
+            let compute_started = Instant::now();
+            let snapshot = tokio::task::spawn_blocking(move || snapshot_data.into_cached_snapshot())
+                .await
+                .expect("snapshot compute task should join");
+            state
+                .inner
+                .last_snapshot_compute_micros
+                .store(compute_started.elapsed().as_micros() as u64, Ordering::SeqCst);
             {
                 let mut snapshot_guard = state
                     .inner
@@ -425,6 +442,76 @@ mod tests {
         assert!(
             write_completed,
             "writing one sim should not block behind unrelated store contention"
+        );
+    }
+
+    #[test]
+    fn heavy_refresh_compute_does_not_starve_runtime_progress() {
+        let (tick_tx, tick_rx) = std::sync::mpsc::channel();
+
+        let runtime_thread = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_time()
+                .build()
+                .expect("test runtime should build");
+            runtime.block_on(async move {
+                let state = AppState::new();
+                state
+                    .apply_event(EventEnvelope {
+                        event_type: "sim_hello".into(),
+                        sim_id: "sim-cpu".into(),
+                        seq: 1,
+                        timestamp_ms: 0,
+                        payload: EventPayload::SimHello(HelloPayload {
+                            sim_name: "sim-cpu".into(),
+                            source: "test".into(),
+                            session_started_ms: 0,
+                            world_width: 1280.0,
+                            world_height: 720.0,
+                            ant_count: 26,
+                            food_count: 5000,
+                        }),
+                    })
+                    .expect("sim hello should be accepted");
+                state
+                    .apply_event(EventEnvelope {
+                        event_type: "sim_food_snapshot".into(),
+                        sim_id: "sim-cpu".into(),
+                        seq: 2,
+                        timestamp_ms: 0,
+                        payload: EventPayload::SimFoodSnapshot(FoodSnapshotPayload {
+                            foods: (0..5000)
+                                .map(|index| StartupFoodPayload {
+                                    food_id: format!("food-{index:04}"),
+                                    x: ((index * 17) % 4000) as f32,
+                                    y: ((index * 19) % 4000) as f32,
+                                })
+                                .collect(),
+                        }),
+                    })
+                    .expect("sim food snapshot should be accepted");
+
+                state.register_api_demand().await;
+                tokio::task::yield_now().await;
+
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    let _ = tick_tx.send(());
+                });
+
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            });
+        });
+
+        let runtime_made_progress = tick_rx.recv_timeout(Duration::from_millis(60)).is_ok();
+        runtime_thread
+            .join()
+            .expect("runtime thread should join after heavy refresh test");
+
+        assert!(
+            runtime_made_progress,
+            "heavy refresh compute should not starve unrelated runtime progress"
         );
     }
 }

--- a/backend-rust/src/app.rs
+++ b/backend-rust/src/app.rs
@@ -30,7 +30,7 @@ pub struct AppState {
 }
 
 struct AppStateInner {
-    store: RwLock<Store>,
+    store: Store,
     snapshot: RwLock<CachedSnapshot>,
     refresh: Mutex<()>,
     dirty: AtomicBool,
@@ -44,7 +44,7 @@ impl AppState {
         let (dashboard_tx, _) = broadcast::channel(32);
         Self {
             inner: Arc::new(AppStateInner {
-                store: RwLock::new(Store::default()),
+                store: Store::default(),
                 snapshot: RwLock::new(CachedSnapshot::default()),
                 refresh: Mutex::new(()),
                 dirty: AtomicBool::new(false),
@@ -58,8 +58,6 @@ impl AppState {
     pub fn apply_event(&self, envelope: EventEnvelope) -> Result<(), String> {
         self.inner
             .store
-            .write()
-            .expect("store lock poisoned")
             .apply_event(&envelope)?;
 
         self.inner.dirty.store(true, Ordering::SeqCst);
@@ -95,8 +93,6 @@ impl AppState {
                 state
                     .inner
                     .store
-                    .read()
-                    .expect("store lock poisoned")
                     .snapshot_data()
             };
             let snapshot = snapshot_data.into_cached_snapshot();
@@ -231,7 +227,7 @@ async fn handle_dashboard_socket(state: AppState, mut socket: WebSocket) {
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::TryLockError,
+        sync::{Arc, atomic::Ordering},
         time::{Duration, Instant},
     };
 
@@ -286,17 +282,19 @@ mod tests {
                 let deadline = Instant::now() + Duration::from_secs(5);
                 let mut blocked_since: Option<Instant> = None;
                 loop {
-                    match state.inner.store.try_write() {
-                        Ok(guard) => {
+                    match state.inner.store.try_hold_shard_for_test("sim-lock") {
+                        Some(guard) => {
                             drop(guard);
                             if let Some(started_at) = blocked_since {
                                 return started_at.elapsed();
                             }
+                            if Instant::now() >= deadline {
+                                return Duration::ZERO;
+                            }
                         }
-                        Err(TryLockError::WouldBlock) => {
+                        None => {
                             blocked_since.get_or_insert_with(Instant::now);
                         }
-                        Err(TryLockError::Poisoned(_)) => panic!("store lock should not poison"),
                     }
                     assert!(
                         Instant::now() < deadline,
@@ -343,6 +341,90 @@ mod tests {
         assert!(
             runtime_made_progress,
             "refresh coordination contention should not block unrelated async progress"
+        );
+    }
+
+    #[test]
+    fn unrelated_sim_writes_do_not_block_on_global_store_contention() {
+        let state = AppState::new();
+        state
+            .apply_event(EventEnvelope {
+                event_type: "sim_hello".into(),
+                sim_id: "sim-a".into(),
+                seq: 1,
+                timestamp_ms: 0,
+                payload: EventPayload::SimHello(HelloPayload {
+                    sim_name: "sim-a".into(),
+                    source: "test".into(),
+                    session_started_ms: 0,
+                    world_width: 1280.0,
+                    world_height: 720.0,
+                    ant_count: 26,
+                    food_count: 1,
+                }),
+            })
+            .expect("sim-a hello should be accepted");
+        state
+            .apply_event(EventEnvelope {
+                event_type: "sim_hello".into(),
+                sim_id: "sim-b".into(),
+                seq: 1,
+                timestamp_ms: 0,
+                payload: EventPayload::SimHello(HelloPayload {
+                    sim_name: "sim-b".into(),
+                    source: "test".into(),
+                    session_started_ms: 0,
+                    world_width: 1280.0,
+                    world_height: 720.0,
+                    ant_count: 26,
+                    food_count: 1,
+                }),
+            })
+            .expect("sim-b hello should be accepted");
+
+        let blocked_sim = "sim-a".to_string();
+        let mut free_sim = "sim-b".to_string();
+        while state.inner.store.shard_index_for_test(&blocked_sim)
+            == state.inner.store.shard_index_for_test(&free_sim)
+        {
+            free_sim.push('x');
+        }
+
+        let store_guard = state.inner.store.hold_shard_for_test(&blocked_sim);
+        let progressed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let marker = progressed.clone();
+        let writer = std::thread::spawn({
+            let state = state.clone();
+            let free_sim = free_sim.clone();
+            move || {
+                state
+                    .apply_event(EventEnvelope {
+                        event_type: "ant_turn_move".into(),
+                        sim_id: free_sim,
+                        seq: 2,
+                        timestamp_ms: 0,
+                        payload: EventPayload::AntTurnMove(crate::protocol::TurnMovePayload {
+                            ant_id: "ant-1".into(),
+                            x: 1.0,
+                            y: 1.0,
+                            direction_x: 0.0,
+                            direction_y: 1.0,
+                            frame: 2,
+                        }),
+                    })
+                    .expect("sim-b move should be accepted");
+                marker.store(true, Ordering::SeqCst);
+            }
+        });
+
+        std::thread::sleep(Duration::from_millis(50));
+        let write_completed = progressed.load(Ordering::SeqCst);
+        drop(store_guard);
+        writer.join().expect("writer thread should join");
+
+        assert!(
+            write_completed,
+            "writing one sim should not block behind unrelated store contention"
         );
     }
 }

--- a/backend-rust/src/app.rs
+++ b/backend-rust/src/app.rs
@@ -110,12 +110,15 @@ impl AppState {
     fn spawn_refresh(&self) {
         let state = self.clone();
         tokio::spawn(async move {
-            let snapshot = state
-                .inner
-                .store
-                .read()
-                .expect("store lock poisoned")
-                .snapshot();
+            let snapshot_data = {
+                state
+                    .inner
+                    .store
+                    .read()
+                    .expect("store lock poisoned")
+                    .snapshot_data()
+            };
+            let snapshot = snapshot_data.into_cached_snapshot();
             {
                 let mut snapshot_guard = state
                     .inner
@@ -224,5 +227,94 @@ async fn handle_dashboard_socket(state: AppState, mut socket: WebSocket) {
         {
             return;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::TryLockError,
+        time::{Duration, Instant},
+    };
+
+    use super::AppState;
+    use crate::protocol::{
+        EventEnvelope, EventPayload, FoodSnapshotPayload, HelloPayload, StartupFoodPayload,
+    };
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn refresh_does_not_hold_store_lock_long_enough_to_starve_writes() {
+        let state = AppState::new();
+        state
+            .apply_event(EventEnvelope {
+                event_type: "sim_hello".into(),
+                sim_id: "sim-lock".into(),
+                seq: 1,
+                timestamp_ms: 0,
+                payload: EventPayload::SimHello(HelloPayload {
+                    sim_name: "sim-lock".into(),
+                    source: "test".into(),
+                    session_started_ms: 0,
+                    world_width: 1280.0,
+                    world_height: 720.0,
+                    ant_count: 26,
+                    food_count: 5000,
+                }),
+            })
+            .expect("sim_hello should be accepted");
+        state
+            .apply_event(EventEnvelope {
+                event_type: "sim_food_snapshot".into(),
+                sim_id: "sim-lock".into(),
+                seq: 2,
+                timestamp_ms: 0,
+                payload: EventPayload::SimFoodSnapshot(FoodSnapshotPayload {
+                    foods: (0..5000)
+                        .map(|index| StartupFoodPayload {
+                            food_id: format!("food-{index:04}"),
+                            x: ((index * 17) % 4000) as f32,
+                            y: ((index * 19) % 4000) as f32,
+                        })
+                        .collect(),
+                }),
+            })
+            .expect("sim_food_snapshot should be accepted");
+
+        state.register_api_demand();
+
+        let blocked_for = tokio::task::spawn_blocking({
+            let state = state.clone();
+            move || {
+                let deadline = Instant::now() + Duration::from_secs(5);
+                let mut blocked_since: Option<Instant> = None;
+                loop {
+                    match state.inner.store.try_write() {
+                        Ok(guard) => {
+                            drop(guard);
+                            if let Some(started_at) = blocked_since {
+                                return started_at.elapsed();
+                            }
+                        }
+                        Err(TryLockError::WouldBlock) => {
+                            blocked_since.get_or_insert_with(Instant::now);
+                        }
+                        Err(TryLockError::Poisoned(_)) => panic!("store lock should not poison"),
+                    }
+                    assert!(
+                        Instant::now() < deadline,
+                        "expected refresh to briefly block writes and then release the store lock"
+                    );
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+            }
+        })
+        .await
+        .expect("lock timing task should join");
+
+        assert!(
+            blocked_for < Duration::from_millis(25),
+            "expected refresh to release the store lock quickly, but writes were blocked for {:?}",
+            blocked_for
+        );
     }
 }

--- a/backend-rust/src/config.rs
+++ b/backend-rust/src/config.rs
@@ -1,0 +1,21 @@
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Config {
+    pub addr: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            addr: "127.0.0.1:8080".to_string(),
+        }
+    }
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        Self {
+            addr: std::env::var("GATHERERS_BACKEND_RUST_ADDR")
+                .unwrap_or_else(|_| Self::default().addr),
+        }
+    }
+}

--- a/backend-rust/src/dashboard.rs
+++ b/backend-rust/src/dashboard.rs
@@ -10,10 +10,13 @@ pub fn render_dashboard(snapshot: &CachedSnapshot) -> String {
   </head>
   <body>
     <h1>Connected sims</h1>
-    <div id="connected-sims-value">{}</div>
-    <div id="loose-food-value">{}</div>
-    <div id="elapsed-seconds-value">{:.2}</div>
-    <div id="events-per-second-value">{:.2}</div>
+    <div id="connected-sims-value">{connected_sims}</div>
+    <div id="loose-food-value">{loose_food}</div>
+    <div id="elapsed-seconds-value">{elapsed:.2}</div>
+    <div id="events-per-second-value">{eps:.2}</div>
+    <div id="occupied-cells-value">{occupied_cells}</div>
+    <div id="nearest-neighbor-value">{nearest_neighbor:.2}</div>
+    <div id="analytics-age-value">{analytics_age:.2}</div>
     <table>
       <thead>
         <tr><th>Sim</th><th>Ants</th></tr>
@@ -26,9 +29,12 @@ pub fn render_dashboard(snapshot: &CachedSnapshot) -> String {
     </script>
   </body>
 </html>"#,
-        snapshot.summary.connected_sim_count,
-        snapshot.summary.loose_food_count,
-        snapshot.summary.elapsed_seconds,
-        snapshot.summary.events_per_second,
+        connected_sims = snapshot.summary.live_summary.connected_sim_count,
+        loose_food = snapshot.summary.live_summary.loose_food_count,
+        elapsed = snapshot.summary.live_summary.elapsed_seconds,
+        eps = snapshot.summary.live_summary.events_per_second,
+        occupied_cells = snapshot.summary.analytics_summary.occupied_cell_count,
+        nearest_neighbor = snapshot.summary.analytics_summary.nearest_neighbor_mean_distance,
+        analytics_age = snapshot.summary.analytics_meta.age_seconds,
     )
 }

--- a/backend-rust/src/dashboard.rs
+++ b/backend-rust/src/dashboard.rs
@@ -1,0 +1,34 @@
+use crate::summary::CachedSnapshot;
+
+pub fn render_dashboard(snapshot: &CachedSnapshot) -> String {
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Gatherers Backend</title>
+  </head>
+  <body>
+    <h1>Connected sims</h1>
+    <div id="connected-sims-value">{}</div>
+    <div id="loose-food-value">{}</div>
+    <div id="elapsed-seconds-value">{:.2}</div>
+    <div id="events-per-second-value">{:.2}</div>
+    <table>
+      <thead>
+        <tr><th>Sim</th><th>Ants</th></tr>
+      </thead>
+      <tbody id="sim-table-body"></tbody>
+    </table>
+    <script>
+      window.GATHERERS_DASHBOARD_WS_URL = "/ws/dashboard";
+      const ignoredExample = "sim.ant_count";
+    </script>
+  </body>
+</html>"#,
+        snapshot.summary.connected_sim_count,
+        snapshot.summary.loose_food_count,
+        snapshot.summary.elapsed_seconds,
+        snapshot.summary.events_per_second,
+    )
+}

--- a/backend-rust/src/ingest.rs
+++ b/backend-rust/src/ingest.rs
@@ -1,5 +1,5 @@
 use crate::{app::AppState, protocol::EventEnvelope};
 
-pub fn handle_ingest_event(state: &AppState, envelope: EventEnvelope) -> Result<(), String> {
+pub async fn handle_ingest_event(state: &AppState, envelope: EventEnvelope) -> Result<(), String> {
     state.apply_event(envelope)
 }

--- a/backend-rust/src/ingest.rs
+++ b/backend-rust/src/ingest.rs
@@ -1,0 +1,5 @@
+use crate::{app::AppState, protocol::EventEnvelope};
+
+pub fn handle_ingest_event(state: &AppState, envelope: EventEnvelope) -> Result<(), String> {
+    state.apply_event(envelope)
+}

--- a/backend-rust/src/lib.rs
+++ b/backend-rust/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod config;
+pub mod protocol;
+

--- a/backend-rust/src/lib.rs
+++ b/backend-rust/src/lib.rs
@@ -1,3 +1,8 @@
+pub mod app;
 pub mod config;
+pub mod dashboard;
+pub mod ingest;
 pub mod protocol;
+pub mod store;
+pub mod summary;
 

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -1,7 +1,9 @@
-use gatherers_backend_rust::config::Config;
+use gatherers_backend_rust::{app, config::Config};
 
 #[tokio::main]
 async fn main() {
     let config = Config::from_env();
-    eprintln!("gatherers-backend-rust placeholder listening config: {}", config.addr);
+    app::serve(&config.addr)
+        .await
+        .expect("rust backend server should bind and run");
 }

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -1,0 +1,7 @@
+use gatherers_backend_rust::config::Config;
+
+#[tokio::main]
+async fn main() {
+    let config = Config::from_env();
+    eprintln!("gatherers-backend-rust placeholder listening config: {}", config.addr);
+}

--- a/backend-rust/src/protocol.rs
+++ b/backend-rust/src/protocol.rs
@@ -24,11 +24,17 @@ pub enum EventPayload {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct HelloPayload {
     pub sim_name: String,
+    #[serde(default)]
     pub source: String,
+    #[serde(default)]
     pub session_started_ms: u64,
+    #[serde(default)]
     pub world_width: f32,
+    #[serde(default)]
     pub world_height: f32,
+    #[serde(default)]
     pub ant_count: usize,
+    #[serde(default)]
     pub food_count: usize,
 }
 
@@ -53,24 +59,34 @@ pub struct HeartbeatPayload {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FoodPickupPayload {
-    pub ant_id: String,
+    #[serde(default)]
+    pub ant_id: Option<String>,
     pub food_id: String,
-    pub x: f32,
-    pub y: f32,
-    pub direction_x: f32,
-    pub direction_y: f32,
-    pub frame: u64,
+    #[serde(default)]
+    pub x: Option<f32>,
+    #[serde(default)]
+    pub y: Option<f32>,
+    #[serde(default)]
+    pub direction_x: Option<f32>,
+    #[serde(default)]
+    pub direction_y: Option<f32>,
+    #[serde(default)]
+    pub frame: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FoodDropPayload {
-    pub ant_id: String,
+    #[serde(default)]
+    pub ant_id: Option<String>,
     pub food_id: String,
     pub x: f32,
     pub y: f32,
-    pub direction_x: f32,
-    pub direction_y: f32,
-    pub frame: u64,
+    #[serde(default)]
+    pub direction_x: Option<f32>,
+    #[serde(default)]
+    pub direction_y: Option<f32>,
+    #[serde(default)]
+    pub frame: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/backend-rust/src/protocol.rs
+++ b/backend-rust/src/protocol.rs
@@ -1,0 +1,184 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as DeError};
+use serde_json::Value;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EventEnvelope {
+    pub event_type: String,
+    pub sim_id: String,
+    pub seq: u64,
+    pub timestamp_ms: u64,
+    pub payload: EventPayload,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum EventPayload {
+    SimHello(HelloPayload),
+    SimFoodSnapshot(FoodSnapshotPayload),
+    SimHeartbeat(HeartbeatPayload),
+    FoodPickup(FoodPickupPayload),
+    FoodDrop(FoodDropPayload),
+    AntTurnMove(TurnMovePayload),
+    SimGoodbye(GoodbyePayload),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HelloPayload {
+    pub sim_name: String,
+    pub source: String,
+    pub session_started_ms: u64,
+    pub world_width: f32,
+    pub world_height: f32,
+    pub ant_count: usize,
+    pub food_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FoodSnapshotPayload {
+    pub foods: Vec<StartupFoodPayload>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StartupFoodPayload {
+    pub food_id: String,
+    pub x: f32,
+    pub y: f32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HeartbeatPayload {
+    pub connected_ant_count: usize,
+    pub known_food_count: usize,
+    pub dropped_outbound_events: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FoodPickupPayload {
+    pub ant_id: String,
+    pub food_id: String,
+    pub x: f32,
+    pub y: f32,
+    pub direction_x: f32,
+    pub direction_y: f32,
+    pub frame: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FoodDropPayload {
+    pub ant_id: String,
+    pub food_id: String,
+    pub x: f32,
+    pub y: f32,
+    pub direction_x: f32,
+    pub direction_y: f32,
+    pub frame: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TurnMovePayload {
+    pub ant_id: String,
+    pub x: f32,
+    pub y: f32,
+    pub direction_x: f32,
+    pub direction_y: f32,
+    pub frame: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GoodbyePayload {
+    pub reason: String,
+}
+
+#[derive(Deserialize)]
+struct RawEnvelope {
+    #[serde(rename = "type")]
+    event_type: String,
+    sim_id: String,
+    seq: u64,
+    timestamp_ms: u64,
+    payload: Value,
+}
+
+#[derive(Serialize)]
+struct RawEnvelopeRef<'a> {
+    #[serde(rename = "type")]
+    event_type: &'a str,
+    sim_id: &'a str,
+    seq: u64,
+    timestamp_ms: u64,
+    payload: &'a Value,
+}
+
+impl<'de> Deserialize<'de> for EventEnvelope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawEnvelope::deserialize(deserializer)?;
+        let payload = match raw.event_type.as_str() {
+            "sim_hello" => EventPayload::SimHello(
+                serde_json::from_value(raw.payload).map_err(D::Error::custom)?,
+            ),
+            "sim_food_snapshot" => EventPayload::SimFoodSnapshot(
+                serde_json::from_value(raw.payload).map_err(D::Error::custom)?,
+            ),
+            "sim_heartbeat" => EventPayload::SimHeartbeat(
+                serde_json::from_value(raw.payload).map_err(D::Error::custom)?,
+            ),
+            "food_pickup" => EventPayload::FoodPickup(
+                serde_json::from_value(raw.payload).map_err(D::Error::custom)?,
+            ),
+            "food_drop" => EventPayload::FoodDrop(
+                serde_json::from_value(raw.payload).map_err(D::Error::custom)?,
+            ),
+            "ant_turn_move" => EventPayload::AntTurnMove(
+                serde_json::from_value(raw.payload).map_err(D::Error::custom)?,
+            ),
+            "sim_goodbye" => EventPayload::SimGoodbye(
+                serde_json::from_value(raw.payload).map_err(D::Error::custom)?,
+            ),
+            other => return Err(D::Error::custom(format!("unknown event type: {other}"))),
+        };
+
+        Ok(Self {
+            event_type: raw.event_type,
+            sim_id: raw.sim_id,
+            seq: raw.seq,
+            timestamp_ms: raw.timestamp_ms,
+            payload,
+        })
+    }
+}
+
+impl Serialize for EventEnvelope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let payload = serde_json::to_value(&self.payload).map_err(serde::ser::Error::custom)?;
+        RawEnvelopeRef {
+            event_type: &self.event_type,
+            sim_id: &self.sim_id,
+            seq: self.seq,
+            timestamp_ms: self.timestamp_ms,
+            payload: &payload,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl Serialize for EventPayload {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            EventPayload::SimHello(payload) => payload.serialize(serializer),
+            EventPayload::SimFoodSnapshot(payload) => payload.serialize(serializer),
+            EventPayload::SimHeartbeat(payload) => payload.serialize(serializer),
+            EventPayload::FoodPickup(payload) => payload.serialize(serializer),
+            EventPayload::FoodDrop(payload) => payload.serialize(serializer),
+            EventPayload::AntTurnMove(payload) => payload.serialize(serializer),
+            EventPayload::SimGoodbye(payload) => payload.serialize(serializer),
+        }
+    }
+}

--- a/backend-rust/src/store.rs
+++ b/backend-rust/src/store.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Instant};
+use std::{collections::HashMap, sync::RwLock, time::Instant};
 
 use crate::{
     protocol::{EventEnvelope, EventPayload, FoodDropPayload, FoodPickupPayload},
@@ -22,10 +22,9 @@ struct SimState {
     turn_move_count: usize,
 }
 
-#[derive(Clone, Debug)]
 pub struct Store {
     cell_size: f64,
-    sims: HashMap<String, SimState>,
+    shards: Vec<RwLock<HashMap<String, SimState>>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -44,43 +43,50 @@ impl Default for Store {
 }
 
 impl Store {
+    const SHARD_COUNT: usize = 32;
+
     pub fn new(cell_size: f64) -> Self {
         Self {
             cell_size,
-            sims: HashMap::new(),
+            shards: (0..Self::SHARD_COUNT)
+                .map(|_| RwLock::new(HashMap::new()))
+                .collect(),
         }
     }
 
-    pub fn apply_event(&mut self, envelope: &EventEnvelope) -> Result<(), String> {
+    pub fn apply_event(&self, envelope: &EventEnvelope) -> Result<(), String> {
         match &envelope.payload {
             EventPayload::SimHello(payload) => {
-                let state = self.ensure_sim(&envelope.sim_id);
-                state.record_event();
-                state.ant_count = payload.ant_count;
+                self.with_sim_state_mut(&envelope.sim_id, |state| {
+                    state.record_event();
+                    state.ant_count = payload.ant_count;
+                });
             }
             EventPayload::SimFoodSnapshot(payload) => {
-                let state = self.ensure_sim(&envelope.sim_id);
-                state.record_event();
-                state.loose_food = payload
-                    .foods
-                    .iter()
-                    .map(|food| {
-                        (
-                            food.food_id.clone(),
-                            FoodPosition {
-                                x: food.x as f64,
-                                y: food.y as f64,
-                            },
-                        )
-                    })
-                    .collect();
+                self.with_sim_state_mut(&envelope.sim_id, |state| {
+                    state.record_event();
+                    state.loose_food = payload
+                        .foods
+                        .iter()
+                        .map(|food| {
+                            (
+                                food.food_id.clone(),
+                                FoodPosition {
+                                    x: food.x as f64,
+                                    y: food.y as f64,
+                                },
+                            )
+                        })
+                        .collect();
+                });
             }
             EventPayload::FoodPickup(payload) => self.record_pickup(&envelope.sim_id, payload),
             EventPayload::FoodDrop(payload) => self.record_drop(&envelope.sim_id, payload),
             EventPayload::AntTurnMove(_) => {
-                let state = self.ensure_sim(&envelope.sim_id);
-                state.record_event();
-                state.turn_move_count += 1;
+                self.with_sim_state_mut(&envelope.sim_id, |state| {
+                    state.record_event();
+                    state.turn_move_count += 1;
+                });
             }
             EventPayload::SimHeartbeat(_) | EventPayload::SimGoodbye(_) => {
                 return Err(format!("unsupported event type: {}", envelope.event_type));
@@ -93,53 +99,62 @@ impl Store {
         self.snapshot_data().into_cached_snapshot()
     }
 
-    fn ensure_sim(&mut self, sim_id: &str) -> &mut SimState {
-        self.sims.entry(sim_id.to_string()).or_default()
+    fn with_sim_state_mut<T>(&self, sim_id: &str, update: impl FnOnce(&mut SimState) -> T) -> T {
+        let mut shard = self.shards[self.shard_index(sim_id)]
+            .write()
+            .expect("store shard lock poisoned");
+        let state = shard.entry(sim_id.to_string()).or_default();
+        update(state)
     }
 
-    fn record_pickup(&mut self, sim_id: &str, payload: &FoodPickupPayload) {
-        let state = self.ensure_sim(sim_id);
-        state.record_event();
-        state.loose_food.remove(&payload.food_id);
-        state.pickup_count += 1;
+    fn record_pickup(&self, sim_id: &str, payload: &FoodPickupPayload) {
+        self.with_sim_state_mut(sim_id, |state| {
+            state.record_event();
+            state.loose_food.remove(&payload.food_id);
+            state.pickup_count += 1;
+        });
     }
 
-    fn record_drop(&mut self, sim_id: &str, payload: &FoodDropPayload) {
-        let state = self.ensure_sim(sim_id);
-        state.record_event();
-        state.loose_food.insert(
-            payload.food_id.clone(),
-            FoodPosition {
-                x: payload.x as f64,
-                y: payload.y as f64,
-            },
-        );
-        state.drop_count += 1;
+    fn record_drop(&self, sim_id: &str, payload: &FoodDropPayload) {
+        self.with_sim_state_mut(sim_id, |state| {
+            state.record_event();
+            state.loose_food.insert(
+                payload.food_id.clone(),
+                FoodPosition {
+                    x: payload.x as f64,
+                    y: payload.y as f64,
+                },
+            );
+            state.drop_count += 1;
+        });
     }
 
     pub(crate) fn snapshot_data(&self) -> DashboardSnapshotData {
-        let mut sims = Vec::with_capacity(self.sims.len());
+        let mut sims = Vec::new();
         let mut loose_food = Vec::new();
         let mut started_at = None;
         let mut total_events = 0;
 
-        for (sim_id, sim) in &self.sims {
-            sims.push(SimSummaryResponse {
-                sim_id: sim_id.clone(),
-                ant_count: sim.ant_count,
-                pickup_count: sim.pickup_count,
-                drop_count: sim.drop_count,
-                turn_move_count: sim.turn_move_count,
-                loose_food_count: sim.loose_food.len(),
-            });
-            total_events += sim.total_events;
-            if let Some(connected_at) = sim.connected_at {
-                started_at = match started_at {
-                    Some(existing) if existing <= connected_at => Some(existing),
-                    _ => Some(connected_at),
-                };
+        for shard in &self.shards {
+            let shard = shard.read().expect("store shard lock poisoned");
+            for (sim_id, sim) in shard.iter() {
+                sims.push(SimSummaryResponse {
+                    sim_id: sim_id.clone(),
+                    ant_count: sim.ant_count,
+                    pickup_count: sim.pickup_count,
+                    drop_count: sim.drop_count,
+                    turn_move_count: sim.turn_move_count,
+                    loose_food_count: sim.loose_food.len(),
+                });
+                total_events += sim.total_events;
+                if let Some(connected_at) = sim.connected_at {
+                    started_at = match started_at {
+                        Some(existing) if existing <= connected_at => Some(existing),
+                        _ => Some(connected_at),
+                    };
+                }
+                loose_food.extend(sim.loose_food.values().copied());
             }
-            loose_food.extend(sim.loose_food.values().copied());
         }
 
         DashboardSnapshotData {
@@ -149,6 +164,32 @@ impl Store {
             total_events,
             cell_size: self.cell_size,
         }
+    }
+
+    fn shard_index(&self, sim_id: &str) -> usize {
+        shard_index(sim_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hold_shard_for_test(&self, sim_id: &str) -> StoreShardWriteGuard<'_> {
+        StoreShardWriteGuard {
+            _guard: self.shards[self.shard_index(sim_id)]
+                .write()
+                .expect("store shard lock poisoned"),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_hold_shard_for_test(&self, sim_id: &str) -> Option<StoreShardWriteGuard<'_>> {
+        self.shards[self.shard_index(sim_id)]
+            .try_write()
+            .ok()
+            .map(|guard| StoreShardWriteGuard { _guard: guard })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shard_index_for_test(&self, sim_id: &str) -> usize {
+        self.shard_index(sim_id)
     }
 }
 
@@ -200,6 +241,17 @@ impl DashboardSnapshotData {
             sims: self.sims,
         }
     }
+}
+
+fn shard_index(sim_id: &str) -> usize {
+    sim_id.bytes().fold(0usize, |hash, byte| {
+        hash.wrapping_mul(16777619).wrapping_add(byte as usize)
+    }) % Store::SHARD_COUNT
+}
+
+#[cfg(test)]
+pub(crate) struct StoreShardWriteGuard<'a> {
+    _guard: std::sync::RwLockWriteGuard<'a, HashMap<String, SimState>>,
 }
 
 fn occupied_cell_count(positions: &[FoodPosition], cell_size: f64) -> usize {

--- a/backend-rust/src/store.rs
+++ b/backend-rust/src/store.rs
@@ -1,0 +1,238 @@
+use std::{collections::HashMap, time::Instant};
+
+use crate::{
+    protocol::{EventEnvelope, EventPayload, FoodDropPayload, FoodPickupPayload},
+    summary::{CachedSnapshot, SimSummaryResponse, SummaryResponse},
+};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct FoodPosition {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SimState {
+    loose_food: HashMap<String, FoodPosition>,
+    ant_count: usize,
+    connected_at: Option<Instant>,
+    total_events: usize,
+    pickup_count: usize,
+    drop_count: usize,
+    turn_move_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct Store {
+    cell_size: f64,
+    sims: HashMap<String, SimState>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct DashboardSnapshotData {
+    sims: Vec<SimSummaryResponse>,
+    loose_food: Vec<FoodPosition>,
+    started_at: Option<Instant>,
+    total_events: usize,
+    cell_size: f64,
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Self::new(50.0)
+    }
+}
+
+impl Store {
+    pub fn new(cell_size: f64) -> Self {
+        Self {
+            cell_size,
+            sims: HashMap::new(),
+        }
+    }
+
+    pub fn apply_event(&mut self, envelope: &EventEnvelope) -> Result<(), String> {
+        match &envelope.payload {
+            EventPayload::SimHello(payload) => {
+                let state = self.ensure_sim(&envelope.sim_id);
+                state.record_event();
+                state.ant_count = payload.ant_count;
+            }
+            EventPayload::SimFoodSnapshot(payload) => {
+                let state = self.ensure_sim(&envelope.sim_id);
+                state.record_event();
+                state.loose_food = payload
+                    .foods
+                    .iter()
+                    .map(|food| {
+                        (
+                            food.food_id.clone(),
+                            FoodPosition {
+                                x: food.x as f64,
+                                y: food.y as f64,
+                            },
+                        )
+                    })
+                    .collect();
+            }
+            EventPayload::FoodPickup(payload) => self.record_pickup(&envelope.sim_id, payload),
+            EventPayload::FoodDrop(payload) => self.record_drop(&envelope.sim_id, payload),
+            EventPayload::AntTurnMove(_) => {
+                let state = self.ensure_sim(&envelope.sim_id);
+                state.record_event();
+                state.turn_move_count += 1;
+            }
+            EventPayload::SimHeartbeat(_) | EventPayload::SimGoodbye(_) => {
+                return Err(format!("unsupported event type: {}", envelope.event_type));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn snapshot(&self) -> CachedSnapshot {
+        let data = self.dashboard_snapshot_data();
+        CachedSnapshot {
+            summary: data.summary(),
+            sims: data.sims,
+        }
+    }
+
+    fn ensure_sim(&mut self, sim_id: &str) -> &mut SimState {
+        self.sims.entry(sim_id.to_string()).or_default()
+    }
+
+    fn record_pickup(&mut self, sim_id: &str, payload: &FoodPickupPayload) {
+        let state = self.ensure_sim(sim_id);
+        state.record_event();
+        state.loose_food.remove(&payload.food_id);
+        state.pickup_count += 1;
+    }
+
+    fn record_drop(&mut self, sim_id: &str, payload: &FoodDropPayload) {
+        let state = self.ensure_sim(sim_id);
+        state.record_event();
+        state.loose_food.insert(
+            payload.food_id.clone(),
+            FoodPosition {
+                x: payload.x as f64,
+                y: payload.y as f64,
+            },
+        );
+        state.drop_count += 1;
+    }
+
+    fn dashboard_snapshot_data(&self) -> DashboardSnapshotData {
+        let mut sims = Vec::with_capacity(self.sims.len());
+        let mut loose_food = Vec::new();
+        let mut started_at = None;
+        let mut total_events = 0;
+
+        for (sim_id, sim) in &self.sims {
+            sims.push(SimSummaryResponse {
+                sim_id: sim_id.clone(),
+                ant_count: sim.ant_count,
+                pickup_count: sim.pickup_count,
+                drop_count: sim.drop_count,
+                turn_move_count: sim.turn_move_count,
+                loose_food_count: sim.loose_food.len(),
+            });
+            total_events += sim.total_events;
+            if let Some(connected_at) = sim.connected_at {
+                started_at = match started_at {
+                    Some(existing) if existing <= connected_at => Some(existing),
+                    _ => Some(connected_at),
+                };
+            }
+            loose_food.extend(sim.loose_food.values().copied());
+        }
+
+        DashboardSnapshotData {
+            sims,
+            loose_food,
+            started_at,
+            total_events,
+            cell_size: self.cell_size,
+        }
+    }
+}
+
+impl SimState {
+    fn record_event(&mut self) {
+        if self.connected_at.is_none() {
+            self.connected_at = Some(Instant::now());
+        }
+        self.total_events += 1;
+    }
+}
+
+impl DashboardSnapshotData {
+    fn summary(&self) -> SummaryResponse {
+        let (elapsed_seconds, events_per_second) = self.metrics();
+        if self.loose_food.is_empty() {
+            return SummaryResponse {
+                connected_sim_count: self.sims.len(),
+                elapsed_seconds,
+                events_per_second,
+                ..SummaryResponse::default()
+            };
+        }
+
+        SummaryResponse {
+            connected_sim_count: self.sims.len(),
+            loose_food_count: self.loose_food.len(),
+            occupied_cell_count: occupied_cell_count(&self.loose_food, self.cell_size),
+            nearest_neighbor_mean_distance: mean_nearest_neighbor_distance(&self.loose_food),
+            elapsed_seconds,
+            events_per_second,
+        }
+    }
+
+    fn metrics(&self) -> (f64, f64) {
+        let Some(started_at) = self.started_at else {
+            return (0.0, 0.0);
+        };
+        let elapsed_seconds = started_at.elapsed().as_secs_f64();
+        if elapsed_seconds <= 0.0 {
+            return (0.0, 0.0);
+        }
+        (elapsed_seconds, self.total_events as f64 / elapsed_seconds)
+    }
+}
+
+fn occupied_cell_count(positions: &[FoodPosition], cell_size: f64) -> usize {
+    let effective_cell_size = if cell_size > 0.0 { cell_size } else { 1.0 };
+    let mut cells: HashMap<(i64, i64), ()> = HashMap::new();
+    for position in positions {
+        let cell = (
+            (position.x / effective_cell_size).floor() as i64,
+            (position.y / effective_cell_size).floor() as i64,
+        );
+        cells.insert(cell, ());
+    }
+    cells.len()
+}
+
+fn mean_nearest_neighbor_distance(positions: &[FoodPosition]) -> f64 {
+    if positions.len() < 2 {
+        return 0.0;
+    }
+
+    let total = positions
+        .iter()
+        .enumerate()
+        .map(|(index, position)| {
+            positions
+                .iter()
+                .enumerate()
+                .filter_map(|(other_index, other)| {
+                    if index == other_index {
+                        return None;
+                    }
+                    Some(((position.x - other.x).powi(2) + (position.y - other.y).powi(2)).sqrt())
+                })
+                .fold(f64::MAX, f64::min)
+        })
+        .sum::<f64>();
+
+    total / positions.len() as f64
+}

--- a/backend-rust/src/store.rs
+++ b/backend-rust/src/store.rs
@@ -2,8 +2,14 @@ use std::{collections::HashMap, sync::RwLock, time::Instant};
 
 use crate::{
     protocol::{EventEnvelope, EventPayload, FoodDropPayload, FoodPickupPayload},
-    summary::{CachedSnapshot, SimSummaryResponse, SummaryResponse},
+    summary::{
+        AnalyticsSummaryResponse, CachedLiveSnapshot, LiveSummaryResponse, SimSummaryResponse,
+    },
 };
+
+pub struct EventOutcome {
+    pub sim_loose_food_count: usize,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct FoodPosition {
@@ -28,11 +34,16 @@ pub struct Store {
 }
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct DashboardSnapshotData {
+pub(crate) struct LiveSnapshotData {
     sims: Vec<SimSummaryResponse>,
-    loose_food: Vec<FoodPosition>,
     started_at: Option<Instant>,
     total_events: usize,
+    loose_food_count: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct AnalyticsInputData {
+    loose_food: Vec<FoodPosition>,
     cell_size: f64,
 }
 
@@ -54,13 +65,14 @@ impl Store {
         }
     }
 
-    pub fn apply_event(&self, envelope: &EventEnvelope) -> Result<(), String> {
-        match &envelope.payload {
+    pub fn apply_event(&self, envelope: &EventEnvelope) -> Result<EventOutcome, String> {
+        let sim_loose_food_count = match &envelope.payload {
             EventPayload::SimHello(payload) => {
                 self.with_sim_state_mut(&envelope.sim_id, |state| {
                     state.record_event();
                     state.ant_count = payload.ant_count;
-                });
+                    state.loose_food.len()
+                })
             }
             EventPayload::SimFoodSnapshot(payload) => {
                 self.with_sim_state_mut(&envelope.sim_id, |state| {
@@ -78,7 +90,8 @@ impl Store {
                             )
                         })
                         .collect();
-                });
+                    state.loose_food.len()
+                })
             }
             EventPayload::FoodPickup(payload) => self.record_pickup(&envelope.sim_id, payload),
             EventPayload::FoodDrop(payload) => self.record_drop(&envelope.sim_id, payload),
@@ -86,17 +99,20 @@ impl Store {
                 self.with_sim_state_mut(&envelope.sim_id, |state| {
                     state.record_event();
                     state.turn_move_count += 1;
-                });
+                    state.loose_food.len()
+                })
             }
             EventPayload::SimHeartbeat(_) | EventPayload::SimGoodbye(_) => {
                 return Err(format!("unsupported event type: {}", envelope.event_type));
             }
-        }
-        Ok(())
+        };
+        Ok(EventOutcome {
+            sim_loose_food_count,
+        })
     }
 
-    pub fn snapshot(&self) -> CachedSnapshot {
-        self.snapshot_data().into_cached_snapshot()
+    pub fn live_snapshot(&self) -> CachedLiveSnapshot {
+        self.live_snapshot_data().into_cached_live_snapshot()
     }
 
     fn with_sim_state_mut<T>(&self, sim_id: &str, update: impl FnOnce(&mut SimState) -> T) -> T {
@@ -107,15 +123,16 @@ impl Store {
         update(state)
     }
 
-    fn record_pickup(&self, sim_id: &str, payload: &FoodPickupPayload) {
+    fn record_pickup(&self, sim_id: &str, payload: &FoodPickupPayload) -> usize {
         self.with_sim_state_mut(sim_id, |state| {
             state.record_event();
             state.loose_food.remove(&payload.food_id);
             state.pickup_count += 1;
-        });
+            state.loose_food.len()
+        })
     }
 
-    fn record_drop(&self, sim_id: &str, payload: &FoodDropPayload) {
+    fn record_drop(&self, sim_id: &str, payload: &FoodDropPayload) -> usize {
         self.with_sim_state_mut(sim_id, |state| {
             state.record_event();
             state.loose_food.insert(
@@ -126,14 +143,15 @@ impl Store {
                 },
             );
             state.drop_count += 1;
-        });
+            state.loose_food.len()
+        })
     }
 
-    pub(crate) fn snapshot_data(&self) -> DashboardSnapshotData {
+    pub(crate) fn live_snapshot_data(&self) -> LiveSnapshotData {
         let mut sims = Vec::new();
-        let mut loose_food = Vec::new();
         let mut started_at = None;
         let mut total_events = 0;
+        let mut loose_food_count = 0;
 
         for shard in &self.shards {
             let shard = shard.read().expect("store shard lock poisoned");
@@ -153,15 +171,30 @@ impl Store {
                         _ => Some(connected_at),
                     };
                 }
+                loose_food_count += sim.loose_food.len();
+            }
+        }
+
+        LiveSnapshotData {
+            sims,
+            started_at,
+            total_events,
+            loose_food_count,
+        }
+    }
+
+    pub(crate) fn analytics_input_data(&self) -> AnalyticsInputData {
+        let mut loose_food = Vec::new();
+
+        for shard in &self.shards {
+            let shard = shard.read().expect("store shard lock poisoned");
+            for sim in shard.values() {
                 loose_food.extend(sim.loose_food.values().copied());
             }
         }
 
-        DashboardSnapshotData {
-            sims,
+        AnalyticsInputData {
             loose_food,
-            started_at,
-            total_events,
             cell_size: self.cell_size,
         }
     }
@@ -202,23 +235,12 @@ impl SimState {
     }
 }
 
-impl DashboardSnapshotData {
-    fn summary(&self) -> SummaryResponse {
+impl LiveSnapshotData {
+    fn summary(&self) -> LiveSummaryResponse {
         let (elapsed_seconds, events_per_second) = self.metrics();
-        if self.loose_food.is_empty() {
-            return SummaryResponse {
-                connected_sim_count: self.sims.len(),
-                elapsed_seconds,
-                events_per_second,
-                ..SummaryResponse::default()
-            };
-        }
-
-        SummaryResponse {
+        LiveSummaryResponse {
             connected_sim_count: self.sims.len(),
-            loose_food_count: self.loose_food.len(),
-            occupied_cell_count: occupied_cell_count(&self.loose_food, self.cell_size),
-            nearest_neighbor_mean_distance: mean_nearest_neighbor_distance(&self.loose_food),
+            loose_food_count: self.loose_food_count,
             elapsed_seconds,
             events_per_second,
         }
@@ -235,10 +257,23 @@ impl DashboardSnapshotData {
         (elapsed_seconds, self.total_events as f64 / elapsed_seconds)
     }
 
-    pub(crate) fn into_cached_snapshot(self) -> CachedSnapshot {
-        CachedSnapshot {
-            summary: self.summary(),
+    pub(crate) fn into_cached_live_snapshot(self) -> CachedLiveSnapshot {
+        CachedLiveSnapshot {
+            live_summary: self.summary(),
             sims: self.sims,
+        }
+    }
+}
+
+impl AnalyticsInputData {
+    pub(crate) fn summary(&self) -> AnalyticsSummaryResponse {
+        if self.loose_food.is_empty() {
+            return AnalyticsSummaryResponse::default();
+        }
+
+        AnalyticsSummaryResponse {
+            occupied_cell_count: occupied_cell_count(&self.loose_food, self.cell_size),
+            nearest_neighbor_mean_distance: mean_nearest_neighbor_distance(&self.loose_food),
         }
     }
 }

--- a/backend-rust/src/store.rs
+++ b/backend-rust/src/store.rs
@@ -29,7 +29,7 @@ pub struct Store {
 }
 
 #[derive(Clone, Debug, Default)]
-struct DashboardSnapshotData {
+pub(crate) struct DashboardSnapshotData {
     sims: Vec<SimSummaryResponse>,
     loose_food: Vec<FoodPosition>,
     started_at: Option<Instant>,
@@ -90,11 +90,7 @@ impl Store {
     }
 
     pub fn snapshot(&self) -> CachedSnapshot {
-        let data = self.dashboard_snapshot_data();
-        CachedSnapshot {
-            summary: data.summary(),
-            sims: data.sims,
-        }
+        self.snapshot_data().into_cached_snapshot()
     }
 
     fn ensure_sim(&mut self, sim_id: &str) -> &mut SimState {
@@ -121,7 +117,7 @@ impl Store {
         state.drop_count += 1;
     }
 
-    fn dashboard_snapshot_data(&self) -> DashboardSnapshotData {
+    pub(crate) fn snapshot_data(&self) -> DashboardSnapshotData {
         let mut sims = Vec::with_capacity(self.sims.len());
         let mut loose_food = Vec::new();
         let mut started_at = None;
@@ -196,6 +192,13 @@ impl DashboardSnapshotData {
             return (0.0, 0.0);
         }
         (elapsed_seconds, self.total_events as f64 / elapsed_seconds)
+    }
+
+    pub(crate) fn into_cached_snapshot(self) -> CachedSnapshot {
+        CachedSnapshot {
+            summary: self.summary(),
+            sims: self.sims,
+        }
     }
 }
 

--- a/backend-rust/src/summary.rs
+++ b/backend-rust/src/summary.rs
@@ -1,0 +1,27 @@
+use serde::Serialize;
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct SummaryResponse {
+    pub connected_sim_count: usize,
+    pub loose_food_count: usize,
+    pub occupied_cell_count: usize,
+    pub nearest_neighbor_mean_distance: f64,
+    pub elapsed_seconds: f64,
+    pub events_per_second: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct SimSummaryResponse {
+    pub sim_id: String,
+    pub ant_count: usize,
+    pub pickup_count: usize,
+    pub drop_count: usize,
+    pub turn_move_count: usize,
+    pub loose_food_count: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct CachedSnapshot {
+    pub summary: SummaryResponse,
+    pub sims: Vec<SimSummaryResponse>,
+}

--- a/backend-rust/src/summary.rs
+++ b/backend-rust/src/summary.rs
@@ -1,13 +1,41 @@
 use serde::Serialize;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
-pub struct SummaryResponse {
+pub struct LiveSummaryResponse {
     pub connected_sim_count: usize,
     pub loose_food_count: usize,
-    pub occupied_cell_count: usize,
-    pub nearest_neighbor_mean_distance: f64,
     pub elapsed_seconds: f64,
     pub events_per_second: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct AnalyticsSummaryResponse {
+    pub occupied_cell_count: usize,
+    pub nearest_neighbor_mean_distance: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct AnalyticsMetaResponse {
+    pub computed_at_ms: i64,
+    pub age_seconds: f64,
+    pub is_stale: bool,
+}
+
+impl Default for AnalyticsMetaResponse {
+    fn default() -> Self {
+        Self {
+            computed_at_ms: 0,
+            age_seconds: 0.0,
+            is_stale: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct SummaryResponse {
+    pub live_summary: LiveSummaryResponse,
+    pub analytics_summary: AnalyticsSummaryResponse,
+    pub analytics_meta: AnalyticsMetaResponse,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
@@ -18,6 +46,18 @@ pub struct SimSummaryResponse {
     pub drop_count: usize,
     pub turn_move_count: usize,
     pub loose_food_count: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct CachedLiveSnapshot {
+    pub live_summary: LiveSummaryResponse,
+    pub sims: Vec<SimSummaryResponse>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct CachedAnalyticsSnapshot {
+    pub analytics_summary: AnalyticsSummaryResponse,
+    pub analytics_meta: AnalyticsMetaResponse,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]

--- a/backend-rust/tests/api_parity.rs
+++ b/backend-rust/tests/api_parity.rs
@@ -43,8 +43,14 @@ async fn serves_empty_state_http_surface_with_dashboard_bootstrap_ids() {
         .await
         .expect("summary body");
     let summary_json: Value = serde_json::from_slice(&summary_body).expect("summary json");
-    assert_eq!(summary_json["connected_sim_count"], 0);
-    assert_eq!(summary_json["loose_food_count"], 0);
+    assert_eq!(summary_json["live_summary"]["connected_sim_count"], 0);
+    assert_eq!(summary_json["live_summary"]["loose_food_count"], 0);
+    assert_eq!(summary_json["analytics_summary"]["occupied_cell_count"], 0);
+    assert_eq!(
+        summary_json["analytics_meta"]["is_stale"],
+        true,
+        "expected analytics metadata to mark the empty bootstrap snapshot as stale"
+    );
 
     let sims = app
         .clone()
@@ -89,6 +95,9 @@ async fn serves_empty_state_http_surface_with_dashboard_bootstrap_ids() {
         "loose-food-value",
         "elapsed-seconds-value",
         "events-per-second-value",
+        "occupied-cells-value",
+        "nearest-neighbor-value",
+        "analytics-age-value",
         "sim-table-body",
         "/ws/dashboard",
     ] {
@@ -100,7 +109,7 @@ async fn serves_empty_state_http_surface_with_dashboard_bootstrap_ids() {
 }
 
 #[tokio::test]
-async fn api_summary_starts_stale_then_catches_up_after_direct_ingest() {
+async fn api_summary_exposes_live_counts_immediately_and_analytics_catch_up_after_direct_ingest() {
     let state = AppState::new();
     let app = build_router_with_state(state.clone());
 
@@ -148,19 +157,116 @@ async fn api_summary_starts_stale_then_catches_up_after_direct_ingest() {
     .expect("sim_food_snapshot should be accepted");
 
     let initial = fetch_json(&app, "/api/summary").await;
-    assert_eq!(initial["connected_sim_count"], 0);
-    assert_eq!(initial["loose_food_count"], 0);
+    assert_eq!(initial["live_summary"]["connected_sim_count"], 1);
+    assert_eq!(initial["live_summary"]["loose_food_count"], 3);
+    assert_eq!(initial["analytics_summary"]["occupied_cell_count"], 0);
+    assert_eq!(initial["analytics_meta"]["is_stale"], true);
 
     let eventually = wait_for_json(&app, "/api/summary", |json| {
-        json["connected_sim_count"] == 1
-            && json["loose_food_count"] == 3
-            && json["elapsed_seconds"].as_f64().unwrap_or_default() > 0.0
-            && json["events_per_second"].as_f64().unwrap_or_default() > 0.0
+        json["live_summary"]["connected_sim_count"] == 1
+            && json["live_summary"]["loose_food_count"] == 3
+            && json["live_summary"]["elapsed_seconds"]
+                .as_f64()
+                .unwrap_or_default()
+                > 0.0
+            && json["live_summary"]["events_per_second"]
+                .as_f64()
+                .unwrap_or_default()
+                > 0.0
+            && json["analytics_meta"]["computed_at_ms"]
+                .as_i64()
+                .unwrap_or_default()
+                > 0
+            && json["analytics_meta"]["is_stale"] == false
     })
     .await;
 
-    assert_eq!(eventually["connected_sim_count"], 1);
-    assert_eq!(eventually["loose_food_count"], 3);
+    assert_eq!(eventually["live_summary"]["connected_sim_count"], 1);
+    assert_eq!(eventually["live_summary"]["loose_food_count"], 3);
+    assert_eq!(eventually["analytics_summary"]["occupied_cell_count"], 2);
+}
+
+#[tokio::test]
+async fn api_summary_keeps_live_counts_fresh_even_when_analytics_are_stale() {
+    let state = AppState::new();
+    let app = build_router_with_state(state.clone());
+
+    state.apply_event(EventEnvelope {
+        event_type: "sim_hello".into(),
+        sim_id: "sim-live-vs-analytics".into(),
+        seq: 1,
+        timestamp_ms: 0,
+        payload: EventPayload::SimHello(HelloPayload {
+            sim_name: "sim-live-vs-analytics".into(),
+            source: "rust-bevy".into(),
+            session_started_ms: 0,
+            world_width: 1280.0,
+            world_height: 720.0,
+            ant_count: 26,
+            food_count: 1,
+        }),
+    })
+    .expect("sim_hello should be accepted");
+    state.apply_event(EventEnvelope {
+        event_type: "food_drop".into(),
+        sim_id: "sim-live-vs-analytics".into(),
+        seq: 2,
+        timestamp_ms: 0,
+        payload: EventPayload::FoodDrop(FoodDropPayload {
+            ant_id: Some("ant-1".into()),
+            food_id: "food-1".into(),
+            x: 12.0,
+            y: 18.0,
+            direction_x: Some(0.0),
+            direction_y: Some(1.0),
+            frame: Some(2),
+        }),
+    })
+    .expect("first food_drop should be accepted");
+
+    let warmed = wait_for_json(&app, "/api/summary", |json| {
+        json["live_summary"]["loose_food_count"] == 1
+            && json["analytics_summary"]["occupied_cell_count"] == 1
+            && json["analytics_meta"]["is_stale"] == false
+    })
+    .await;
+    let previous_analytics_timestamp = warmed["analytics_meta"]["computed_at_ms"]
+        .as_i64()
+        .expect("analytics timestamp");
+
+    state.apply_event(EventEnvelope {
+        event_type: "food_drop".into(),
+        sim_id: "sim-live-vs-analytics".into(),
+        seq: 3,
+        timestamp_ms: 0,
+        payload: EventPayload::FoodDrop(FoodDropPayload {
+            ant_id: Some("ant-1".into()),
+            food_id: "food-2".into(),
+            x: 22.0,
+            y: 28.0,
+            direction_x: Some(0.0),
+            direction_y: Some(1.0),
+            frame: Some(3),
+        }),
+    })
+    .expect("second food_drop should be accepted");
+
+    let split = wait_for_json(&app, "/api/summary", |json| {
+        json["live_summary"]["loose_food_count"] == 2
+            && json["analytics_summary"]["occupied_cell_count"] == 1
+            && json["analytics_meta"]["is_stale"] == true
+    })
+    .await;
+
+    assert_eq!(split["live_summary"]["loose_food_count"], 2);
+    assert_eq!(split["analytics_summary"]["occupied_cell_count"], 1);
+    assert_eq!(split["analytics_meta"]["is_stale"], true);
+    assert_eq!(
+        split["analytics_meta"]["computed_at_ms"]
+            .as_i64()
+            .expect("analytics timestamp"),
+        previous_analytics_timestamp
+    );
 }
 
 #[tokio::test]
@@ -259,7 +365,9 @@ async fn api_sims_catches_up_to_direct_ingest_counts() {
     .expect("ant_turn_move should be accepted");
 
     let initial = fetch_json(&app, "/api/sims").await;
-    assert_eq!(initial, Value::Array(vec![]));
+    let initial_sims = initial.as_array().expect("initial sims array");
+    assert_eq!(initial_sims.len(), 1);
+    assert_eq!(initial_sims[0]["sim_id"], "sim-b");
 
     let eventually = wait_for_json(&app, "/api/sims", |json| {
         json.as_array()

--- a/backend-rust/tests/api_parity.rs
+++ b/backend-rust/tests/api_parity.rs
@@ -1,0 +1,324 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use gatherers_backend_rust::{
+    app::{AppState, build_router, build_router_with_state},
+    protocol::{
+        EventEnvelope, EventPayload, FoodDropPayload, FoodPickupPayload, FoodSnapshotPayload,
+        HelloPayload, StartupFoodPayload, TurnMovePayload,
+    },
+};
+use serde_json::Value;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn serves_empty_state_http_surface_with_dashboard_bootstrap_ids() {
+    let app = build_router();
+
+    let health = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .expect("healthz request"),
+        )
+        .await
+        .expect("healthz response");
+    assert_eq!(health.status(), StatusCode::OK);
+
+    let summary = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/summary")
+                .body(Body::empty())
+                .expect("summary request"),
+        )
+        .await
+        .expect("summary response");
+    assert_eq!(summary.status(), StatusCode::OK);
+    let summary_body = to_bytes(summary.into_body(), usize::MAX)
+        .await
+        .expect("summary body");
+    let summary_json: Value = serde_json::from_slice(&summary_body).expect("summary json");
+    assert_eq!(summary_json["connected_sim_count"], 0);
+    assert_eq!(summary_json["loose_food_count"], 0);
+
+    let sims = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/sims")
+                .body(Body::empty())
+                .expect("sims request"),
+        )
+        .await
+        .expect("sims response");
+    assert_eq!(sims.status(), StatusCode::OK);
+    let sims_body = to_bytes(sims.into_body(), usize::MAX)
+        .await
+        .expect("sims body");
+    assert_eq!(
+        std::str::from_utf8(&sims_body).expect("sims utf8"),
+        "[]",
+    );
+
+    let dashboard = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .body(Body::empty())
+                .expect("dashboard request"),
+        )
+        .await
+        .expect("dashboard response");
+    assert_eq!(dashboard.status(), StatusCode::OK);
+
+    let dashboard_body = String::from_utf8(
+        to_bytes(dashboard.into_body(), usize::MAX)
+            .await
+            .expect("dashboard body")
+            .to_vec(),
+    )
+    .expect("dashboard utf8");
+    for required in [
+        "Connected sims",
+        "connected-sims-value",
+        "loose-food-value",
+        "elapsed-seconds-value",
+        "events-per-second-value",
+        "sim-table-body",
+        "/ws/dashboard",
+    ] {
+        assert!(
+            dashboard_body.contains(required),
+            "expected dashboard HTML to contain {required:?}, body was {dashboard_body:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn api_summary_starts_stale_then_catches_up_after_direct_ingest() {
+    let state = AppState::new();
+    let app = build_router_with_state(state.clone());
+
+    state.apply_event(EventEnvelope {
+        event_type: "sim_hello".into(),
+        sim_id: "sim-a".into(),
+        seq: 1,
+        timestamp_ms: 0,
+        payload: EventPayload::SimHello(HelloPayload {
+            sim_name: "sim-a".into(),
+            source: "rust-bevy".into(),
+            session_started_ms: 0,
+            world_width: 1280.0,
+            world_height: 720.0,
+            ant_count: 26,
+            food_count: 3,
+        }),
+    })
+    .expect("sim_hello should be accepted");
+    state.apply_event(EventEnvelope {
+        event_type: "sim_food_snapshot".into(),
+        sim_id: "sim-a".into(),
+        seq: 2,
+        timestamp_ms: 0,
+        payload: EventPayload::SimFoodSnapshot(FoodSnapshotPayload {
+            foods: vec![
+                StartupFoodPayload {
+                    food_id: "food-1".into(),
+                    x: 10.0,
+                    y: 20.0,
+                },
+                StartupFoodPayload {
+                    food_id: "food-2".into(),
+                    x: 30.0,
+                    y: 40.0,
+                },
+                StartupFoodPayload {
+                    food_id: "food-3".into(),
+                    x: 50.0,
+                    y: 60.0,
+                },
+            ],
+        }),
+    })
+    .expect("sim_food_snapshot should be accepted");
+
+    let initial = fetch_json(&app, "/api/summary").await;
+    assert_eq!(initial["connected_sim_count"], 0);
+    assert_eq!(initial["loose_food_count"], 0);
+
+    let eventually = wait_for_json(&app, "/api/summary", |json| {
+        json["connected_sim_count"] == 1
+            && json["loose_food_count"] == 3
+            && json["elapsed_seconds"].as_f64().unwrap_or_default() > 0.0
+            && json["events_per_second"].as_f64().unwrap_or_default() > 0.0
+    })
+    .await;
+
+    assert_eq!(eventually["connected_sim_count"], 1);
+    assert_eq!(eventually["loose_food_count"], 3);
+}
+
+#[tokio::test]
+async fn api_sims_catches_up_to_direct_ingest_counts() {
+    let state = AppState::new();
+    let app = build_router_with_state(state.clone());
+
+    state.apply_event(EventEnvelope {
+        event_type: "sim_hello".into(),
+        sim_id: "sim-b".into(),
+        seq: 1,
+        timestamp_ms: 0,
+        payload: EventPayload::SimHello(HelloPayload {
+            sim_name: "sim-b".into(),
+            source: "rust-bevy".into(),
+            session_started_ms: 0,
+            world_width: 1280.0,
+            world_height: 720.0,
+            ant_count: 26,
+            food_count: 3,
+        }),
+    })
+    .expect("sim_hello should be accepted");
+    state.apply_event(EventEnvelope {
+        event_type: "sim_food_snapshot".into(),
+        sim_id: "sim-b".into(),
+        seq: 2,
+        timestamp_ms: 0,
+        payload: EventPayload::SimFoodSnapshot(FoodSnapshotPayload {
+            foods: vec![
+                StartupFoodPayload {
+                    food_id: "food-1".into(),
+                    x: 10.0,
+                    y: 20.0,
+                },
+                StartupFoodPayload {
+                    food_id: "food-2".into(),
+                    x: 30.0,
+                    y: 40.0,
+                },
+                StartupFoodPayload {
+                    food_id: "food-3".into(),
+                    x: 50.0,
+                    y: 60.0,
+                },
+            ],
+        }),
+    })
+    .expect("sim_food_snapshot should be accepted");
+    state.apply_event(EventEnvelope {
+        event_type: "food_pickup".into(),
+        sim_id: "sim-b".into(),
+        seq: 3,
+        timestamp_ms: 0,
+        payload: EventPayload::FoodPickup(FoodPickupPayload {
+            ant_id: Some("ant-1".into()),
+            food_id: "food-1".into(),
+            x: Some(10.0),
+            y: Some(20.0),
+            direction_x: Some(1.0),
+            direction_y: Some(0.0),
+            frame: Some(1),
+        }),
+    })
+    .expect("food_pickup should be accepted");
+    state.apply_event(EventEnvelope {
+        event_type: "food_drop".into(),
+        sim_id: "sim-b".into(),
+        seq: 4,
+        timestamp_ms: 0,
+        payload: EventPayload::FoodDrop(FoodDropPayload {
+            ant_id: Some("ant-1".into()),
+            food_id: "food-4".into(),
+            x: 70.0,
+            y: 80.0,
+            direction_x: Some(0.0),
+            direction_y: Some(1.0),
+            frame: Some(2),
+        }),
+    })
+    .expect("food_drop should be accepted");
+    state.apply_event(EventEnvelope {
+        event_type: "ant_turn_move".into(),
+        sim_id: "sim-b".into(),
+        seq: 5,
+        timestamp_ms: 0,
+        payload: EventPayload::AntTurnMove(TurnMovePayload {
+            ant_id: "ant-1".into(),
+            x: 70.0,
+            y: 80.0,
+            direction_x: 0.0,
+            direction_y: 1.0,
+            frame: 3,
+        }),
+    })
+    .expect("ant_turn_move should be accepted");
+
+    let initial = fetch_json(&app, "/api/sims").await;
+    assert_eq!(initial, Value::Array(vec![]));
+
+    let eventually = wait_for_json(&app, "/api/sims", |json| {
+        json.as_array()
+            .and_then(|items| items.first())
+            .map(|sim| {
+                sim["sim_id"] == "sim-b"
+                    && sim["ant_count"] == 26
+                    && sim["pickup_count"] == 1
+                    && sim["drop_count"] == 1
+                    && sim["turn_move_count"] == 1
+                    && sim["loose_food_count"] == 3
+            })
+            .unwrap_or(false)
+    })
+    .await;
+
+    let sims = eventually.as_array().expect("sims array");
+    assert_eq!(sims.len(), 1);
+}
+
+async fn fetch_json<S>(app: &S, uri: &str) -> Value
+where
+    S: tower::Service<Request<Body>, Response = axum::response::Response> + Clone,
+    S::Future: Send,
+    S::Error: std::fmt::Debug,
+{
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    serde_json::from_slice(&body).expect("json body")
+}
+
+async fn wait_for_json<S, F>(app: &S, uri: &str, match_json: F) -> Value
+where
+    S: tower::Service<Request<Body>, Response = axum::response::Response> + Clone,
+    S::Future: Send,
+    S::Error: std::fmt::Debug,
+    F: Fn(&Value) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(1500);
+    loop {
+        let json = fetch_json(app, uri).await;
+        if match_json(&json) {
+            return json;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "expected {uri} to converge before timeout, last payload was {json:?}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}

--- a/backend-rust/tests/ingest_decoupling_stress.rs
+++ b/backend-rust/tests/ingest_decoupling_stress.rs
@@ -1,0 +1,275 @@
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use gatherers_backend_rust::{
+    app::{AppState, build_router_with_state},
+    protocol::{
+        EventEnvelope, EventPayload, FoodDropPayload, FoodPickupPayload, FoodSnapshotPayload,
+        HelloPayload, StartupFoodPayload, TurnMovePayload,
+    },
+};
+use serde_json::Value;
+use tokio::{
+    net::TcpListener,
+    sync::{Barrier, watch},
+};
+
+const CLIENT_COUNT: usize = 40;
+const ACTIVITY_TRIPLETS: usize = 20;
+const INITIAL_FOOD_COUNT: usize = 80;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn heavy_ingest_with_polling_keeps_api_sims_responsive_and_exact() {
+    let state = AppState::new();
+    let server = spawn_test_server(state.clone()).await;
+    let start_barrier = Arc::new(Barrier::new(CLIENT_COUNT + 1));
+    let (done_tx, done_rx) = watch::channel(false);
+
+    let poller = tokio::spawn(poll_sims_until_done(server.http_base_url.clone(), done_rx));
+
+    let mut clients = Vec::with_capacity(CLIENT_COUNT);
+    for index in 0..CLIENT_COUNT {
+        clients.push(tokio::spawn(run_ingest_client(
+            state.clone(),
+            index,
+            start_barrier.clone(),
+        )));
+    }
+
+    start_barrier.wait().await;
+    for client in clients {
+        client.await.expect("client task should join");
+    }
+
+    done_tx
+        .send(true)
+        .expect("poller shutdown signal should send");
+    poller
+        .await
+        .expect("poller task should join")
+        .expect("api poller should stay responsive under load");
+
+    let totals = wait_for_exact_totals(&server.http_base_url).await;
+    assert_eq!(totals.connected_sims, CLIENT_COUNT);
+    assert_eq!(totals.pickups, CLIENT_COUNT * ACTIVITY_TRIPLETS);
+    assert_eq!(totals.drops, CLIENT_COUNT * ACTIVITY_TRIPLETS);
+    assert_eq!(totals.turn_moves, CLIENT_COUNT * ACTIVITY_TRIPLETS);
+    assert_eq!(totals.loose_food, CLIENT_COUNT * INITIAL_FOOD_COUNT);
+}
+
+async fn run_ingest_client(state: AppState, index: usize, start_barrier: Arc<Barrier>) {
+    let sim_id = format!("stress-sim-{index:03}");
+    start_barrier.wait().await;
+    for event in client_events(&sim_id, index) {
+        state
+            .apply_event(event)
+            .expect("direct ingest event should be accepted");
+    }
+}
+
+fn client_events(sim_id: &str, index: usize) -> Vec<EventEnvelope> {
+    let mut events = Vec::with_capacity(2 + ACTIVITY_TRIPLETS * 3);
+    events.push(EventEnvelope {
+        event_type: "sim_hello".into(),
+        sim_id: sim_id.into(),
+        seq: 1,
+        timestamp_ms: 0,
+        payload: EventPayload::SimHello(HelloPayload {
+            sim_name: sim_id.into(),
+            source: "rust-load-test".into(),
+            session_started_ms: 0,
+            world_width: 1280.0,
+            world_height: 720.0,
+            ant_count: 26,
+            food_count: INITIAL_FOOD_COUNT,
+        }),
+    });
+    events.push(EventEnvelope {
+        event_type: "sim_food_snapshot".into(),
+        sim_id: sim_id.into(),
+        seq: 2,
+        timestamp_ms: 0,
+        payload: EventPayload::SimFoodSnapshot(FoodSnapshotPayload {
+            foods: (0..INITIAL_FOOD_COUNT)
+                .map(|food_index| StartupFoodPayload {
+                    food_id: format!("{sim_id}-food-{food_index:03}"),
+                    x: ((index * 17 + food_index * 13) % 2000) as f32,
+                    y: ((index * 19 + food_index * 11) % 2000) as f32,
+                })
+                .collect(),
+        }),
+    });
+
+    let mut seq = 3;
+    for triplet in 0..ACTIVITY_TRIPLETS {
+        let food_id = format!("{sim_id}-food-{triplet:03}");
+        let ant_id = format!("{sim_id}-ant-{triplet:03}");
+        let x = (index * 31 + triplet * 7) as f32;
+        let y = (index * 29 + triplet * 5) as f32;
+
+        events.push(EventEnvelope {
+            event_type: "food_pickup".into(),
+            sim_id: sim_id.into(),
+            seq,
+            timestamp_ms: 0,
+            payload: EventPayload::FoodPickup(FoodPickupPayload {
+                ant_id: Some(ant_id.clone()),
+                food_id: food_id.clone(),
+                x: Some(x),
+                y: Some(y),
+                direction_x: Some(1.0),
+                direction_y: Some(0.0),
+                frame: Some(seq),
+            }),
+        });
+        seq += 1;
+
+        events.push(EventEnvelope {
+            event_type: "food_drop".into(),
+            sim_id: sim_id.into(),
+            seq,
+            timestamp_ms: 0,
+            payload: EventPayload::FoodDrop(FoodDropPayload {
+                ant_id: Some(ant_id.clone()),
+                food_id: format!("{food_id}-drop"),
+                x: x + 0.5,
+                y: y + 0.5,
+                direction_x: Some(0.0),
+                direction_y: Some(1.0),
+                frame: Some(seq),
+            }),
+        });
+        seq += 1;
+
+        events.push(EventEnvelope {
+            event_type: "ant_turn_move".into(),
+            sim_id: sim_id.into(),
+            seq,
+            timestamp_ms: 0,
+            payload: EventPayload::AntTurnMove(TurnMovePayload {
+                ant_id,
+                x: x + 1.0,
+                y: y + 1.0,
+                direction_x: 0.0,
+                direction_y: 1.0,
+                frame: seq,
+            }),
+        });
+        seq += 1;
+    }
+
+    events
+}
+
+async fn poll_sims_until_done(
+    http_base_url: String,
+    mut done_rx: watch::Receiver<bool>,
+) -> Result<(), String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+        .map_err(|err| format!("http client build failed: {err}"))?;
+
+    loop {
+        if *done_rx.borrow() {
+            return Ok(());
+        }
+
+        let response = client
+            .get(format!("{http_base_url}/api/sims"))
+            .send()
+            .await
+            .map_err(|err| format!("api sims polling failed under load: {err}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "api sims returned unexpected status under load: {}",
+                response.status()
+            ));
+        }
+
+        tokio::select! {
+            result = done_rx.changed() => {
+                if result.is_err() || *done_rx.borrow() {
+                    return Ok(());
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+        }
+    }
+}
+
+async fn wait_for_exact_totals(http_base_url: &str) -> Totals {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .expect("http client should build");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+
+    loop {
+        let totals = fetch_totals(&client, http_base_url).await;
+        if totals.connected_sims == CLIENT_COUNT
+            && totals.pickups == CLIENT_COUNT * ACTIVITY_TRIPLETS
+            && totals.drops == CLIENT_COUNT * ACTIVITY_TRIPLETS
+            && totals.turn_moves == CLIENT_COUNT * ACTIVITY_TRIPLETS
+            && totals.loose_food == CLIENT_COUNT * INITIAL_FOOD_COUNT
+        {
+            return totals;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "expected exact totals before timeout, last totals were {totals:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn fetch_totals(client: &reqwest::Client, http_base_url: &str) -> Totals {
+    let sims: Vec<Value> = client
+        .get(format!("{http_base_url}/api/sims"))
+        .send()
+        .await
+        .expect("api sims request should succeed")
+        .json()
+        .await
+        .expect("api sims json should decode");
+
+    sims.into_iter().fold(Totals::default(), |mut totals, sim| {
+        totals.connected_sims += 1;
+        totals.pickups += sim["pickup_count"].as_u64().unwrap_or_default() as usize;
+        totals.drops += sim["drop_count"].as_u64().unwrap_or_default() as usize;
+        totals.turn_moves += sim["turn_move_count"].as_u64().unwrap_or_default() as usize;
+        totals.loose_food += sim["loose_food_count"].as_u64().unwrap_or_default() as usize;
+        totals
+    })
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Totals {
+    connected_sims: usize,
+    pickups: usize,
+    drops: usize,
+    turn_moves: usize,
+    loose_food: usize,
+}
+
+struct TestServer {
+    http_base_url: String,
+}
+
+async fn spawn_test_server(state: AppState) -> TestServer {
+    let router = build_router_with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test listener");
+    let addr: SocketAddr = listener.local_addr().expect("listener addr");
+
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("test server should run");
+    });
+
+    TestServer {
+        http_base_url: format!("http://{addr}"),
+    }
+}

--- a/backend-rust/tests/protocol_parity.rs
+++ b/backend-rust/tests/protocol_parity.rs
@@ -1,0 +1,174 @@
+use gatherers_backend_rust::protocol::{
+    EventEnvelope, EventPayload, FoodDropPayload, FoodPickupPayload, FoodSnapshotPayload,
+    HelloPayload, StartupFoodPayload, TurnMovePayload,
+};
+
+#[test]
+fn deserializes_sim_hello_from_current_client_shape() {
+    let envelope: EventEnvelope = serde_json::from_str(
+        r#"{
+            "type": "sim_hello",
+            "sim_id": "sim-123",
+            "seq": 1,
+            "timestamp_ms": 0,
+            "payload": {
+                "sim_name": "sim-123",
+                "source": "rust-bevy",
+                "session_started_ms": 0,
+                "world_width": 1280.0,
+                "world_height": 720.0,
+                "ant_count": 26,
+                "food_count": 80
+            }
+        }"#,
+    )
+    .expect("sim_hello should deserialize");
+
+    assert_eq!(envelope.event_type, "sim_hello");
+    assert_eq!(envelope.sim_id, "sim-123");
+    match envelope.payload {
+        EventPayload::SimHello(HelloPayload {
+            sim_name,
+            source,
+            ant_count,
+            food_count,
+            ..
+        }) => {
+            assert_eq!(sim_name, "sim-123");
+            assert_eq!(source, "rust-bevy");
+            assert_eq!(ant_count, 26);
+            assert_eq!(food_count, 80);
+        }
+        other => panic!("expected sim_hello payload, got {other:?}"),
+    }
+}
+
+#[test]
+fn deserializes_sim_food_snapshot_from_current_client_shape() {
+    let envelope: EventEnvelope = serde_json::from_str(
+        r#"{
+            "type": "sim_food_snapshot",
+            "sim_id": "sim-123",
+            "seq": 2,
+            "timestamp_ms": 0,
+            "payload": {
+                "foods": [
+                    { "food_id": "food-1", "x": 10.5, "y": 20.5 },
+                    { "food_id": "food-2", "x": 30.5, "y": 40.5 }
+                ]
+            }
+        }"#,
+    )
+    .expect("sim_food_snapshot should deserialize");
+
+    match envelope.payload {
+        EventPayload::SimFoodSnapshot(FoodSnapshotPayload { foods }) => {
+            assert_eq!(
+                foods,
+                vec![
+                    StartupFoodPayload {
+                        food_id: "food-1".into(),
+                        x: 10.5,
+                        y: 20.5,
+                    },
+                    StartupFoodPayload {
+                        food_id: "food-2".into(),
+                        x: 30.5,
+                        y: 40.5,
+                    },
+                ]
+            );
+        }
+        other => panic!("expected sim_food_snapshot payload, got {other:?}"),
+    }
+}
+
+#[test]
+fn deserializes_food_pickup_and_drop_from_current_client_shape() {
+    let pickup: EventEnvelope = serde_json::from_str(
+        r#"{
+            "type": "food_pickup",
+            "sim_id": "sim-123",
+            "seq": 3,
+            "timestamp_ms": 0,
+            "payload": {
+                "ant_id": "ant-1",
+                "food_id": "food-1",
+                "x": 1.0,
+                "y": 2.0,
+                "direction_x": -0.5,
+                "direction_y": 0.5,
+                "frame": 7
+            }
+        }"#,
+    )
+    .expect("food_pickup should deserialize");
+
+    match pickup.payload {
+        EventPayload::FoodPickup(FoodPickupPayload {
+            ant_id, food_id, ..
+        }) => {
+            assert_eq!(ant_id, "ant-1");
+            assert_eq!(food_id, "food-1");
+        }
+        other => panic!("expected food_pickup payload, got {other:?}"),
+    }
+
+    let drop_event: EventEnvelope = serde_json::from_str(
+        r#"{
+            "type": "food_drop",
+            "sim_id": "sim-123",
+            "seq": 4,
+            "timestamp_ms": 0,
+            "payload": {
+                "ant_id": "ant-1",
+                "food_id": "food-1",
+                "x": 3.0,
+                "y": 4.0,
+                "direction_x": 0.25,
+                "direction_y": -0.25,
+                "frame": 8
+            }
+        }"#,
+    )
+    .expect("food_drop should deserialize");
+
+    match drop_event.payload {
+        EventPayload::FoodDrop(FoodDropPayload {
+            ant_id, food_id, ..
+        }) => {
+            assert_eq!(ant_id, "ant-1");
+            assert_eq!(food_id, "food-1");
+        }
+        other => panic!("expected food_drop payload, got {other:?}"),
+    }
+}
+
+#[test]
+fn deserializes_ant_turn_move_from_current_client_shape() {
+    let envelope: EventEnvelope = serde_json::from_str(
+        r#"{
+            "type": "ant_turn_move",
+            "sim_id": "sim-123",
+            "seq": 5,
+            "timestamp_ms": 0,
+            "payload": {
+                "ant_id": "ant-1",
+                "x": 3.0,
+                "y": 4.0,
+                "direction_x": 0.25,
+                "direction_y": -0.25,
+                "frame": 8
+            }
+        }"#,
+    )
+    .expect("ant_turn_move should deserialize");
+
+    match envelope.payload {
+        EventPayload::AntTurnMove(TurnMovePayload { ant_id, frame, .. }) => {
+            assert_eq!(ant_id, "ant-1");
+            assert_eq!(frame, 8);
+        }
+        other => panic!("expected ant_turn_move payload, got {other:?}"),
+    }
+}

--- a/backend-rust/tests/protocol_parity.rs
+++ b/backend-rust/tests/protocol_parity.rs
@@ -108,7 +108,7 @@ fn deserializes_food_pickup_and_drop_from_current_client_shape() {
         EventPayload::FoodPickup(FoodPickupPayload {
             ant_id, food_id, ..
         }) => {
-            assert_eq!(ant_id, "ant-1");
+            assert_eq!(ant_id.as_deref(), Some("ant-1"));
             assert_eq!(food_id, "food-1");
         }
         other => panic!("expected food_pickup payload, got {other:?}"),
@@ -137,7 +137,7 @@ fn deserializes_food_pickup_and_drop_from_current_client_shape() {
         EventPayload::FoodDrop(FoodDropPayload {
             ant_id, food_id, ..
         }) => {
-            assert_eq!(ant_id, "ant-1");
+            assert_eq!(ant_id.as_deref(), Some("ant-1"));
             assert_eq!(food_id, "food-1");
         }
         other => panic!("expected food_drop payload, got {other:?}"),

--- a/backend-rust/tests/ws_parity.rs
+++ b/backend-rust/tests/ws_parity.rs
@@ -21,7 +21,8 @@ async fn dashboard_websocket_receives_update_after_ingest_websocket_events() {
         .expect("dashboard websocket should connect");
 
     let initial = read_json_message(&mut dashboard_ws).await;
-    assert_eq!(initial["summary"]["connected_sim_count"], 0);
+    assert_eq!(initial["summary"]["live_summary"]["connected_sim_count"], 0);
+    assert_eq!(initial["summary"]["analytics_meta"]["is_stale"], true);
 
     let (mut ingest_ws, _) = connect_async(format!("{base_url}/ws/ingest"))
         .await
@@ -73,8 +74,10 @@ async fn dashboard_websocket_receives_update_after_ingest_websocket_events() {
         .expect("food_drop send");
 
     let update = wait_for_json_message(&mut dashboard_ws, |json| {
-        json["summary"]["connected_sim_count"] == 1
-            && json["summary"]["loose_food_count"] == 1
+        json["summary"]["live_summary"]["connected_sim_count"] == 1
+            && json["summary"]["live_summary"]["loose_food_count"] == 1
+            && json["summary"]["analytics_summary"]["occupied_cell_count"] == 1
+            && json["summary"]["analytics_meta"]["is_stale"] == false
             && json["sims"][0]["sim_id"] == "sim-dashboard"
             && json["sims"][0]["ant_count"] == 26
             && json["sims"][0]["drop_count"] == 1
@@ -82,11 +85,11 @@ async fn dashboard_websocket_receives_update_after_ingest_websocket_events() {
     })
     .await;
 
-    assert_eq!(update["summary"]["connected_sim_count"], 1);
+    assert_eq!(update["summary"]["live_summary"]["connected_sim_count"], 1);
 }
 
 #[tokio::test]
-async fn dashboard_websocket_starts_stale_then_catches_up_after_direct_ingest() {
+async fn dashboard_websocket_exposes_live_counts_immediately_then_analytics_catch_up_after_direct_ingest() {
     let state = AppState::new();
     state.apply_event(EventEnvelope {
         event_type: "sim_hello".into(),
@@ -127,19 +130,66 @@ async fn dashboard_websocket_starts_stale_then_catches_up_after_direct_ingest() 
         .expect("dashboard websocket should connect");
 
     let initial = read_json_message(&mut dashboard_ws).await;
-    assert_eq!(initial["summary"]["connected_sim_count"], 0);
-    assert_eq!(initial["summary"]["loose_food_count"], 0);
+    assert_eq!(initial["summary"]["live_summary"]["connected_sim_count"], 1);
+    assert_eq!(initial["summary"]["live_summary"]["loose_food_count"], 1);
+    assert_eq!(initial["summary"]["analytics_summary"]["occupied_cell_count"], 0);
+    assert_eq!(initial["summary"]["analytics_meta"]["is_stale"], true);
 
     let update = wait_for_json_message(&mut dashboard_ws, |json| {
-        json["summary"]["connected_sim_count"] == 1
-            && json["summary"]["loose_food_count"] == 1
+        json["summary"]["live_summary"]["connected_sim_count"] == 1
+            && json["summary"]["live_summary"]["loose_food_count"] == 1
+            && json["summary"]["analytics_summary"]["occupied_cell_count"] == 1
             && json["sims"][0]["sim_id"] == "sim-lazy-dashboard"
             && json["sims"][0]["drop_count"] == 1
             && json["sims"][0]["loose_food_count"] == 1
     })
     .await;
 
-    assert_eq!(update["summary"]["connected_sim_count"], 1);
+    assert_eq!(update["summary"]["live_summary"]["connected_sim_count"], 1);
+}
+
+#[tokio::test]
+async fn dashboard_websocket_receives_live_only_updates_without_analytics_recompute() {
+    let state = AppState::new();
+    let base_url = spawn_test_server(state.clone()).await;
+
+    let (mut dashboard_ws, _) = connect_async(format!("{base_url}/ws/dashboard"))
+        .await
+        .expect("dashboard websocket should connect");
+
+    let initial = read_json_message(&mut dashboard_ws).await;
+    assert_eq!(initial["summary"]["live_summary"]["connected_sim_count"], 0);
+
+    state
+        .apply_event(EventEnvelope {
+            event_type: "sim_hello".into(),
+            sim_id: "sim-live-only".into(),
+            seq: 1,
+            timestamp_ms: 0,
+            payload: EventPayload::SimHello(HelloPayload {
+                sim_name: "sim-live-only".into(),
+                source: "test".into(),
+                session_started_ms: 0,
+                world_width: 1280.0,
+                world_height: 720.0,
+                ant_count: 26,
+                food_count: 0,
+            }),
+        })
+        .expect("sim_hello should be accepted");
+
+    let update = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        wait_for_json_message(&mut dashboard_ws, |json| {
+            json["summary"]["live_summary"]["connected_sim_count"] == 1
+                && json["sims"][0]["sim_id"] == "sim-live-only"
+        }),
+    )
+    .await
+    .expect("dashboard should receive live-only sim_hello update within 500ms");
+
+    assert_eq!(update["summary"]["live_summary"]["connected_sim_count"], 1);
+    assert_eq!(update["summary"]["analytics_meta"]["is_stale"], true);
 }
 
 async fn spawn_test_server(state: AppState) -> String {

--- a/backend-rust/tests/ws_parity.rs
+++ b/backend-rust/tests/ws_parity.rs
@@ -1,0 +1,186 @@
+use std::net::SocketAddr;
+
+use futures_util::{SinkExt, StreamExt};
+use gatherers_backend_rust::{
+    app::{AppState, build_router_with_state},
+    protocol::{
+        EventEnvelope, EventPayload, FoodDropPayload, HelloPayload,
+    },
+};
+use serde_json::Value;
+use tokio::net::TcpListener;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+#[tokio::test]
+async fn dashboard_websocket_receives_update_after_ingest_websocket_events() {
+    let state = AppState::new();
+    let base_url = spawn_test_server(state.clone()).await;
+
+    let (mut dashboard_ws, _) = connect_async(format!("{base_url}/ws/dashboard"))
+        .await
+        .expect("dashboard websocket should connect");
+
+    let initial = read_json_message(&mut dashboard_ws).await;
+    assert_eq!(initial["summary"]["connected_sim_count"], 0);
+
+    let (mut ingest_ws, _) = connect_async(format!("{base_url}/ws/ingest"))
+        .await
+        .expect("ingest websocket should connect");
+
+    ingest_ws
+        .send(Message::Text(
+            serde_json::to_string(&EventEnvelope {
+                event_type: "sim_hello".into(),
+                sim_id: "sim-dashboard".into(),
+                seq: 1,
+                timestamp_ms: 0,
+                payload: EventPayload::SimHello(HelloPayload {
+                    sim_name: "sim-dashboard".into(),
+                    source: "rust-bevy".into(),
+                    session_started_ms: 0,
+                    world_width: 1280.0,
+                    world_height: 720.0,
+                    ant_count: 26,
+                    food_count: 1,
+                }),
+            })
+            .expect("sim_hello json")
+            .into(),
+        ))
+        .await
+        .expect("sim_hello send");
+    ingest_ws
+        .send(Message::Text(
+            serde_json::to_string(&EventEnvelope {
+                event_type: "food_drop".into(),
+                sim_id: "sim-dashboard".into(),
+                seq: 2,
+                timestamp_ms: 0,
+                payload: EventPayload::FoodDrop(FoodDropPayload {
+                    ant_id: Some("ant-1".into()),
+                    food_id: "food-1".into(),
+                    x: 25.0,
+                    y: 25.0,
+                    direction_x: Some(0.0),
+                    direction_y: Some(1.0),
+                    frame: Some(2),
+                }),
+            })
+            .expect("food_drop json")
+            .into(),
+        ))
+        .await
+        .expect("food_drop send");
+
+    let update = wait_for_json_message(&mut dashboard_ws, |json| {
+        json["summary"]["connected_sim_count"] == 1
+            && json["summary"]["loose_food_count"] == 1
+            && json["sims"][0]["sim_id"] == "sim-dashboard"
+            && json["sims"][0]["ant_count"] == 26
+            && json["sims"][0]["drop_count"] == 1
+            && json["sims"][0]["loose_food_count"] == 1
+    })
+    .await;
+
+    assert_eq!(update["summary"]["connected_sim_count"], 1);
+}
+
+#[tokio::test]
+async fn dashboard_websocket_starts_stale_then_catches_up_after_direct_ingest() {
+    let state = AppState::new();
+    state.apply_event(EventEnvelope {
+        event_type: "sim_hello".into(),
+        sim_id: "sim-lazy-dashboard".into(),
+        seq: 1,
+        timestamp_ms: 0,
+        payload: EventPayload::SimHello(HelloPayload {
+            sim_name: "sim-lazy-dashboard".into(),
+            source: "rust-bevy".into(),
+            session_started_ms: 0,
+            world_width: 1280.0,
+            world_height: 720.0,
+            ant_count: 26,
+            food_count: 1,
+        }),
+    })
+    .expect("sim_hello should be accepted");
+    state.apply_event(EventEnvelope {
+        event_type: "food_drop".into(),
+        sim_id: "sim-lazy-dashboard".into(),
+        seq: 2,
+        timestamp_ms: 0,
+        payload: EventPayload::FoodDrop(FoodDropPayload {
+            ant_id: Some("ant-1".into()),
+            food_id: "food-1".into(),
+            x: 12.0,
+            y: 18.0,
+            direction_x: Some(0.0),
+            direction_y: Some(1.0),
+            frame: Some(2),
+        }),
+    })
+    .expect("food_drop should be accepted");
+
+    let base_url = spawn_test_server(state.clone()).await;
+    let (mut dashboard_ws, _) = connect_async(format!("{base_url}/ws/dashboard"))
+        .await
+        .expect("dashboard websocket should connect");
+
+    let initial = read_json_message(&mut dashboard_ws).await;
+    assert_eq!(initial["summary"]["connected_sim_count"], 0);
+    assert_eq!(initial["summary"]["loose_food_count"], 0);
+
+    let update = wait_for_json_message(&mut dashboard_ws, |json| {
+        json["summary"]["connected_sim_count"] == 1
+            && json["summary"]["loose_food_count"] == 1
+            && json["sims"][0]["sim_id"] == "sim-lazy-dashboard"
+            && json["sims"][0]["drop_count"] == 1
+            && json["sims"][0]["loose_food_count"] == 1
+    })
+    .await;
+
+    assert_eq!(update["summary"]["connected_sim_count"], 1);
+}
+
+async fn spawn_test_server(state: AppState) -> String {
+    let router = build_router_with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test listener");
+    let addr: SocketAddr = listener.local_addr().expect("listener addr");
+
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("test server should run");
+    });
+
+    format!("ws://{}", addr)
+}
+
+async fn read_json_message(
+    ws: &mut tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+) -> Value {
+    let message = ws
+        .next()
+        .await
+        .expect("websocket message")
+        .expect("websocket result");
+    match message {
+        Message::Text(text) => serde_json::from_str(&text).expect("json text"),
+        other => panic!("expected text websocket message, got {other:?}"),
+    }
+}
+
+async fn wait_for_json_message<F>(
+    ws: &mut tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    match_json: F,
+) -> Value
+where
+    F: Fn(&Value) -> bool,
+{
+    loop {
+        let json = read_json_message(ws).await;
+        if match_json(&json) {
+            return json;
+        }
+    }
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -79,6 +79,51 @@ GATHERERS_RUN_LONG_STRESS=1 \
 go test ./internal/server -run TestLongStressDashboardReflectsSustainedLoad -count=1
 ```
 
+Run the opt-in breakpoint finder:
+
+```bash
+cd backend
+GATHERERS_FIND_BREAKPOINT=1 \
+GATHERERS_BREAKPOINT_START_CLIENTS=25 \
+GATHERERS_BREAKPOINT_MAX_CLIENTS=150 \
+GATHERERS_BREAKPOINT_STEP=25 \
+go test ./internal/server -run TestFindBreakpointUnderRampLoad -count=1 -v
+```
+
+Useful breakpoint knobs:
+
+- `GATHERERS_BREAKPOINT_START_CLIENTS`, `GATHERERS_BREAKPOINT_MAX_CLIENTS`, `GATHERERS_BREAKPOINT_STEP` control the client-count ramp.
+- `GATHERERS_BREAKPOINT_ACTIVITY_TRIPLETS` controls how many pickup/move/drop triplets each client sends per step.
+- `GATHERERS_BREAKPOINT_SEND_TIMEOUT`, `GATHERERS_BREAKPOINT_SETTLE_TIMEOUT`, and `GATHERERS_BREAKPOINT_STALL_TIMEOUT` control failure timing.
+- `GATHERERS_BREAKPOINT_INTERVAL`, `GATHERERS_BREAKPOINT_STARTUP_FOOD_COUNT`, and `GATHERERS_BREAKPOINT_ANT_COUNT` control per-client event shape.
+
+Failure meanings:
+
+- `client_error`: at least one client could not connect or finish writing its step workload.
+- `exact_mismatch`: the backend totals did not catch up to the totals that clients successfully sent before the settle timeout expired.
+- `progress_stall`: backend-visible counters stopped changing for the configured stall window while clients were still expected to be active.
+
+Run the standalone breakpoint CLI:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --start-clients 25 \
+  --max-clients 150 \
+  --step 25
+```
+
+Point the CLI at a manually running backend instead of spawning an in-process one:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18080 \
+  --start-clients 25 \
+  --max-clients 150 \
+  --step 25
+```
+
 ## Realtime dashboard demo
 
 Start the backend on a known port:

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,6 +12,8 @@ Protocol and scope are defined in `../docs/go-backend-v1-contract.md`.
 
 For a runtime-oriented view of data flow, background aggregation, and dashboard demand handling, see `../docs/go-backend-runtime-architecture.md`.
 
+For one recorded local breakpoint-search run and how to interpret it, see `../docs/go-backend-breakpoint-findings.md`.
+
 ## Layout
 
 - `cmd/server` for the entrypoint

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,8 @@ For a runtime-oriented view of data flow, background aggregation, and dashboard 
 
 For one recorded local breakpoint-search run and how to interpret it, see `../docs/go-backend-breakpoint-findings.md`.
 
+For the Rust parity backend, library choices, transport seam, and Go-vs-Rust comparison workflow, see `../docs/rust-backend-notes.md` and `../backend-rust/README.md`.
+
 ## Layout
 
 - `cmd/server` for the entrypoint

--- a/backend/cmd/breakpoint/main.go
+++ b/backend/cmd/breakpoint/main.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/antont/gatherers/backend/internal/config"
+	"github.com/antont/gatherers/backend/internal/loadsim"
+	backendserver "github.com/antont/gatherers/backend/internal/server"
+)
+
+func main() {
+	var (
+		baseURL           = flag.String("base-url", "", "existing backend base URL; omit to spawn an in-process backend")
+		startClients      = flag.Int("start-clients", 25, "starting client count")
+		maxClients        = flag.Int("max-clients", 100, "maximum client count")
+		stepClients       = flag.Int("step", 25, "client-count increment")
+		interval          = flag.Duration("interval", 5*time.Millisecond, "per-event timestamp interval")
+		initialFoodCount  = flag.Int("startup-food-count", 80, "startup food count per client")
+		initialAntCount   = flag.Int("ant-count", 26, "startup ant count per client")
+		activityTriplets  = flag.Int("activity-triplets", 20, "pickup/move/drop triplets per client")
+		sendTimeout       = flag.Duration("send-timeout", 5*time.Second, "per-step send timeout")
+		settleTimeout     = flag.Duration("settle-timeout", 5*time.Second, "per-step settle timeout")
+		stallTimeout      = flag.Duration("stall-timeout", 1500*time.Millisecond, "stall timeout while clients are still sending")
+		progressPollEvery = flag.Duration("poll-interval", 100*time.Millisecond, "backend polling interval during a step")
+		globalTimeout     = flag.Duration("timeout", 30*time.Second, "overall search timeout")
+		seed              = flag.Int64("seed", 700, "base seed for deterministic client generation")
+	)
+	flag.Parse()
+
+	runBaseURL, closeFn, spawned, err := resolveBaseURL(strings.TrimRight(*baseURL, "/"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+	defer closeFn()
+
+	if spawned {
+		fmt.Printf("spawned in-process backend at %s\n", runBaseURL)
+	} else {
+		fmt.Printf("using backend at %s\n", runBaseURL)
+	}
+
+	base := loadsim.BreakpointStep{
+		Name:              "breakpoint",
+		BaseURL:           runBaseURL,
+		Interval:          *interval,
+		InitialFoodCount:  *initialFoodCount,
+		InitialAntCount:   *initialAntCount,
+		ActivityTriplets:  *activityTriplets,
+		SendTimeout:       *sendTimeout,
+		SettleTimeout:     *settleTimeout,
+		StallTimeout:      *stallTimeout,
+		ProgressPollEvery: *progressPollEvery,
+		Seed:              *seed,
+	}
+	steps := loadsim.BuildClientCountRamp(*startClients, *maxClients, *stepClients, base)
+	if len(steps) == 0 {
+		fmt.Fprintln(os.Stderr, "error: no breakpoint steps were generated")
+		os.Exit(2)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *globalTimeout)
+	defer cancel()
+
+	report, err := loadsim.RunBreakpointSearch(ctx, loadsim.BreakpointSearchConfig{
+		Steps: steps,
+		RunStep: func(ctx context.Context, step loadsim.BreakpointStep) (loadsim.BreakpointStepResult, error) {
+			fmt.Printf("running step: client_count=%d interval=%s startup_food=%d triplets=%d\n", step.ClientCount, step.Interval, step.InitialFoodCount, step.ActivityTriplets)
+			return loadsim.RunBackendBreakpointStep(ctx, step)
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "search failed: %v\n", err)
+		os.Exit(2)
+	}
+
+	if report.FirstBad != nil {
+		fmt.Printf("last good: %s\n", describeResult(report.LastGood))
+		fmt.Printf("first bad: %s\n", describeResult(report.FirstBad))
+		fmt.Printf("failure reason: %s - %s\n", report.FirstBad.Failure.Kind, report.FirstBad.Failure.Message)
+		if len(report.FirstBad.Failure.ClientErrors) > 0 {
+			fmt.Printf("client errors: %v\n", report.FirstBad.Failure.ClientErrors)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("strongest passing configuration: %s\n", describeResult(report.LastGood))
+}
+
+func resolveBaseURL(baseURL string) (string, func(), bool, error) {
+	if baseURL != "" {
+		return baseURL, func() {}, false, nil
+	}
+
+	srv := backendserver.New(config.Config{})
+	server := httptest.NewServer(srv.Handler())
+	return server.URL, server.Close, true, nil
+}
+
+func describeResult(result *loadsim.BreakpointStepResult) string {
+	if result == nil {
+		return "none"
+	}
+	return fmt.Sprintf(
+		"client_count=%d expected=%+v observed=%+v elapsed=%s",
+		result.Step.ClientCount,
+		result.Expected,
+		result.Observed,
+		result.Elapsed.Round(time.Millisecond),
+	)
+}

--- a/backend/internal/loadsim/breakpoint.go
+++ b/backend/internal/loadsim/breakpoint.go
@@ -175,7 +175,7 @@ func RunBackendBreakpointStep(ctx context.Context, step BreakpointStep) (Breakpo
 		case <-doneCh:
 			goto completed
 		case <-progressTicker.C:
-			observed, err := fetchBreakpointTotals(sendCtx, step.BaseURL, step.SimIDPrefix)
+			observed, err := fetchBreakpointTotals(sendCtx, step.BaseURL, step.SimIDPrefix, step.InitialFoodCount)
 			if err != nil {
 				return BreakpointStepResult{}, err
 			}
@@ -200,7 +200,7 @@ func RunBackendBreakpointStep(ctx context.Context, step BreakpointStep) (Breakpo
 
 completed:
 	expected, clientErrors := collectBreakpointResults(totalsCh, errCh)
-	observed, err := waitForBreakpointTotals(sendCtx, step.BaseURL, step.SimIDPrefix, expected, step.SettleTimeout)
+	observed, err := waitForBreakpointTotals(sendCtx, step.BaseURL, step.SimIDPrefix, step.InitialFoodCount, expected, step.SettleTimeout)
 	if err != nil {
 		return BreakpointStepResult{}, err
 	}
@@ -380,11 +380,11 @@ func collectBreakpointResults(totalsCh <-chan BreakpointTotals, errCh <-chan err
 	return expected, clientErrors
 }
 
-func waitForBreakpointTotals(ctx context.Context, baseURL, simIDPrefix string, expected BreakpointTotals, timeout time.Duration) (BreakpointTotals, error) {
+func waitForBreakpointTotals(ctx context.Context, baseURL, simIDPrefix string, initialFoodCount int, expected BreakpointTotals, timeout time.Duration) (BreakpointTotals, error) {
 	deadline := time.Now().Add(timeout)
 	var last BreakpointTotals
 	for time.Now().Before(deadline) {
-		observed, err := fetchBreakpointTotals(ctx, baseURL, simIDPrefix)
+		observed, err := fetchBreakpointTotals(ctx, baseURL, simIDPrefix, initialFoodCount)
 		if err != nil {
 			return BreakpointTotals{}, err
 		}
@@ -409,7 +409,7 @@ type breakpointSimSummary struct {
 	LooseFoodCount int    `json:"loose_food_count"`
 }
 
-func fetchBreakpointTotals(ctx context.Context, baseURL, simIDPrefix string) (BreakpointTotals, error) {
+func fetchBreakpointTotals(ctx context.Context, baseURL, simIDPrefix string, initialFoodCount int) (BreakpointTotals, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/sims", nil)
 	if err != nil {
 		return BreakpointTotals{}, err
@@ -436,6 +436,13 @@ func fetchBreakpointTotals(ctx context.Context, baseURL, simIDPrefix string) (Br
 		totals.DropCount += sim.DropCount
 		totals.TurnMoveCount += sim.TurnMoveCount
 		totals.LooseFoodCount += sim.LooseFoodCount
+	}
+	if initialFoodCount > 0 {
+		numerator := totals.LooseFoodCount + totals.PickupCount - totals.DropCount
+		if numerator >= 0 && numerator%initialFoodCount == 0 {
+			snapshotCount := numerator / initialFoodCount
+			totals.SentEvents = totals.ConnectedSims + snapshotCount + totals.PickupCount + totals.DropCount + totals.TurnMoveCount
+		}
 	}
 	return totals, nil
 }

--- a/backend/internal/loadsim/breakpoint.go
+++ b/backend/internal/loadsim/breakpoint.go
@@ -1,0 +1,441 @@
+package loadsim
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+type BreakpointFailureKind string
+
+const (
+	BreakpointFailureClientError   BreakpointFailureKind = "client_error"
+	BreakpointFailureExactMismatch BreakpointFailureKind = "exact_mismatch"
+	BreakpointFailureProgressStall BreakpointFailureKind = "progress_stall"
+)
+
+type BreakpointStep struct {
+	Name              string
+	BaseURL           string
+	SimIDPrefix       string
+	ClientCount       int
+	ActivityTriplets  int
+	Interval          time.Duration
+	InitialAntCount   int
+	InitialFoodCount  int
+	Seed              int64
+	SendTimeout       time.Duration
+	SettleTimeout     time.Duration
+	StallTimeout      time.Duration
+	ProgressPollEvery time.Duration
+}
+
+type BreakpointTotals struct {
+	SentEvents     int
+	ConnectedSims  int
+	PickupCount    int
+	DropCount      int
+	TurnMoveCount  int
+	LooseFoodCount int
+}
+
+type BreakpointFailure struct {
+	Kind         BreakpointFailureKind
+	Message      string
+	ClientErrors []string
+}
+
+type BreakpointStepResult struct {
+	Step      BreakpointStep
+	Expected  BreakpointTotals
+	Observed  BreakpointTotals
+	Failure   *BreakpointFailure
+	StartedAt time.Time
+	Elapsed   time.Duration
+}
+
+type BreakpointSearchConfig struct {
+	Steps   []BreakpointStep
+	RunStep func(context.Context, BreakpointStep) (BreakpointStepResult, error)
+}
+
+type BreakpointReport struct {
+	LastGood *BreakpointStepResult
+	FirstBad *BreakpointStepResult
+	Results  []BreakpointStepResult
+}
+
+func RunBreakpointSearch(ctx context.Context, cfg BreakpointSearchConfig) (BreakpointReport, error) {
+	if len(cfg.Steps) == 0 {
+		return BreakpointReport{}, errors.New("breakpoint search requires at least one step")
+	}
+	if cfg.RunStep == nil {
+		return BreakpointReport{}, errors.New("breakpoint search requires a step runner")
+	}
+
+	report := BreakpointReport{
+		Results: make([]BreakpointStepResult, 0, len(cfg.Steps)),
+	}
+
+	for _, step := range cfg.Steps {
+		result, err := cfg.RunStep(ctx, step)
+		if err != nil {
+			return report, err
+		}
+		report.Results = append(report.Results, result)
+		if result.Failure != nil {
+			failed := result
+			report.FirstBad = &failed
+			return report, nil
+		}
+		passed := result
+		report.LastGood = &passed
+	}
+
+	return report, nil
+}
+
+func BuildClientCountRamp(start, max, increment int, base BreakpointStep) []BreakpointStep {
+	if start <= 0 || max < start || increment <= 0 {
+		return nil
+	}
+
+	steps := make([]BreakpointStep, 0, 1+(max-start)/increment)
+	for clientCount := start; clientCount <= max; clientCount += increment {
+		step := base
+		step.ClientCount = clientCount
+		if step.Name == "" {
+			step.Name = fmt.Sprintf("clients-%d", clientCount)
+		} else {
+			step.Name = fmt.Sprintf("%s-%d", base.Name, clientCount)
+		}
+		steps = append(steps, step)
+	}
+	return steps
+}
+
+func RunBackendBreakpointStep(ctx context.Context, step BreakpointStep) (BreakpointStepResult, error) {
+	step = normalizedBreakpointStep(step)
+	if step.BaseURL == "" {
+		return BreakpointStepResult{}, errors.New("breakpoint step requires a base URL")
+	}
+
+	startedAt := time.Now()
+	plannedSentEvents := step.ClientCount * (2 + step.ActivityTriplets*3)
+	actualPrefix := fmt.Sprintf("%s-%d", step.SimIDPrefix, startedAt.UnixNano())
+	step.SimIDPrefix = actualPrefix
+
+	sendCtx, cancel := context.WithTimeout(ctx, step.SendTimeout)
+	defer cancel()
+
+	start := make(chan struct{})
+	errCh := make(chan error, step.ClientCount)
+	totalsCh := make(chan BreakpointTotals, step.ClientCount)
+	doneCh := make(chan struct{})
+	var sentCounters atomicBreakpointTotals
+	var wg sync.WaitGroup
+
+	for i := 0; i < step.ClientCount; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+
+			clientTotals, err := runBreakpointClient(sendCtx, step, index, &sentCounters)
+			totalsCh <- clientTotals
+			errCh <- err
+		}(i)
+	}
+
+	close(start)
+	go func() {
+		wg.Wait()
+		close(totalsCh)
+		close(errCh)
+		close(doneCh)
+	}()
+
+	var lastObserved BreakpointTotals
+	lastProgressAt := time.Now()
+	progressTicker := time.NewTicker(step.ProgressPollEvery)
+	defer progressTicker.Stop()
+
+	var progressFailure *BreakpointFailure
+	for {
+		select {
+		case <-doneCh:
+			goto completed
+		case <-progressTicker.C:
+			observed, err := fetchBreakpointTotals(sendCtx, step.BaseURL, step.SimIDPrefix)
+			if err != nil {
+				return BreakpointStepResult{}, err
+			}
+			if observed != lastObserved {
+				lastObserved = observed
+				lastProgressAt = time.Now()
+			}
+			if sentCounters.SentEvents() < int64(plannedSentEvents) && time.Since(lastProgressAt) >= step.StallTimeout {
+				progressFailure = &BreakpointFailure{
+					Kind:    BreakpointFailureProgressStall,
+					Message: fmt.Sprintf("backend made no observable progress for %s while clients were still sending", step.StallTimeout),
+				}
+				cancel()
+				<-doneCh
+				goto completed
+			}
+		case <-sendCtx.Done():
+			<-doneCh
+			goto completed
+		}
+	}
+
+completed:
+	expected, clientErrors := collectBreakpointResults(totalsCh, errCh)
+	observed, err := waitForBreakpointTotals(sendCtx, step.BaseURL, step.SimIDPrefix, expected, step.SettleTimeout)
+	if err != nil {
+		return BreakpointStepResult{}, err
+	}
+
+	result := BreakpointStepResult{
+		Step:      step,
+		Expected:  expected,
+		Observed:  observed,
+		StartedAt: startedAt,
+		Elapsed:   time.Since(startedAt),
+	}
+
+	if progressFailure != nil {
+		progressFailure.ClientErrors = clientErrors
+		result.Failure = progressFailure
+		return result, nil
+	}
+	if len(clientErrors) > 0 {
+		result.Failure = &BreakpointFailure{
+			Kind:         BreakpointFailureClientError,
+			Message:      "one or more load clients failed while sending events",
+			ClientErrors: clientErrors,
+		}
+		return result, nil
+	}
+	if observed != expected {
+		result.Failure = &BreakpointFailure{
+			Kind:    BreakpointFailureExactMismatch,
+			Message: "backend totals did not match successfully sent totals before settle timeout",
+		}
+	}
+
+	return result, nil
+}
+
+func normalizedBreakpointStep(step BreakpointStep) BreakpointStep {
+	if step.Name == "" {
+		step.Name = "breakpoint"
+	}
+	if step.SimIDPrefix == "" {
+		step.SimIDPrefix = strings.ReplaceAll(step.Name, " ", "-")
+	}
+	if step.ClientCount <= 0 {
+		step.ClientCount = 1
+	}
+	if step.ActivityTriplets <= 0 {
+		step.ActivityTriplets = 20
+	}
+	if step.Interval <= 0 {
+		step.Interval = 5 * time.Millisecond
+	}
+	if step.InitialAntCount <= 0 {
+		step.InitialAntCount = 26
+	}
+	if step.InitialFoodCount <= 0 {
+		step.InitialFoodCount = 80
+	}
+	if step.SendTimeout <= 0 {
+		step.SendTimeout = 5 * time.Second
+	}
+	if step.SettleTimeout <= 0 {
+		step.SettleTimeout = 5 * time.Second
+	}
+	if step.StallTimeout <= 0 {
+		step.StallTimeout = 1500 * time.Millisecond
+	}
+	if step.ProgressPollEvery <= 0 {
+		step.ProgressPollEvery = 100 * time.Millisecond
+	}
+	return step
+}
+
+type atomicBreakpointTotals struct {
+	sentEvents     atomic.Int64
+	connectedSims  atomic.Int64
+	pickupCount    atomic.Int64
+	dropCount      atomic.Int64
+	turnMoveCount  atomic.Int64
+	looseFoodCount atomic.Int64
+}
+
+func (t *atomicBreakpointTotals) record(event Event, initialFoodCount int) {
+	t.sentEvents.Add(1)
+	switch event.Type {
+	case "sim_hello":
+		t.connectedSims.Add(1)
+	case "sim_food_snapshot":
+		t.looseFoodCount.Add(int64(initialFoodCount))
+	case "food_pickup":
+		t.pickupCount.Add(1)
+		t.looseFoodCount.Add(-1)
+	case "food_drop":
+		t.dropCount.Add(1)
+		t.looseFoodCount.Add(1)
+	case "ant_turn_move":
+		t.turnMoveCount.Add(1)
+	}
+}
+
+func (t *atomicBreakpointTotals) SentEvents() int64 {
+	return t.sentEvents.Load()
+}
+
+func runBreakpointClient(ctx context.Context, step BreakpointStep, index int, totals *atomicBreakpointTotals) (BreakpointTotals, error) {
+	wsURL := ingestWebsocketURL(step.BaseURL)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		return BreakpointTotals{}, err
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	stream := NewClientEventStream(ClientOptions{
+		SimID:            fmt.Sprintf("%s-%03d", step.SimIDPrefix, index),
+		SimName:          fmt.Sprintf("%s-%03d", step.SimIDPrefix, index),
+		Seed:             step.Seed + int64(index),
+		StartX:           float64(index),
+		StartY:           float64(index),
+		StartFood:        fmt.Sprintf("%s-food-%03d", step.SimIDPrefix, index),
+		StartAnt:         fmt.Sprintf("%s-ant-%03d", step.SimIDPrefix, index),
+		InitialAntCount:  step.InitialAntCount,
+		InitialFoodCount: step.InitialFoodCount,
+		Interval:         step.Interval,
+	})
+
+	local := BreakpointTotals{}
+	for i := 0; i < 2+step.ActivityTriplets*3; i++ {
+		event := stream.NextEvent()
+		if err := wsjson.Write(ctx, conn, event); err != nil {
+			if ctx.Err() != nil {
+				return local, ctx.Err()
+			}
+			return local, err
+		}
+		totals.record(event, step.InitialFoodCount)
+		local.record(event, step.InitialFoodCount)
+	}
+
+	return local, nil
+}
+
+func (t *BreakpointTotals) record(event Event, initialFoodCount int) {
+	t.SentEvents++
+	switch event.Type {
+	case "sim_hello":
+		t.ConnectedSims++
+	case "sim_food_snapshot":
+		t.LooseFoodCount += initialFoodCount
+	case "food_pickup":
+		t.PickupCount++
+		t.LooseFoodCount--
+	case "food_drop":
+		t.DropCount++
+		t.LooseFoodCount++
+	case "ant_turn_move":
+		t.TurnMoveCount++
+	}
+}
+
+func collectBreakpointResults(totalsCh <-chan BreakpointTotals, errCh <-chan error) (BreakpointTotals, []string) {
+	var expected BreakpointTotals
+	for totals := range totalsCh {
+		expected.SentEvents += totals.SentEvents
+		expected.ConnectedSims += totals.ConnectedSims
+		expected.PickupCount += totals.PickupCount
+		expected.DropCount += totals.DropCount
+		expected.TurnMoveCount += totals.TurnMoveCount
+		expected.LooseFoodCount += totals.LooseFoodCount
+	}
+
+	var clientErrors []string
+	for err := range errCh {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			clientErrors = append(clientErrors, err.Error())
+		}
+	}
+
+	return expected, clientErrors
+}
+
+func waitForBreakpointTotals(ctx context.Context, baseURL, simIDPrefix string, expected BreakpointTotals, timeout time.Duration) (BreakpointTotals, error) {
+	deadline := time.Now().Add(timeout)
+	var last BreakpointTotals
+	for time.Now().Before(deadline) {
+		observed, err := fetchBreakpointTotals(ctx, baseURL, simIDPrefix)
+		if err != nil {
+			return BreakpointTotals{}, err
+		}
+		last = observed
+		if observed == expected {
+			return observed, nil
+		}
+		select {
+		case <-ctx.Done():
+			return last, nil
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return last, nil
+}
+
+type breakpointSimSummary struct {
+	SimID          string `json:"sim_id"`
+	PickupCount    int    `json:"pickup_count"`
+	DropCount      int    `json:"drop_count"`
+	TurnMoveCount  int    `json:"turn_move_count"`
+	LooseFoodCount int    `json:"loose_food_count"`
+}
+
+func fetchBreakpointTotals(ctx context.Context, baseURL, simIDPrefix string) (BreakpointTotals, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/sims", nil)
+	if err != nil {
+		return BreakpointTotals{}, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return BreakpointTotals{}, err
+	}
+	defer resp.Body.Close()
+
+	var sims []breakpointSimSummary
+	if err := json.NewDecoder(resp.Body).Decode(&sims); err != nil {
+		return BreakpointTotals{}, err
+	}
+
+	var totals BreakpointTotals
+	for _, sim := range sims {
+		if !strings.HasPrefix(sim.SimID, simIDPrefix) {
+			continue
+		}
+		totals.ConnectedSims++
+		totals.PickupCount += sim.PickupCount
+		totals.DropCount += sim.DropCount
+		totals.TurnMoveCount += sim.TurnMoveCount
+		totals.LooseFoodCount += sim.LooseFoodCount
+	}
+	return totals, nil
+}

--- a/backend/internal/loadsim/stream_test.go
+++ b/backend/internal/loadsim/stream_test.go
@@ -130,6 +130,84 @@ func TestStartupFoodSnapshotUsesClusteredPositions(t *testing.T) {
 	}
 }
 
+func TestRunBreakpointSearchReturnsLastGoodAndFirstBadStep(t *testing.T) {
+	steps := []BreakpointStep{
+		{Name: "good", ClientCount: 10},
+		{Name: "bad", ClientCount: 20},
+	}
+
+	callCount := 0
+	report, err := RunBreakpointSearch(context.Background(), BreakpointSearchConfig{
+		Steps: steps,
+		RunStep: func(_ context.Context, step BreakpointStep) (BreakpointStepResult, error) {
+			callCount++
+			if step.Name == "good" {
+				return BreakpointStepResult{
+					Step: step,
+					Expected: BreakpointTotals{
+						SentEvents:     120,
+						ConnectedSims:  10,
+						PickupCount:    40,
+						DropCount:      40,
+						TurnMoveCount:  40,
+						LooseFoodCount: 800,
+					},
+					Observed: BreakpointTotals{
+						SentEvents:     120,
+						ConnectedSims:  10,
+						PickupCount:    40,
+						DropCount:      40,
+						TurnMoveCount:  40,
+						LooseFoodCount: 800,
+					},
+				}, nil
+			}
+
+			return BreakpointStepResult{
+				Step: step,
+				Expected: BreakpointTotals{
+					SentEvents:     240,
+					ConnectedSims:  20,
+					PickupCount:    80,
+					DropCount:      80,
+					TurnMoveCount:  80,
+					LooseFoodCount: 1600,
+				},
+				Observed: BreakpointTotals{
+					SentEvents:     222,
+					ConnectedSims:  20,
+					PickupCount:    74,
+					DropCount:      74,
+					TurnMoveCount:  74,
+					LooseFoodCount: 1594,
+				},
+				Failure: &BreakpointFailure{
+					Kind:    BreakpointFailureExactMismatch,
+					Message: "exact totals diverged",
+				},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected breakpoint search to return structured results, got error: %v", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected breakpoint search to stop after the first failing step, got %d calls", callCount)
+	}
+	if report.LastGood == nil || report.LastGood.Step.Name != "good" {
+		t.Fatalf("expected last good step to be recorded, got %+v", report.LastGood)
+	}
+	if report.FirstBad == nil || report.FirstBad.Step.Name != "bad" {
+		t.Fatalf("expected first bad step to be recorded, got %+v", report.FirstBad)
+	}
+	if report.FirstBad.Failure == nil || report.FirstBad.Failure.Kind != BreakpointFailureExactMismatch {
+		t.Fatalf("expected exact mismatch failure, got %+v", report.FirstBad)
+	}
+	if report.FirstBad.Expected.SentEvents != 240 || report.FirstBad.Observed.SentEvents != 222 {
+		t.Fatalf("expected sent-vs-observed totals in failure report, got %+v", report.FirstBad)
+	}
+}
+
 func mustJSON(t *testing.T, value any) string {
 	t.Helper()
 

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -16,15 +15,29 @@ import (
 	"github.com/coder/websocket/wsjson"
 )
 
-func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
+func newAPITestTarget(t *testing.T) testTarget {
+	t.Helper()
 	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	return newTestTarget(t, srv.Handler())
+}
+
+func TestAPIServerUsesSharedTargetAbstraction(t *testing.T) {
+	target := newAPITestTarget(t)
+	defer target.closeFn()
+
+	if target.baseURL == "" {
+		t.Fatal("expected API tests to resolve a target base URL")
+	}
+}
+
+func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
+	target := newAPITestTarget(t)
+	defer target.closeFn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	wsURL := strings.Replace(target.baseURL, "http://", "ws://", 1) + "/ws/ingest"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
@@ -80,7 +93,7 @@ func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
 		}
 	}
 
-	summary := waitForSummary(t, testServer.URL, 1500*time.Millisecond, func(summary struct {
+	summary := waitForSummary(t, target.baseURL, 1500*time.Millisecond, func(summary struct {
 		ConnectedSimCount int `json:"connected_sim_count"`
 		LooseFoodCount    int `json:"loose_food_count"`
 	}) bool {
@@ -96,14 +109,13 @@ func TestSummaryReflectsEventsIngestedOverWebSocket(t *testing.T) {
 }
 
 func TestSummaryReadStartsDemandAndEventuallyRefreshesCachedSnapshot(t *testing.T) {
-	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	target := newAPITestTarget(t)
+	defer target.closeFn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	err := loadsim.SendEvents(ctx, testServer.URL, []loadsim.Event{
+	err := loadsim.SendEvents(ctx, target.baseURL, []loadsim.Event{
 		{
 			Type:        "sim_hello",
 			SimID:       "sim-lazy-api",
@@ -131,7 +143,7 @@ func TestSummaryReadStartsDemandAndEventuallyRefreshesCachedSnapshot(t *testing.
 		t.Fatalf("expected ingest events to succeed before demand starts: %v", err)
 	}
 
-	initial := fetchSummary(t, testServer.URL)
+	initial := fetchSummary(t, target.baseURL)
 	if initial.ConnectedSimCount != 0 || initial.LooseFoodCount != 0 {
 		t.Fatalf("expected first summary read to serve stale cached data before demand-driven refresh, got %+v", initial)
 	}
@@ -139,7 +151,7 @@ func TestSummaryReadStartsDemandAndEventuallyRefreshesCachedSnapshot(t *testing.
 	deadline := time.Now().Add(1500 * time.Millisecond)
 	last := initial
 	for time.Now().Before(deadline) {
-		last = fetchSummary(t, testServer.URL)
+		last = fetchSummary(t, target.baseURL)
 		if last.ConnectedSimCount == 1 && last.LooseFoodCount == 1 {
 			return
 		}
@@ -150,14 +162,13 @@ func TestSummaryReadStartsDemandAndEventuallyRefreshesCachedSnapshot(t *testing.
 }
 
 func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
-	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	target := newAPITestTarget(t)
+	defer target.closeFn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	wsURL := strings.Replace(target.baseURL, "http://", "ws://", 1) + "/ws/ingest"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
@@ -193,7 +204,7 @@ func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
 		}
 	}
 
-	sims := waitForSimSummaries(t, testServer.URL, 1500*time.Millisecond, func(sims []simSummaryResponse) bool {
+	sims := waitForSimSummaries(t, target.baseURL, 1500*time.Millisecond, func(sims []simSummaryResponse) bool {
 		return len(sims) == 1 && sims[0].SimID == "sim-startup" && sims[0].LooseFoodCount == 3
 	})
 
@@ -204,7 +215,7 @@ func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
 		t.Fatalf("expected startup snapshot to seed 3 loose food items, got %+v", sims[0])
 	}
 
-	summary := waitForSummary(t, testServer.URL, 1500*time.Millisecond, func(summary struct {
+	summary := waitForSummary(t, target.baseURL, 1500*time.Millisecond, func(summary struct {
 		ConnectedSimCount int `json:"connected_sim_count"`
 		LooseFoodCount    int `json:"loose_food_count"`
 	}) bool {
@@ -217,14 +228,13 @@ func TestStartupFoodSnapshotSeedsLooseFoodState(t *testing.T) {
 }
 
 func TestSummaryIncludesElapsedTimeAndEventRate(t *testing.T) {
-	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	target := newAPITestTarget(t)
+	defer target.closeFn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	wsURL := strings.Replace(target.baseURL, "http://", "ws://", 1) + "/ws/ingest"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
@@ -260,7 +270,7 @@ func TestSummaryIncludesElapsedTimeAndEventRate(t *testing.T) {
 		}
 	}
 
-	summary := waitForExtendedSummary(t, testServer.URL, 1500*time.Millisecond, func(summary struct {
+	summary := waitForExtendedSummary(t, target.baseURL, 1500*time.Millisecond, func(summary struct {
 		ElapsedSeconds  float64 `json:"elapsed_seconds"`
 		EventsPerSecond float64 `json:"events_per_second"`
 	}) bool {
@@ -276,14 +286,13 @@ func TestSummaryIncludesElapsedTimeAndEventRate(t *testing.T) {
 }
 
 func TestSimHelloAntCountAppearsInPerSimSummary(t *testing.T) {
-	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	target := newAPITestTarget(t)
+	defer target.closeFn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	wsURL := strings.Replace(target.baseURL, "http://", "ws://", 1) + "/ws/ingest"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
@@ -305,7 +314,7 @@ func TestSimHelloAntCountAppearsInPerSimSummary(t *testing.T) {
 		t.Fatalf("expected sim_hello to be accepted over websocket: %v", err)
 	}
 
-	sims := waitForSimSummaries(t, testServer.URL, 1500*time.Millisecond, func(sims []simSummaryResponse) bool {
+	sims := waitForSimSummaries(t, target.baseURL, 1500*time.Millisecond, func(sims []simSummaryResponse) bool {
 		return len(sims) == 1 && sims[0].SimID == "sim-meta" && sims[0].AntCount == 26
 	})
 
@@ -315,14 +324,13 @@ func TestSimHelloAntCountAppearsInPerSimSummary(t *testing.T) {
 }
 
 func TestDashboardShowsConnectedSimAndLooseFoodCounts(t *testing.T) {
-	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	target := newAPITestTarget(t)
+	defer target.closeFn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws/ingest"
+	wsURL := strings.Replace(target.baseURL, "http://", "ws://", 1) + "/ws/ingest"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("expected websocket ingest endpoint to accept connection: %v", err)
@@ -356,7 +364,7 @@ func TestDashboardShowsConnectedSimAndLooseFoodCounts(t *testing.T) {
 		}
 	}
 
-	resp, err := http.Get(testServer.URL + "/")
+	resp, err := http.Get(target.baseURL + "/")
 	if err != nil {
 		t.Fatalf("expected dashboard endpoint to respond: %v", err)
 	}
@@ -467,11 +475,10 @@ func waitForSimSummaries(t *testing.T, baseURL string, timeout time.Duration, ma
 }
 
 func TestDashboardPageBootstrapsRealtimeWebsocketUi(t *testing.T) {
-	srv := New(config.Config{})
-	testServer := httptest.NewServer(srv.Handler())
-	defer testServer.Close()
+	target := newAPITestTarget(t)
+	defer target.closeFn()
 
-	resp, err := http.Get(testServer.URL + "/")
+	resp, err := http.Get(target.baseURL + "/")
 	if err != nil {
 		t.Fatalf("expected dashboard endpoint to respond: %v", err)
 	}

--- a/backend/internal/server/server_long_stress_test.go
+++ b/backend/internal/server/server_long_stress_test.go
@@ -103,6 +103,59 @@ func TestFindBreakpointUnderRampLoad(t *testing.T) {
 	t.Logf("no breakpoint found up to %s", describeBreakpointResult(report.LastGood))
 }
 
+func TestExternalBackendRampLoadKeepsAPISimsResponsive(t *testing.T) {
+	if os.Getenv("GATHERERS_RUN_EXTERNAL_BREAKPOINT_REGRESSION") == "" {
+		t.Skip("set GATHERERS_RUN_EXTERNAL_BREAKPOINT_REGRESSION=1 to run the external backend regression ramp")
+	}
+	if os.Getenv("GATHERERS_BACKEND_BASE_URL") == "" {
+		t.Skip("set GATHERERS_BACKEND_BASE_URL to target an external backend")
+	}
+
+	target := newTestTarget(t, http.NewServeMux())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	base := loadsim.BreakpointStep{
+		BaseURL:           target.baseURL,
+		SimIDPrefix:       "external-regression",
+		ActivityTriplets:  20,
+		InitialAntCount:   26,
+		InitialFoodCount:  80,
+		SendTimeout:       10 * time.Second,
+		SettleTimeout:     10 * time.Second,
+		StallTimeout:      2 * time.Second,
+		ProgressPollEvery: 100 * time.Millisecond,
+	}
+	report, err := loadsim.RunBreakpointSearch(ctx, loadsim.BreakpointSearchConfig{
+		Steps:   loadsim.BuildClientCountRamp(100, 110, 5, base),
+		RunStep: loadsim.RunBackendBreakpointStep,
+	})
+	if err != nil {
+		t.Fatalf("expected external breakpoint regression ramp to complete cleanly: %v", err)
+	}
+
+	if report.LastGood == nil || report.LastGood.Step.ClientCount < 100 {
+		t.Fatalf(
+			"expected external backend to stay exact through 100 clients, got last_good=%v first_bad=%v",
+			describeBreakpointResult(report.LastGood),
+			describeBreakpointResult(report.FirstBad),
+		)
+	}
+	if report.FirstBad != nil && report.FirstBad.Step.ClientCount <= 100 {
+		t.Fatalf(
+			"external backend regressed too early at client_count=%d after last_good=%v: reason=%s message=%s expected=%+v observed=%+v client_errors=%v",
+			report.FirstBad.Step.ClientCount,
+			describeBreakpointResult(report.LastGood),
+			report.FirstBad.Failure.Kind,
+			report.FirstBad.Failure.Message,
+			report.FirstBad.Expected,
+			report.FirstBad.Observed,
+			report.FirstBad.Failure.ClientErrors,
+		)
+	}
+}
+
 func describeBreakpointResult(result *loadsim.BreakpointStepResult) string {
 	if result == nil {
 		return "none"

--- a/backend/internal/server/server_long_stress_test.go
+++ b/backend/internal/server/server_long_stress_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"testing"
@@ -67,4 +68,44 @@ func TestLongStressDashboardReflectsSustainedLoad(t *testing.T) {
 		t.Fatalf("expected sims endpoint to respond: %v", err)
 	}
 	defer resp.Body.Close()
+}
+
+func TestFindBreakpointUnderRampLoad(t *testing.T) {
+	if os.Getenv("GATHERERS_FIND_BREAKPOINT") == "" {
+		t.Skip("set GATHERERS_FIND_BREAKPOINT=1 to run breakpoint search")
+	}
+
+	srv := New(config.Config{})
+	target := newTestTarget(t, srv.Handler())
+	defer target.closeFn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), breakpointEnvDuration("GATHERERS_BREAKPOINT_TEST_TIMEOUT", 30*time.Second))
+	defer cancel()
+
+	report, err := loadsim.RunBreakpointSearch(ctx, buildBreakpointSearchConfig(target.baseURL))
+	if err != nil {
+		t.Fatalf("expected breakpoint search to complete cleanly: %v", err)
+	}
+
+	if report.FirstBad != nil {
+		t.Fatalf(
+			"breakpoint found at client_count=%d after last_good=%v: reason=%s message=%s expected=%+v observed=%+v client_errors=%v",
+			report.FirstBad.Step.ClientCount,
+			describeBreakpointResult(report.LastGood),
+			report.FirstBad.Failure.Kind,
+			report.FirstBad.Failure.Message,
+			report.FirstBad.Expected,
+			report.FirstBad.Observed,
+			report.FirstBad.Failure.ClientErrors,
+		)
+	}
+
+	t.Logf("no breakpoint found up to %s", describeBreakpointResult(report.LastGood))
+}
+
+func describeBreakpointResult(result *loadsim.BreakpointStepResult) string {
+	if result == nil {
+		return "none"
+	}
+	return fmt.Sprintf("client_count=%d expected=%+v observed=%+v", result.Step.ClientCount, result.Expected, result.Observed)
 }

--- a/backend/internal/server/server_stress_test.go
+++ b/backend/internal/server/server_stress_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -309,4 +311,56 @@ func fetchSummary(t *testing.T, baseURL string) struct {
 	}
 
 	return summary
+}
+
+func buildBreakpointSearchConfig(baseURL string) loadsim.BreakpointSearchConfig {
+	base := loadsim.BreakpointStep{
+		Name:              "breakpoint",
+		BaseURL:           baseURL,
+		ActivityTriplets:  breakpointEnvInt("GATHERERS_BREAKPOINT_ACTIVITY_TRIPLETS", 20),
+		Interval:          breakpointEnvDuration("GATHERERS_BREAKPOINT_INTERVAL", 5*time.Millisecond),
+		InitialAntCount:   breakpointEnvInt("GATHERERS_BREAKPOINT_ANT_COUNT", 26),
+		InitialFoodCount:  breakpointEnvInt("GATHERERS_BREAKPOINT_STARTUP_FOOD_COUNT", 80),
+		Seed:              int64(breakpointEnvInt("GATHERERS_BREAKPOINT_SEED", 700)),
+		SendTimeout:       breakpointEnvDuration("GATHERERS_BREAKPOINT_SEND_TIMEOUT", 5*time.Second),
+		SettleTimeout:     breakpointEnvDuration("GATHERERS_BREAKPOINT_SETTLE_TIMEOUT", 5*time.Second),
+		StallTimeout:      breakpointEnvDuration("GATHERERS_BREAKPOINT_STALL_TIMEOUT", 1500*time.Millisecond),
+		ProgressPollEvery: breakpointEnvDuration("GATHERERS_BREAKPOINT_POLL_INTERVAL", 100*time.Millisecond),
+	}
+
+	return loadsim.BreakpointSearchConfig{
+		Steps: loadsim.BuildClientCountRamp(
+			breakpointEnvInt("GATHERERS_BREAKPOINT_START_CLIENTS", 25),
+			breakpointEnvInt("GATHERERS_BREAKPOINT_MAX_CLIENTS", 100),
+			breakpointEnvInt("GATHERERS_BREAKPOINT_STEP", 25),
+			base,
+		),
+		RunStep: loadsim.RunBackendBreakpointStep,
+	}
+}
+
+func breakpointEnvInt(name string, fallback int) int {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func breakpointEnvDuration(name string, fallback time.Duration) time.Duration {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
 }

--- a/docs/go-backend-breakpoint-findings.md
+++ b/docs/go-backend-breakpoint-findings.md
@@ -1,0 +1,171 @@
+# Go Backend Breakpoint Findings
+
+## Purpose
+
+This note records one concrete breakpoint search run against the current Go backend on one local machine.
+
+It is not a universal backend limit.
+
+The reported breakpoint depends on:
+
+- machine performance
+- current backend code
+- test workload shape
+- timeout settings
+
+## Workload Used
+
+The breakpoint runner used this fixed workload while ramping `client_count`:
+
+- startup food count: `80`
+- activity triplets per client: `20`
+- interval: `5ms`
+- one-dimensional ramp: `client_count` only
+
+Each client step sends:
+
+- `sim_hello`
+- `sim_food_snapshot`
+- then `20` repetitions of:
+  - `food_pickup`
+  - `ant_turn_move`
+  - `food_drop`
+
+That means each client sends `62` events total for the step.
+
+## Findings
+
+### First pass with 10s send/settle timeouts
+
+Observed threshold:
+
+- last good: `255` clients
+- first bad: `260` clients
+
+### Narrower pass with 30s send/settle timeouts
+
+Observed threshold:
+
+- last good: `268` clients
+- first bad: `269` clients
+
+## Interpretation
+
+The important result is that the first failure moved upward when the timeouts were relaxed.
+
+That means the initial `260` breakpoint was not a pure “events are definitely lost at 260” conclusion. It was a timeout-bound breakpoint for this workload and these time budgets.
+
+With more generous timeouts, the same backend and workload still completed up to `268` clients, and then failed at `269`.
+
+So the current practical breakpoint for this exact local run was:
+
+- around `269` concurrent clients
+
+But more precisely, this means:
+
+- at `268`, the step completed and the backend caught up within the configured window
+- at `269`, the step no longer became observable through the backend within the configured window
+
+## Failure Shape
+
+The failing step reported:
+
+- failure kind: `exact_mismatch`
+- observed totals: all zero before timeout
+
+This should be read carefully.
+
+It does **not** mean the backend cleanly processed part of the step and dropped a small suffix of events.
+
+Instead, for that step and timeout window, the runner never observed the expected sim totals through the backend API before the deadline expired.
+
+So this finding is best described as:
+
+- a timeout-bound load breakpoint
+
+not yet as:
+
+- a proven minimal event-loss breakpoint under unlimited wait
+
+## Commands Used
+
+Initial coarse search:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --start-clients 100 \
+  --max-clients 1000 \
+  --step 100 \
+  --timeout 120s \
+  --send-timeout 10s \
+  --settle-timeout 10s \
+  --stall-timeout 3s
+```
+
+First narrowing pass:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --start-clients 225 \
+  --max-clients 300 \
+  --step 25 \
+  --timeout 120s \
+  --send-timeout 10s \
+  --settle-timeout 10s \
+  --stall-timeout 3s
+```
+
+Second narrowing pass:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --start-clients 255 \
+  --max-clients 275 \
+  --step 5 \
+  --timeout 120s \
+  --send-timeout 10s \
+  --settle-timeout 10s \
+  --stall-timeout 3s
+```
+
+Longer-timeout confirmation:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --start-clients 255 \
+  --max-clients 270 \
+  --step 5 \
+  --timeout 180s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+Final pinpoint run:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --start-clients 266 \
+  --max-clients 270 \
+  --step 1 \
+  --timeout 220s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+## What To Vary Next
+
+If future runs want more insight instead of just one threshold, the next useful experiments are:
+
+- vary `activity-triplets` to separate sustained event pressure from connection count
+- vary `startup-food-count` to isolate startup payload pressure
+- vary `interval` to separate message rate from concurrency
+- compare in-process backend runs with a manually started backend via `--base-url`
+
+Those experiments would help answer which dimension is actually dominating the breakpoint.

--- a/docs/go-backend-v1-contract.md
+++ b/docs/go-backend-v1-contract.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Define the v1 contract between optional Rust simulation clients and the new Go backend before backend behavior is implemented.
+Define the v1 contract between optional Rust simulation clients and the backend implementation before backend behavior is implemented.
 
 This document is intentionally limited to:
 
@@ -14,9 +14,14 @@ This document is intentionally limited to:
 
 It does not define durable persistence, auth, or production deployment details.
 
+This document now serves as the shared external contract for both backend implementations in this repository:
+
+- `backend/` for Go
+- `backend-rust/` for Rust parity work
+
 ## Backend Scope
 
-The Go service is a standalone backend under `backend/` that:
+The backend service is a standalone process that:
 
 - accepts simulation events over WebSockets
 - keeps live in-memory state for connected sims
@@ -50,6 +55,8 @@ Recommended hello payload fields:
 Immediately after `sim_hello`, the client may send a startup snapshot message containing all currently loose food positions. This gives the backend an initial world view without waiting for later pickup/drop events.
 
 ## Transport
+
+The current parity target is WebSocket ingest plus HTTP readers. Native-only raw TCP may be added later, but it should reuse the same logical event envelope and differ only in framing.
 
 ### WebSocket ingest
 

--- a/docs/rust-backend-actor-notes.md
+++ b/docs/rust-backend-actor-notes.md
@@ -1,0 +1,268 @@
+## Purpose
+
+This note summarizes how the current Rust backend relates to actor-style ownership and other Rust concurrency options, and which direction looks most promising if this backend evolves further.
+
+The goal is not to argue that the current design is wrong. The goal is to clarify which next-step simplifications would actually fit this codebase well.
+
+## Current Shape
+
+The Rust backend today is a hybrid:
+
+- ingest mutates authoritative shared state in `Store`
+- `Store` uses sharded `RwLock<HashMap<...>>` state for concurrent writes by sim
+- app state keeps separately published live and analytics snapshots
+- one demand-driven refresh worker serializes heavy analytics recomputation
+- dashboard updates are broadcast through one shared fanout channel
+
+That means the system already has one strongly actor-like component:
+
+- the analytics refresh worker has one serialized execution context
+- it owns refresh timing and demand handling
+- it decides when heavy analytics are recomputed
+- it publishes analytics-derived updates
+
+But the backend is not a pure actor system, because the authoritative ingest state is still shared-memory state protected by locks.
+
+So, just like the Go backend, the current Rust backend is best described as:
+
+- shared-memory ingest/store ownership
+- plus an actor-like analysis worker
+
+## What Rust Changes About The Discussion
+
+Rust changes the trade-offs somewhat compared with Go.
+
+In Go, the main question was whether the analysis side should be made more explicitly actor-shaped for clarity.
+
+In Rust, there is an additional strong option:
+
+- publish immutable snapshots for readers
+
+That option is especially attractive in Rust because immutable shared data wrapped in `Arc` is ergonomic and safe, and because the current problem is largely about separating:
+
+- cheap hot-path ingest mutation
+- from safe concurrent reads
+- from heavy background analytics
+
+So the Rust design space is not just:
+
+- mutexes vs actors
+
+It is more like:
+
+- shared mutable state with locks
+- actor ownership
+- concurrent map structures
+- immutable published snapshots
+
+## Option 1: Keep The Current Hybrid, With Small Refinements
+
+Shape:
+
+- keep the sharded `Store` as authoritative mutable state
+- keep the analytics worker actor-like
+- keep live and analytics caches as separately published derived state
+- continue to use `RwLock` around mutable shared structures
+
+Benefits:
+
+- smallest change from current code
+- already tested and understood
+- preserves the successful performance result where live counters stay exact through high load
+- keeps the code easy to map to the Go version
+
+Costs:
+
+- read locks still exist on the published cache objects
+- ownership remains split between shared state and one worker
+- future coordination logic may become harder to reason about if more caches or workers are added
+
+This is a good default if the goal is stability and parity rather than deeper architectural change.
+
+## Option 2: Make Only The Analysis Side More Explicitly Actor-Like
+
+Shape:
+
+- keep ingest writing to the shared store
+- make the analytics/live publication side more explicitly mailbox-driven
+- let one task own:
+  - demand state
+  - refresh cadence
+  - stale/fresh transitions
+  - published analytics snapshot
+  - possibly published live snapshot too
+
+Possible message types could look like:
+
+- `EventApplied`
+- `DashboardWatcherAdded`
+- `DashboardWatcherRemoved`
+- `ApiDemand`
+- `RefreshNow`
+- `Shutdown`
+
+Benefits:
+
+- clearer ownership of refresh policy and publication behavior
+- easier to test as a state machine
+- easier to log and reason about transitions
+- removes some coordination from shared mutable fields
+
+Costs:
+
+- authoritative ingest state is still shared-memory state
+- adds channel/message plumbing
+- does not eliminate store locking
+
+This is the most direct Rust equivalent of the “make analysis more actor-like” idea from the Go note.
+
+## Option 3: Use A Concurrent Map For Authoritative State
+
+Examples in Rust would include designs based on structures such as:
+
+- `DashMap`
+- `scc::HashMap`
+- similar fine-grained concurrent containers
+
+Shape:
+
+- replace the sharded `Vec<RwLock<HashMap<...>>>`
+- let the concurrent data structure internalize some of the synchronization
+
+Benefits:
+
+- less custom sharding code
+- concurrent reads and writes become more direct at the container layer
+- may simplify some hot-path mutation code
+
+Costs:
+
+- the synchronization does not disappear; it just moves inside the data structure
+- whole-world analytics still need a consistent materialized read view
+- iteration semantics and snapshot consistency become more subtle
+- it adds a dependency and a different mental model without clearly solving the publish/snapshot question
+
+For this backend, this looks possible but not especially compelling as the next move.
+
+It helps container concurrency, but the core architecture problem here is not really “we need a better map.” It is “we want readers to see a coherent view without interfering with the write path.”
+
+## Option 4: Publish Immutable Snapshots For Readers
+
+This is the most Rust-specific and, in many ways, the most interesting option.
+
+Shape:
+
+- keep one authoritative mutable store for ingest writes
+- build immutable live snapshots and immutable analytics snapshots from that state
+- publish them by swapping an `Arc` to the latest snapshot
+- readers use the latest published immutable snapshot without taking a traditional read lock on the payload itself
+
+This can be implemented with patterns such as:
+
+- `Arc` plus swap behind a small lock
+- `ArcSwap`
+- similar read-copy-update style publication
+
+Benefits:
+
+- readers always see a coherent view
+- no reader can observe partially mutated structures
+- read-side access becomes extremely cheap
+- it matches the current architectural split very naturally:
+  - mutable ingest state
+  - separately published live view
+  - separately published analytics view
+
+Costs:
+
+- publishing requires cloning or rebuilding snapshot data
+- this is best for published views, not as the raw ingest store itself
+- writes still need synchronization in the authoritative store
+
+This is not a pure actor model, but it solves the exact thing the backend cares about most:
+
+- ingest should keep moving
+- readers should always see a valid consistent view
+- heavy analytics should be independently publishable
+
+## Option 5: Make The Whole Store Actor-Owned
+
+Shape:
+
+- one task owns all mutable simulation state
+- ingest handlers send event messages to that task
+- API/dashboard reads become request/response messages or subscribe to published snapshots
+- shared mutable maps mostly disappear from the application layer
+
+Benefits:
+
+- very strong ownership story
+- no shared mutable store across tasks
+- some classes of race simply disappear
+
+Costs:
+
+- much larger rewrite
+- more queueing and request/response plumbing
+- higher risk of creating one central bottleneck if not designed carefully
+- less useful if the actual workload benefits from parallel writes across sims
+
+For this backend, this feels too large and too constraining for the current goals.
+
+The backend’s load story improved precisely because writes can proceed across sharded state while analytics is detached. A single fully actor-owned store would simplify ownership, but it would also serialize much more of the hot path.
+
+## Best Fit For This Backend
+
+The best next-step Rust direction is not “actors everywhere.”
+
+It is:
+
+- keep the authoritative ingest store shared and parallel-friendly
+- keep the analytics worker actor-like
+- if the read/publication side needs further cleanup, move published snapshots toward immutable snapshot swapping rather than deeper shared read locking
+
+In other words, the strongest Rust-specific refinement is:
+
+- **shared mutable raw state**
+- **actor-like analysis scheduling**
+- **immutable published views for readers**
+
+That combination fits the current backend especially well because it preserves the architecture that already worked well in measurement:
+
+- ingest stays cheap
+- live counters stay exact and prompt
+- analytics can lag independently
+- readers can be made simpler and safer
+
+## Why This Looks Better Than The Alternatives
+
+Why not full actor ownership of all state?
+
+- it is a much larger rewrite
+- it would likely serialize too much of the ingest path
+- it solves more problems than this backend currently has
+
+Why not jump to a concurrent-map crate first?
+
+- it changes the container, but not the publication model
+- the hard part here is coherent publication of views, not only concurrent insertion/removal
+
+Why not just stay exactly as-is forever?
+
+- that is a valid choice for now
+- but if the code grows, immutable published snapshots would likely make the read side easier to reason about than more shared read locks and more mutable cache objects
+
+## Recommended Interpretation
+
+The Rust backend should currently be viewed as:
+
+- a parallel shared-memory ingest/store layer
+- plus an actor-like analytics/publication layer
+
+If it evolves further, the most promising refinement is:
+
+- **not** a full actor rewrite
+- **not** “find a more magical concurrent map”
+- **but** making the published read side more explicitly immutable and snapshot-based
+
+That would likely improve clarity and robustness more than pushing the entire backend into a pure actor model.

--- a/docs/rust-backend-breakpoint-findings.md
+++ b/docs/rust-backend-breakpoint-findings.md
@@ -63,22 +63,28 @@ Fresh run detail:
 
 - observed totals at `100`: `SentEvents=52 ConnectedSims=6 PickupCount=15 DropCount=15 TurnMoveCount=15 LooseFoodCount=80`
 
-## Interpretation
+## Learning-First Experiment Results
 
-The important result is not whether the precise edge is `100` or `101`.
+Starting from the baseline above, the Rust backend was then improved in four measured steps:
 
-The important result is that, under the same general workload shape and timeout budget used for the recorded Go comparison, the Rust backend hits its first timeout-bound breakpoint at roughly `100` concurrent clients on this machine.
+| Step | Change | Last good | First bad | Delta vs previous |
+|---|---|---:|---:|---:|
+| Baseline | pre-experiment reference | 99 | 100 | - |
+| 1 | async-friendly refresh coordination | 107 | 108 | +8 |
+| 2 | shard store writes by sim | 118 | 119 | +11 |
+| 3 | move snapshot compute off Tokio workers | 128 | 129 | +10 |
+| 4 | Go-style demand worker and adaptive cadence | 155 | 160 | +27 |
 
-So the current practical breakpoint for this exact local run was:
+The biggest single move came from step 4.
 
-- around `100` concurrent clients
+That matters because it means the Rust backend was not only paying for low-level locking and runtime-thread placement. The refresh policy itself was a major part of the gap.
 
-More precisely, this means:
+After the full learning-first sequence, the current practical breakpoint for this workload on this machine is:
 
-- at `99`, the step completed and the backend caught up within the configured window
-- at `100` or `101`, depending on the sweep, the step no longer became observable through the backend within the configured window
+- last good: `155`
+- first bad: `160`
 
-The small wobble between `99`, `100`, and `101` should be treated as expected edge variance for this style of timeout-bound load search, especially because each step adds state to the same running backend process.
+That is a large improvement over the original `99-100` baseline, but it still trails the current Go result on the same workload.
 
 ## Failure Shape
 
@@ -101,7 +107,7 @@ not yet as:
 
 - a proven minimal event-loss breakpoint under unlimited wait
 
-## Commands Used
+## Baseline Commands Used
 
 Coarse search:
 
@@ -155,19 +161,51 @@ The recorded Go note in `docs/go-backend-breakpoint-findings.md` reached:
 - last good: `268` clients
 - first bad: `269` clients
 
-The recorded Rust runs here reached roughly:
+The final measured Rust result after the learning-first sequence reached:
 
-- last good: about `99-100` clients
-- first bad: about `100-101` clients
+- last good: `155` clients
+- first bad: `160` clients
 
-So, for this workload on this machine, the current Go backend clearly outperforms the current Rust backend.
+So, for this workload on this machine, the current Go backend still clearly outperforms the current Rust backend, but the gap is now much smaller than it was at the original baseline.
+
+## Commands Used
+
+Final coarse search after Go-style cadence:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18237 \
+  --start-clients 125 \
+  --max-clients 250 \
+  --step 25 \
+  --timeout 220s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+Final narrowing pass after Go-style cadence:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18238 \
+  --start-clients 150 \
+  --max-clients 175 \
+  --step 5 \
+  --timeout 220s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
 
 ## What To Vary Next
 
 If future runs want more insight instead of just one threshold, the next useful experiments are:
 
-- repeat the Rust search with multiple fresh backend starts per point to reduce edge variance
+- repeat the final Rust search with multiple fresh backend starts per point to reduce edge variance
 - vary `activity-triplets` to separate sustained event pressure from connection count
 - vary `startup-food-count` to isolate startup payload pressure
 - vary `interval` to separate message rate from concurrency
-- profile the Rust backend during the failing `100-110` range to find the next dominant bottleneck after the snapshot-lock fix
+- profile the Rust backend during the failing `155-160` range to find the next dominant bottleneck after cadence matching

--- a/docs/rust-backend-breakpoint-findings.md
+++ b/docs/rust-backend-breakpoint-findings.md
@@ -86,9 +86,53 @@ After the full learning-first sequence, the current practical breakpoint for thi
 
 That is a large improvement over the original `99-100` baseline, but it still trails the current Go result on the same workload.
 
-## Failure Shape
+## Live Vs Analytics Separation Result
 
-The failing steps reported:
+After splitting cheap live ingest-derived counters from heavy analytics, the externally observed breakpoint moved dramatically again.
+
+### Initial separation measurement
+
+- strongest passing configuration in the first new sweep: `1000` clients
+- strongest passing configuration in the higher sweep: `1600` clients
+- first observed failure in the higher sweep: `1800` clients
+
+### Post-consistency-fix measurement
+
+The initial separation had correctness issues: the live cache used arithmetic deltas that could diverge from the authoritative store on duplicate or idempotent food events, and dashboard websocket subscribers missed live-only updates. After fixing those:
+
+- `Store::apply_event()` returns an `EventOutcome` with the authoritative per-sim `loose_food_count`
+- the live cache sets counts from the outcome instead of guessing with `+1` / `saturating_sub(1)`
+- every event broadcasts to dashboard websocket subscribers, not only analytics-affecting events
+- the `broadcast::Receiver` handles `Lagged` errors gracefully instead of disconnecting
+
+Measured result after the fix:
+
+- strongest passing in coarse sweep: `1200` clients
+- strongest passing in narrowing sweep: `1500` clients (all steps 1200-1500 passed)
+- strongest passing in high-range sweep: `2000` clients
+- first observed failure: `2250` clients
+
+At `2000`, the observed totals still matched exactly:
+
+- `SentEvents=124000`
+- `ConnectedSims=2000`
+- `PickupCount=40000`
+- `DropCount=40000`
+- `TurnMoveCount=40000`
+- `LooseFoodCount=160000`
+
+### Failure shape
+
+The failure at `2250` was purely connection-level:
+
+- failure kind: `client_error`
+- specific shape: many websocket dial timeouts while the load generator was still trying to open `/ws/ingest` connections
+
+No `exact_mismatch` failures were observed at any client count. Every connected client's events were correctly and promptly visible through the live counters.
+
+## Historical Failure Shape
+
+Before the live-vs-analytics separation, the failing steps reported:
 
 - failure kind: `exact_mismatch`
 - observed totals: sometimes effectively zero, and on a fresh confirmation run partial but far-from-complete progress
@@ -161,12 +205,17 @@ The recorded Go note in `docs/go-backend-breakpoint-findings.md` reached:
 - last good: `268` clients
 - first bad: `269` clients
 
-The final measured Rust result after the learning-first sequence reached:
+The learning-first Rust result before the live-vs-analytics split reached:
 
 - last good: `155` clients
 - first bad: `160` clients
 
-So, for this workload on this machine, the current Go backend still clearly outperforms the current Rust backend, but the gap is now much smaller than it was at the original baseline.
+After the live-vs-analytics split and consistency fix, the Rust backend:
+
+- matched exact live totals through `2000` clients in the measured sweep
+- first showed failure at `2250`, and that failure was `client_error` during websocket dialing rather than stale live totals
+
+The current Rust backend outperforms the recorded Go backend on the exact-count live-counter dimension that the breakpoint harness measures. The trade-off is that this measures a deliberately different architecture: live counters stay fresh while heavy analytics are allowed to lag independently.
 
 ## Commands Used
 
@@ -200,12 +249,73 @@ go run ./cmd/breakpoint \
   --stall-timeout 5s
 ```
 
+Live-vs-analytics separation sweep:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18239 \
+  --start-clients 150 \
+  --max-clients 350 \
+  --step 25 \
+  --timeout 220s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+Higher-range confirmation (pre-consistency-fix):
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18239 \
+  --start-clients 1200 \
+  --max-clients 2000 \
+  --step 200 \
+  --timeout 220s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+Post-consistency-fix coarse sweep:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18270 \
+  --start-clients 200 \
+  --max-clients 2000 \
+  --step 200 \
+  --timeout 300s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+Post-consistency-fix high-range sweep:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18272 \
+  --start-clients 1500 \
+  --max-clients 3000 \
+  --step 250 \
+  --timeout 300s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
 ## What To Vary Next
 
-If future runs want more insight instead of just one threshold, the next useful experiments are:
+If future runs want more insight, the next useful experiments are:
 
-- repeat the final Rust search with multiple fresh backend starts per point to reduce edge variance
+- add explicit analytics-lag measurements under the breakpoint workload, since the main live-counter bottleneck has moved far outward
+- repeat the high-range Rust search with multiple fresh backend starts per point to reduce edge variance
 - vary `activity-triplets` to separate sustained event pressure from connection count
 - vary `startup-food-count` to isolate startup payload pressure
 - vary `interval` to separate message rate from concurrency
-- profile the Rust backend during the failing `155-160` range to find the next dominant bottleneck after cadence matching
+- profile connection setup and accept backlog behavior in the `2000-2250` range, because the first observed failure is websocket dial timeout rather than stale live totals

--- a/docs/rust-backend-breakpoint-findings.md
+++ b/docs/rust-backend-breakpoint-findings.md
@@ -1,0 +1,173 @@
+# Rust Backend Breakpoint Findings
+
+## Purpose
+
+This note records one concrete breakpoint search run against the current Rust backend on one local machine.
+
+It is not a universal backend limit.
+
+The reported breakpoint depends on:
+
+- machine performance
+- current backend code
+- test workload shape
+- timeout settings
+
+## Workload Used
+
+The breakpoint runner used the same fixed workload shape as the recorded Go run while ramping `client_count`:
+
+- startup food count: `80`
+- activity triplets per client: `20`
+- interval: `5ms`
+- one-dimensional ramp: `client_count` only
+- send timeout: `30s`
+- settle timeout: `30s`
+- stall timeout: `5s`
+
+Each client step sends:
+
+- `sim_hello`
+- `sim_food_snapshot`
+- then `20` repetitions of:
+  - `food_pickup`
+  - `ant_turn_move`
+  - `food_drop`
+
+That means each client sends `62` events total for the step.
+
+## Findings
+
+### Coarse pass with 30s send/settle timeouts
+
+Observed threshold:
+
+- last good: `100` clients
+- first bad: `110` clients
+
+### Narrowing pass with 30s send/settle timeouts
+
+Observed threshold:
+
+- last good: `100` clients
+- first bad: `101` clients
+
+### Fresh confirmation sweep
+
+Observed threshold:
+
+- last good: `99` clients
+- first bad: `100` clients
+
+Fresh run detail:
+
+- observed totals at `100`: `SentEvents=52 ConnectedSims=6 PickupCount=15 DropCount=15 TurnMoveCount=15 LooseFoodCount=80`
+
+## Interpretation
+
+The important result is not whether the precise edge is `100` or `101`.
+
+The important result is that, under the same general workload shape and timeout budget used for the recorded Go comparison, the Rust backend hits its first timeout-bound breakpoint at roughly `100` concurrent clients on this machine.
+
+So the current practical breakpoint for this exact local run was:
+
+- around `100` concurrent clients
+
+More precisely, this means:
+
+- at `99`, the step completed and the backend caught up within the configured window
+- at `100` or `101`, depending on the sweep, the step no longer became observable through the backend within the configured window
+
+The small wobble between `99`, `100`, and `101` should be treated as expected edge variance for this style of timeout-bound load search, especially because each step adds state to the same running backend process.
+
+## Failure Shape
+
+The failing steps reported:
+
+- failure kind: `exact_mismatch`
+- observed totals: sometimes effectively zero, and on a fresh confirmation run partial but far-from-complete progress
+
+This should be read carefully.
+
+It does **not** mean the backend cleanly processed almost the whole step and only dropped a tiny suffix of events.
+
+Instead, for those steps and timeout windows, the runner never observed the expected sim totals through the backend API before the deadline expired. In some runs that looked like almost no visible progress; in the freshest confirmation run it looked like limited progress that still stalled far short of the expected totals.
+
+So this finding is best described as:
+
+- a timeout-bound load breakpoint
+
+not yet as:
+
+- a proven minimal event-loss breakpoint under unlimited wait
+
+## Commands Used
+
+Coarse search:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18220 \
+  --start-clients 100 \
+  --max-clients 160 \
+  --step 10 \
+  --timeout 180s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+First narrowing pass:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18220 \
+  --start-clients 101 \
+  --max-clients 110 \
+  --step 1 \
+  --timeout 220s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+Fresh confirmation sweep:
+
+```bash
+cd backend
+go run ./cmd/breakpoint \
+  --base-url http://127.0.0.1:18230 \
+  --start-clients 99 \
+  --max-clients 102 \
+  --step 1 \
+  --timeout 220s \
+  --send-timeout 30s \
+  --settle-timeout 30s \
+  --stall-timeout 5s
+```
+
+## Comparison With Go
+
+The recorded Go note in `docs/go-backend-breakpoint-findings.md` reached:
+
+- last good: `268` clients
+- first bad: `269` clients
+
+The recorded Rust runs here reached roughly:
+
+- last good: about `99-100` clients
+- first bad: about `100-101` clients
+
+So, for this workload on this machine, the current Go backend clearly outperforms the current Rust backend.
+
+## What To Vary Next
+
+If future runs want more insight instead of just one threshold, the next useful experiments are:
+
+- repeat the Rust search with multiple fresh backend starts per point to reduce edge variance
+- vary `activity-triplets` to separate sustained event pressure from connection count
+- vary `startup-food-count` to isolate startup payload pressure
+- vary `interval` to separate message rate from concurrency
+- profile the Rust backend during the failing `100-110` range to find the next dominant bottleneck after the snapshot-lock fix

--- a/docs/rust-backend-notes.md
+++ b/docs/rust-backend-notes.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This note explains the current Rust backend direction, why the stack was chosen, how it compares with the Go backend, and where the transport seam for future raw TCP now lives.
+This note explains the current Rust backend direction, why the stack was chosen, how it compares with the Go backend, where the transport seam for future raw TCP now lives, and how the snapshot path was decoupled from ingest after reproducing the first heavy-load failure mode.
 
 ## Library Choices
 
@@ -64,6 +64,43 @@ but not:
 - store mutation logic
 - snapshot invalidation logic
 
+## Snapshot Decoupling
+
+The first Rust parity version repeated the same architectural mistake the Go backend originally had in milder form:
+
+- ingest writes took the store write lock
+- demand-driven refresh took the store read lock
+- while still holding that read lock, refresh computed expensive derived metrics such as nearest-neighbor distance
+
+That meant refresh could block writers for far longer than the cheap raw-state copy itself required.
+
+The current snapshot path now matches the fixed Go shape more closely:
+
+1. ingest mutates raw state and marks cached data dirty
+2. a demand-triggered refresh task takes the store read lock only long enough to copy `DashboardSnapshotData`
+3. the read lock is released
+4. expensive derived metrics are computed from that copied data
+5. the cached snapshot is replaced and broadcast to dashboard watchers
+
+This keeps the public HTTP and WebSocket contract the same, while removing the long lock hold that previously starved writes under load.
+
+## Failure Reproduction And Evidence
+
+Two new regressions were added specifically around this issue:
+
+- `backend-rust/src/app.rs`: `refresh_does_not_hold_store_lock_long_enough_to_starve_writes`
+- `backend-rust/tests/ingest_decoupling_stress.rs`: `heavy_ingest_with_polling_keeps_api_sims_responsive_and_exact`
+
+Before the refactor, the targeted lock test showed a single refresh blocking writes for roughly half a second on a large snapshot. The first heavy-load regression also failed while `/api/sims` polling was active.
+
+The shared Go breakpoint harness was then rerun against a fresh Rust backend process. That changed the observed behavior from an API timeout-style collapse at the first heavy step to:
+
+- exact through `100` clients in the reused Go exact-count stress test
+- exact through `100` clients in the reused Go breakpoint regression ramp
+- first observed breakpoint moving up to `105` clients, and presenting as an exact-count mismatch rather than `/api/sims` timing out
+
+That does not mean the Rust backend has no breakpoint. It means the specific ingest-vs-refresh lock coupling that originally caused request starvation was removed, and the next remaining limit now appears as ordinary throughput capacity instead.
+
 ## Raw TCP Status
 
 Raw TCP is intentionally deferred.
@@ -85,15 +122,12 @@ Planned direction for later:
 
 ### Go tests reused unchanged against Rust
 
-These external black-box tests were verified against the Rust backend by setting `GATHERERS_BACKEND_BASE_URL`:
+These external black-box tests were verified against fresh Rust backend instances by setting `GATHERERS_BACKEND_BASE_URL`:
 
-- `TestSummaryReflectsEventsIngestedOverWebSocket`
-- `TestDashboardPageBootstrapsRealtimeWebsocketUi`
-- `TestDashboardWebsocketReceivesUpdatedSnapshotAfterIngest`
 - `TestDashboardWebsocketStartsWithCachedSnapshotThenCatchesUp`
-- `TestFakeClientsPopulatePerSimSummaries`
+- `TestSummaryReadStartsDemandAndEventuallyRefreshesCachedSnapshot`
 - `TestStressHundredFakeClientsDeliversExactEventTotals`
-- `TestFindBreakpointUnderRampLoad` with a small ramp config
+- `TestExternalBackendRampLoadKeepsAPISimsResponsive`
 
 ### What required adaptation
 
@@ -115,17 +149,18 @@ The Go backend already has a recorded local breakpoint note in `docs/go-backend-
 
 ### Rust backend
 
-The Rust backend has currently been verified at two levels:
+The Rust backend now has stronger post-fix evidence:
 
-- focused black-box Go tests pass against it
-- the Go exact-count stress test with `100` fake clients passes against it
-- the Go breakpoint wrapper passes in a small smoke configuration up to `4` clients
+- full Rust test suite passes locally
+- reused Go lazy-refresh API and dashboard tests pass against fresh Rust backend instances
+- the reused Go exact-count `100` fake-client stress test passes against a fresh Rust backend instance
+- the reused Go breakpoint regression ramp now proves exact behavior through `100` clients and sees the first bad step at `105`
 
-That means the Rust backend is already compatible enough for apples-to-apples harness reuse, but it does **not** yet have a heavy breakpoint characterization comparable to the Go backend note.
+That means the Rust backend is compatible enough for apples-to-apples harness reuse and is clear of the original request-starvation failure mode, but it still has a lower heavy-load breakpoint than the Go backend on this machine.
 
 ## Remaining Gaps Before Raw TCP
 
-- run the same larger breakpoint search against Rust that was already recorded for Go
+- run and record a fuller Rust breakpoint characterization comparable to `docs/go-backend-breakpoint-findings.md`
 - decide whether the Rust backend should copy the Go adaptive cadence exactly or only semantically
 - decide whether external Go test reuse should eventually spawn fresh Rust processes automatically for zero-state-sensitive tests
 - add a documented native-only TCP framing choice

--- a/docs/rust-backend-notes.md
+++ b/docs/rust-backend-notes.md
@@ -1,0 +1,131 @@
+# Rust Backend Notes
+
+## Purpose
+
+This note explains the current Rust backend direction, why the stack was chosen, how it compares with the Go backend, and where the transport seam for future raw TCP now lives.
+
+## Library Choices
+
+The Rust parity backend currently uses:
+
+- `tokio` for async runtime and background tasks
+- `axum` for HTTP routes and WebSocket upgrades
+- `serde` and `serde_json` for the shared JSON event envelope
+- `tokio::sync::broadcast` for dashboard fanout
+- `std::sync::{Mutex, RwLock}` for small in-memory shared state
+
+### Why `axum` and `tokio`
+
+This stack maps closely to the current Go backend:
+
+- one process
+- one HTTP router
+- WebSocket ingest plus dashboard fanout
+- in-memory state
+- one cached snapshot path for readers
+
+It also keeps the Rust backend easy to run as a standalone process and easy to test both:
+
+- in-process from Rust integration tests
+- externally from the existing Go black-box tests
+
+## Shared Protocol
+
+The Rust backend reuses the same logical protocol as the Go backend:
+
+- same event envelope fields
+- same event type names
+- same HTTP route names
+- same WebSocket route names
+
+One important compatibility detail from implementation was that the Rust side must accept the looser payload shapes already used by the Go tests and fake clients. For example:
+
+- `sim_hello` may contain only `sim_name`
+- `food_pickup` may contain only `food_id`
+- `food_drop` may omit ant and direction metadata
+
+So the Rust backend now matches the protocol as actually exercised, not only the richer client payloads produced by `src/net.rs`.
+
+## Transport-Independent Ingest Seam
+
+The current seam for future transport expansion is:
+
+- `backend-rust/src/ingest.rs`
+
+That module exposes a transport-independent entrypoint that accepts a decoded `EventEnvelope` and applies it to shared state. Today it is called by the WebSocket handler. Later, native-only raw TCP should call the same ingest core after its own framing/decoding layer.
+
+That means future TCP should change:
+
+- transport framing
+
+but not:
+
+- event schema
+- store mutation logic
+- snapshot invalidation logic
+
+## Raw TCP Status
+
+Raw TCP is intentionally deferred.
+
+Reasons:
+
+- WebSocket parity is enough to reuse the strongest existing Go tests now.
+- The browser dashboard and existing Rust client already fit naturally with WebSockets.
+- Adding raw TCP too early would mix transport experimentation with parity work and make comparison harder.
+
+Planned direction for later:
+
+- native-only TCP mode
+- same JSON envelope
+- framing-only difference from WebSocket
+- same `handle_ingest_event` path after decode
+
+## Comparison Status
+
+### Go tests reused unchanged against Rust
+
+These external black-box tests were verified against the Rust backend by setting `GATHERERS_BACKEND_BASE_URL`:
+
+- `TestSummaryReflectsEventsIngestedOverWebSocket`
+- `TestDashboardPageBootstrapsRealtimeWebsocketUi`
+- `TestDashboardWebsocketReceivesUpdatedSnapshotAfterIngest`
+- `TestDashboardWebsocketStartsWithCachedSnapshotThenCatchesUp`
+- `TestFakeClientsPopulatePerSimSummaries`
+- `TestStressHundredFakeClientsDeliversExactEventTotals`
+- `TestFindBreakpointUnderRampLoad` with a small ramp config
+
+### What required adaptation
+
+Two kinds of adaptation were needed:
+
+1. Test harness adaptation:
+   - `backend/internal/server/server_api_test.go` had to move onto the shared `newTestTarget` base-URL abstraction so those tests can target an external backend process.
+
+2. Rust contract adaptation:
+   - the Rust payload models had to accept the lighter request bodies already used by the Go tests and fake clients.
+
+No Go test logic had to be rewritten for the Rust backend after the base-URL refactor.
+
+## Current Comparison Result
+
+### Go backend
+
+The Go backend already has a recorded local breakpoint note in `docs/go-backend-breakpoint-findings.md`, including a workload that reached a timeout-bound breakpoint around `269` clients on one machine.
+
+### Rust backend
+
+The Rust backend has currently been verified at two levels:
+
+- focused black-box Go tests pass against it
+- the Go exact-count stress test with `100` fake clients passes against it
+- the Go breakpoint wrapper passes in a small smoke configuration up to `4` clients
+
+That means the Rust backend is already compatible enough for apples-to-apples harness reuse, but it does **not** yet have a heavy breakpoint characterization comparable to the Go backend note.
+
+## Remaining Gaps Before Raw TCP
+
+- run the same larger breakpoint search against Rust that was already recorded for Go
+- decide whether the Rust backend should copy the Go adaptive cadence exactly or only semantically
+- decide whether external Go test reuse should eventually spawn fresh Rust processes automatically for zero-state-sensitive tests
+- add a documented native-only TCP framing choice


### PR DESCRIPTION
## Summary
- add a standalone `backend-rust/` crate using `tokio` and `axum` that serves the same core HTTP and WebSocket surface as the Go backend
- reuse the existing JSON event envelope and refactor the Go black-box API tests onto the shared base-URL target abstraction so selected Go tests can run unchanged against Rust
- document the Rust backend architecture, comparison workflow, and future transport seam for raw TCP without implementing TCP yet

## Test plan
- [x] `cargo test --manifest-path backend-rust/Cargo.toml`
- [x] `cd backend && go test ./... -count=1`
- [x] selected Go black-box tests against fresh Rust backend processes:
- [x] `TestSummaryReflectsEventsIngestedOverWebSocket`
- [x] `TestDashboardPageBootstrapsRealtimeWebsocketUi`
- [x] `TestDashboardWebsocketReceivesUpdatedSnapshotAfterIngest`
- [x] `TestDashboardWebsocketStartsWithCachedSnapshotThenCatchesUp`
- [x] `TestFakeClientsPopulatePerSimSummaries`
- [x] `TestStressHundredFakeClientsDeliversExactEventTotals`
- [x] `TestFindBreakpointUnderRampLoad` with the small smoke config


Made with [Cursor](https://cursor.com)