### PR TITLE
Add Mass-backed Unreal simulation and visuals

### DIFF
--- a/unreal_gatherers/README.md
+++ b/unreal_gatherers/README.md
@@ -7,7 +7,8 @@ Unreal 5.7 port of the `gatherers` simulation.
 Current implemented slice:
 
 - editor-only automation test module
-- preserved deterministic gather-demo path with one ant and two foods
+- random full-simulation game startup path with Rust-like ant row spacing and food count
+- preserved deterministic gather-demo path with one ant and two foods for explicit test/manual fixtures
 - separate full-simulation path with heading-based movement, pickup/drop, cooldown, and border turn-back
 - startup integration through `Aunreal_gatherersGameModeBase`
 - standalone `-game` launch into `SimBlank`
@@ -56,7 +57,7 @@ Useful targeted reruns:
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodBackIntoWorld;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodTwiceInSameEditorSession;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.FullSimulation;Quit"
--ExecCmds="Automation RunTest supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsOneAntAndTwoFoods;Quit"
+-ExecCmds="Automation RunTest supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsRustLikeFullSimulationCounts;Quit"
 ```
 
 ## Run the visual gather demos
@@ -100,4 +101,10 @@ The current startup path should load:
 - `/Game/SimBlank/Levels/SimBlank`
 - `unreal_gatherersGameModeBase`
 
-and spawn the preserved deterministic gather-demo path with one ant actor plus two food actors.
+and spawn the random full-simulation path by default:
+
+- 80 food actors at random positions
+- a Rust-like row of ants spaced 50 units apart across the play area
+- random initial headings for those ants
+
+The old one-ant/two-food deterministic setup is still preserved, but only when a test or manual harness explicitly asks for `BuildInitialGatherersSpawnPlan()`.

--- a/unreal_gatherers/README.md
+++ b/unreal_gatherers/README.md
@@ -9,8 +9,8 @@ Current implemented slice:
 - editor-only automation test module
 - random full-simulation game startup path with Rust-like ant row spacing and food count, now backed by Mass-managed sim state with actor proxies
 - preserved deterministic gather-demo path with one ant and two foods for explicit test/manual fixtures
-- preserved actor-backed full-simulation fixture path for comparison and regression tests
-- separate Mass-backed full-simulation path with heading-based movement, pickup/drop, cooldown, repeated gathering, and border turn-back
+- preserved direct-actor full-simulation fixture specs for comparison and regression coverage
+- Mass-backed full-simulation runtime with heading-based movement, pickup/drop, cooldown, repeated gathering, and border turn-back
 - startup integration through `Aunreal_gatherersGameModeBase`
 - standalone `-game` launch into `SimBlank`
 - separate visual/manual editor inspection paths for the deterministic demo and the new full simulation
@@ -58,6 +58,7 @@ Useful targeted reruns:
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodBackIntoWorld;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodTwiceInSameEditorSession;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.FullSimulation;Quit"
+-ExecCmds="Automation RunTest default.unreal_gatherers.FullSimulationActorFixture;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Mass;Quit"
 -ExecCmds="Automation RunTest supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsRustLikeFullSimulationCounts;Quit"
 ```
@@ -110,4 +111,4 @@ and spawn the random full-simulation path by default:
 - random initial headings for those ants
 - Mass-managed ant/food simulation state synchronized into the spawned actors
 
-The old one-ant/two-food deterministic setup is still preserved, and the actor-backed full-simulation fixtures are preserved too, but only when a test or manual harness explicitly asks for those non-Mass spawn builders.
+The old one-ant/two-food deterministic setup is still preserved, and the direct-actor full-simulation comparison specs are preserved too, but the live full-simulation runtime now means the Mass-backed path.

--- a/unreal_gatherers/README.md
+++ b/unreal_gatherers/README.md
@@ -7,9 +7,10 @@ Unreal 5.7 port of the `gatherers` simulation.
 Current implemented slice:
 
 - editor-only automation test module
-- random full-simulation game startup path with Rust-like ant row spacing and food count
+- random full-simulation game startup path with Rust-like ant row spacing and food count, now backed by Mass-managed sim state with actor proxies
 - preserved deterministic gather-demo path with one ant and two foods for explicit test/manual fixtures
-- separate full-simulation path with heading-based movement, pickup/drop, cooldown, and border turn-back
+- preserved actor-backed full-simulation fixture path for comparison and regression tests
+- separate Mass-backed full-simulation path with heading-based movement, pickup/drop, cooldown, repeated gathering, and border turn-back
 - startup integration through `Aunreal_gatherersGameModeBase`
 - standalone `-game` launch into `SimBlank`
 - separate visual/manual editor inspection paths for the deterministic demo and the new full simulation
@@ -57,6 +58,7 @@ Useful targeted reruns:
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodBackIntoWorld;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodTwiceInSameEditorSession;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.FullSimulation;Quit"
+-ExecCmds="Automation RunTest default.unreal_gatherers.Mass;Quit"
 -ExecCmds="Automation RunTest supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsRustLikeFullSimulationCounts;Quit"
 ```
 
@@ -106,5 +108,6 @@ and spawn the random full-simulation path by default:
 - 80 food actors at random positions
 - a Rust-like row of ants spaced 50 units apart across the play area
 - random initial headings for those ants
+- Mass-managed ant/food simulation state synchronized into the spawned actors
 
-The old one-ant/two-food deterministic setup is still preserved, but only when a test or manual harness explicitly asks for `BuildInitialGatherersSpawnPlan()`.
+The old one-ant/two-food deterministic setup is still preserved, and the actor-backed full-simulation fixtures are preserved too, but only when a test or manual harness explicitly asks for those non-Mass spawn builders.

--- a/unreal_gatherers/README.md
+++ b/unreal_gatherers/README.md
@@ -7,11 +7,11 @@ Unreal 5.7 port of the `gatherers` simulation.
 Current implemented slice:
 
 - editor-only automation test module
-- deterministic spawn plan with one ant and two foods
-- `AAnt`/`AFood` repeated gather loop
+- preserved deterministic gather-demo path with one ant and two foods
+- separate full-simulation path with heading-based movement, pickup/drop, cooldown, and border turn-back
 - startup integration through `Aunreal_gatherersGameModeBase`
 - standalone `-game` launch into `SimBlank`
-- visual/manual editor inspection path
+- separate visual/manual editor inspection paths for the deterministic demo and the new full simulation
 
 Still out of scope:
 
@@ -55,18 +55,25 @@ Useful targeted reruns:
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntMovesAndPicksUpFoodInWorld;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodBackIntoWorld;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodTwiceInSameEditorSession;Quit"
+-ExecCmds="Automation RunTest default.unreal_gatherers.FullSimulation;Quit"
 -ExecCmds="Automation RunTest supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsOneAntAndTwoFoods;Quit"
 ```
 
-## Run the visual gather demo
+## Run the visual gather demos
 
 The visual/manual pickup path is intentionally separate from `./scripts/test_unreal.sh` so the default automation suite stays clean and rerunnable.
 
-Run this scenario from the editor automation UI under:
+Deterministic gather-demo path:
 
 `manual.unreal_gatherers.Visual.AntFirstDropLeavesWorldForInspection`
 
 That visual/manual test loads `SimBlank` into a clean editor world, frames the viewport around the two-food layout, advances the ant through pickup and return, and leaves the first dropped-food state behind for inspection.
+
+Full-simulation path:
+
+`manual.unreal_gatherers.Visual.FullSimulationSecondPickupStaysVisible`
+
+That visual/manual test also loads `SimBlank` into a clean editor world, but it uses the separate full-simulation spawn harness and runtime path. It shows a heading-driven ant pick up food, drop it, cool down, and reach a second pickup state for inspection.
 
 ## Refresh editor indexing
 
@@ -93,4 +100,4 @@ The current startup path should load:
 - `/Game/SimBlank/Levels/SimBlank`
 - `unreal_gatherersGameModeBase`
 
-and spawn one ant actor plus two food actors.
+and spawn the preserved deterministic gather-demo path with one ant actor plus two food actors.

--- a/unreal_gatherers/README.md
+++ b/unreal_gatherers/README.md
@@ -7,9 +7,9 @@ Unreal 5.7 port of the `gatherers` simulation.
 Current implemented slice:
 
 - editor-only automation test module
-- random full-simulation game startup path with Rust-like ant row spacing and food count, now backed by Mass-managed sim state with actor proxies
-- preserved deterministic gather-demo path with one ant and two foods for explicit test/manual fixtures
-- preserved direct-actor full-simulation fixture specs for comparison and regression coverage
+- random full-simulation game startup path with Rust-like ant row spacing and food count, backed by Mass-managed sim state and dedicated subsystem-owned instanced-mesh visuals
+- preserved deterministic gather-demo path with one ant and two foods for explicit test/manual fixtures, now rendered through the Mass visual path by default
+- optional actor-spawn fixture coverage for focused comparison/regression tests that explicitly opt in to actor visuals
 - Mass-backed full-simulation runtime with heading-based movement, pickup/drop, cooldown, repeated gathering, and border turn-back
 - startup integration through `Aunreal_gatherersGameModeBase`
 - standalone `-game` launch into `SimBlank`
@@ -53,6 +53,7 @@ Useful targeted reruns:
 ```sh
 -ExecCmds="Automation RunTest default.unreal_gatherers.Placeholder.LoadsTestModule;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Spawning.SpawnPlanDefinesOneAntAndTwoFoods;Quit"
+-ExecCmds="Automation RunTest default.unreal_gatherers.Spawning.MassDefaultSpawnerSkipsAntAndFoodActors;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Spawning.WorldSpawnerCreatesAntAndTwoFoodActors;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntMovesAndPicksUpFoodInWorld;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Simulation.AntDropsFoodBackIntoWorld;Quit"
@@ -61,6 +62,7 @@ Useful targeted reruns:
 -ExecCmds="Automation RunTest default.unreal_gatherers.FullSimulationActorFixture;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Mass;Quit"
 -ExecCmds="Automation RunTest supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsRustLikeFullSimulationCounts;Quit"
+-ExecCmds="Automation RunTest supplemental.unreal_gatherers.Mass.MassVisualsStayStableAcrossLiveFrames;Quit"
 ```
 
 ## Run the visual gather demos
@@ -71,13 +73,13 @@ Deterministic gather-demo path:
 
 `manual.unreal_gatherers.Visual.AntFirstDropLeavesWorldForInspection`
 
-That visual/manual test loads `SimBlank` into a clean editor world, frames the viewport around the two-food layout, advances the ant through pickup and return, and leaves the first dropped-food state behind for inspection.
+That visual/manual test loads `SimBlank` into a clean editor world, frames the viewport around the two-food layout, advances the Mass sim through pickup and return, and leaves the first dropped-food state behind for inspection with instanced ant/food visuals.
 
 Full-simulation path:
 
 `manual.unreal_gatherers.Visual.FullSimulationSecondPickupStaysVisible`
 
-That visual/manual test also loads `SimBlank` into a clean editor world, but it uses the separate full-simulation spawn harness and runtime path. It shows a heading-driven ant pick up food, drop it, cool down, and reach a second pickup state for inspection.
+That visual/manual test also loads `SimBlank` into a clean editor world, but it uses the separate full-simulation spawn harness and runtime path. It shows a heading-driven ant pick up food, drop it, cool down, and reach a second pickup state for inspection through the Mass instanced-mesh visuals.
 
 ## Refresh editor indexing
 
@@ -106,9 +108,10 @@ The current startup path should load:
 
 and spawn the random full-simulation path by default:
 
-- 80 food actors at random positions
-- a Rust-like row of ants spaced 50 units apart across the play area
+- 80 food instances at random positions
+- a Rust-like row of ant instances spaced 50 units apart across the play area
 - random initial headings for those ants
-- Mass-managed ant/food simulation state synchronized into the spawned actors
+- Mass-managed ant/food simulation state rendered through dedicated ant/food instanced mesh components owned by the gatherers Mass subsystem
+- no per-entity `AAnt`/`AFood` runtime actor spawning on the default path
 
-The old one-ant/two-food deterministic setup is still preserved, and the direct-actor full-simulation comparison specs are preserved too, but the live full-simulation runtime now means the Mass-backed path.
+The old one-ant/two-food deterministic setup is still preserved, and explicit actor-spawn fixtures are still available for targeted regression coverage, but the live full-simulation runtime now means the actor-free Mass-backed path.

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
@@ -15,6 +15,9 @@ constexpr float AntMovementSpeed = 100.0f;
 constexpr float AntPickupRadius = 15.0f;
 constexpr float CarriedFoodHeight = 20.0f;
 constexpr float AntPickupCooldownSeconds = 0.5f;
+constexpr float AntSafeStepDistance = 18.0f;
+constexpr float AntPickupSeparationDistance = 50.0f;
+constexpr float AntTurnJitterRadians = PI / 2.0f;
 const FLinearColor AntColor(0.8f, 0.8f, 0.8f, 1.0f);
 const FVector AntVisualScale(0.2f, 0.2f, 0.2f);
 }
@@ -57,6 +60,41 @@ void AAnt::Tick(float DeltaSeconds)
 
 	const FVector CurrentLocation = GetActorLocation();
 	PickupCooldownRemainingSeconds = ComputeRemainingPickupCooldown(PickupCooldownRemainingSeconds, DeltaSeconds);
+
+	if (bUseFullSimulationMode)
+	{
+		const FVector NextLocation = ComputeAntHeadingMovementStep(
+			CurrentLocation,
+			MovementDirection,
+			AntMovementSpeed,
+			AntSafeStepDistance,
+			DeltaSeconds);
+		SetActorLocation(NextLocation);
+
+		if (PickupCooldownRemainingSeconds > 0.0f)
+		{
+			return;
+		}
+
+		if (AFood* NearbyLooseFood = FindLooseFoodInPickupRadius())
+		{
+			MovementDirection = ComputeAntTurnDirection(
+				MovementDirection,
+				FullSimulationRandomStream.FRandRange(-1.0f, 1.0f),
+				AntTurnJitterRadians);
+
+			if (IsCarryingFood())
+			{
+				DropFood();
+			}
+			else
+			{
+				PickUpFood(*NearbyLooseFood);
+			}
+		}
+
+		return;
+	}
 
 	if (IsCarryingFood())
 	{
@@ -101,6 +139,19 @@ void AAnt::Tick(float DeltaSeconds)
 	SetActorLocation(ComputeAntNextLocation(CurrentLocation, FoodLocation, AntMovementSpeed, DeltaSeconds));
 }
 
+void AAnt::ConfigureForFullSimulation(const FVector& InitialDirection, const FBox& PlayAreaBounds, int32 RandomSeed)
+{
+	bUseFullSimulationMode = true;
+	MovementDirection = InitialDirection.GetSafeNormal();
+	if (MovementDirection.IsNearlyZero())
+	{
+		MovementDirection = FVector(1.0f, 0.0f, 0.0f);
+	}
+
+	FullSimulationBounds = PlayAreaBounds;
+	FullSimulationRandomStream.Initialize(RandomSeed);
+}
+
 AFood* AAnt::FindClosestLooseFood() const
 {
 	UWorld* World = GetWorld();
@@ -131,6 +182,31 @@ AFood* AAnt::FindClosestLooseFood() const
 	return ClosestFood;
 }
 
+AFood* AAnt::FindLooseFoodInPickupRadius() const
+{
+	UWorld* World = GetWorld();
+	if (World == nullptr)
+	{
+		return nullptr;
+	}
+
+	for (TActorIterator<AFood> It(World); It; ++It)
+	{
+		AFood* Food = *It;
+		if (Food == nullptr || Food->GetAttachParentActor() != nullptr)
+		{
+			continue;
+		}
+
+		if (ShouldAntPickUpFood(GetActorLocation(), Food->GetActorLocation(), AntPickupRadius))
+		{
+			return Food;
+		}
+	}
+
+	return nullptr;
+}
+
 bool AAnt::IsCarryingFood() const
 {
 	return CarriedFood != nullptr;
@@ -152,6 +228,12 @@ void AAnt::DropFood()
 
 	CarriedFood->DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
 	CarriedFood = nullptr;
-	PickupCooldownRemainingSeconds = AntPickupCooldownSeconds;
-	MovementDirection = ComputeAntRetargetDirection(MovementDirection, 0.0f);
+	PickupCooldownRemainingSeconds = bUseFullSimulationMode
+		? ComputePickupCooldownForSeparationDistance(AntPickupSeparationDistance, AntMovementSpeed)
+		: AntPickupCooldownSeconds;
+
+	if (!bUseFullSimulationMode)
+	{
+		MovementDirection = ComputeAntRetargetDirection(MovementDirection, 0.0f);
+	}
 }

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
@@ -17,7 +17,6 @@ constexpr float CarriedFoodHeight = 20.0f;
 constexpr float AntPickupCooldownSeconds = 0.5f;
 constexpr float AntSafeStepDistance = 18.0f;
 constexpr float AntPickupSeparationDistance = 50.0f;
-constexpr float AntTurnJitterRadians = PI / 2.0f;
 const FLinearColor AntColor(0.8f, 0.8f, 0.8f, 1.0f);
 const FVector AntVisualScale(0.2f, 0.2f, 0.2f);
 }
@@ -113,7 +112,7 @@ void AAnt::Tick(float DeltaSeconds)
 			MovementDirection = ComputeAntTurnDirection(
 				MovementDirection,
 				FullSimulationRandomStream.FRandRange(-1.0f, 1.0f),
-				AntTurnJitterRadians);
+				FullSimulationTurnJitterRadians);
 
 			if (IsCarryingFood())
 			{
@@ -182,6 +181,11 @@ void AAnt::ConfigureForFullSimulation(const FVector& InitialDirection, const FBo
 
 	FullSimulationBounds = PlayAreaBounds;
 	FullSimulationRandomStream.Initialize(RandomSeed);
+}
+
+void AAnt::SetFullSimulationTurnJitterRadians(float InTurnJitterRadians)
+{
+	FullSimulationTurnJitterRadians = FMath::Max(0.0f, InTurnJitterRadians);
 }
 
 AFood* AAnt::FindClosestLooseFood() const
@@ -258,7 +262,9 @@ void AAnt::DropFood()
 		return;
 	}
 
+	const FVector DroppedFoodLocation = GetActorLocation();
 	CarriedFood->DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
+	CarriedFood->SetActorLocation(DroppedFoodLocation);
 	CarriedFood = nullptr;
 	PickupCooldownRemainingSeconds = bUseFullSimulationMode
 		? ComputePickupCooldownForSeparationDistance(AntPickupSeparationDistance, AntMovementSpeed)

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
@@ -63,12 +63,44 @@ void AAnt::Tick(float DeltaSeconds)
 
 	if (bUseFullSimulationMode)
 	{
-		const FVector NextLocation = ComputeAntHeadingMovementStep(
+		FVector NextLocation = ComputeAntHeadingMovementStep(
 			CurrentLocation,
 			MovementDirection,
 			AntMovementSpeed,
 			AntSafeStepDistance,
 			DeltaSeconds);
+
+		if (FullSimulationBounds.IsValid)
+		{
+			FVector InwardBoundaryNormal = FVector::ZeroVector;
+			if (NextLocation.X < FullSimulationBounds.Min.X)
+			{
+				NextLocation.X = FullSimulationBounds.Min.X;
+				InwardBoundaryNormal += FVector(1.0f, 0.0f, 0.0f);
+			}
+			else if (NextLocation.X > FullSimulationBounds.Max.X)
+			{
+				NextLocation.X = FullSimulationBounds.Max.X;
+				InwardBoundaryNormal += FVector(-1.0f, 0.0f, 0.0f);
+			}
+
+			if (NextLocation.Y < FullSimulationBounds.Min.Y)
+			{
+				NextLocation.Y = FullSimulationBounds.Min.Y;
+				InwardBoundaryNormal += FVector(0.0f, 1.0f, 0.0f);
+			}
+			else if (NextLocation.Y > FullSimulationBounds.Max.Y)
+			{
+				NextLocation.Y = FullSimulationBounds.Max.Y;
+				InwardBoundaryNormal += FVector(0.0f, -1.0f, 0.0f);
+			}
+
+			if (!InwardBoundaryNormal.IsNearlyZero())
+			{
+				MovementDirection = ComputeBoundaryTurnBackDirection(MovementDirection, InwardBoundaryNormal);
+			}
+		}
+
 		SetActorLocation(NextLocation);
 
 		if (PickupCooldownRemainingSeconds > 0.0f)

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
@@ -65,7 +65,7 @@ void AAnt::Tick(float DeltaSeconds)
 		FVector NextLocation = ComputeAntHeadingMovementStep(
 			CurrentLocation,
 			MovementDirection,
-			AntMovementSpeed,
+			FullSimulationMovementSpeed,
 			AntSafeStepDistance,
 			DeltaSeconds);
 
@@ -188,6 +188,11 @@ void AAnt::SetFullSimulationTurnJitterRadians(float InTurnJitterRadians)
 	FullSimulationTurnJitterRadians = FMath::Max(0.0f, InTurnJitterRadians);
 }
 
+void AAnt::SetFullSimulationMovementSpeed(float InMovementSpeed)
+{
+	FullSimulationMovementSpeed = FMath::Max(0.0f, InMovementSpeed);
+}
+
 AFood* AAnt::FindClosestLooseFood() const
 {
 	UWorld* World = GetWorld();
@@ -267,7 +272,7 @@ void AAnt::DropFood()
 	CarriedFood->SetActorLocation(DroppedFoodLocation);
 	CarriedFood = nullptr;
 	PickupCooldownRemainingSeconds = bUseFullSimulationMode
-		? ComputePickupCooldownForSeparationDistance(AntPickupSeparationDistance, AntMovementSpeed)
+		? ComputePickupCooldownForSeparationDistance(AntPickupSeparationDistance, FullSimulationMovementSpeed)
 		: AntPickupCooldownSeconds;
 
 	if (!bUseFullSimulationMode)

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Actors/Ant.cpp
@@ -1,30 +1,21 @@
 #include "Actors/Ant.h"
 
-#include "Actors/Food.h"
 #include "Components/SceneComponent.h"
 #include "Components/StaticMeshComponent.h"
-#include "EngineUtils.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Materials/MaterialInterface.h"
-#include "Simulation/GatherersAntSimulation.h"
 #include "UObject/ConstructorHelpers.h"
 
 namespace
 {
-constexpr float AntMovementSpeed = 100.0f;
-constexpr float AntPickupRadius = 15.0f;
-constexpr float CarriedFoodHeight = 20.0f;
-constexpr float AntPickupCooldownSeconds = 0.5f;
-constexpr float AntSafeStepDistance = 18.0f;
-constexpr float AntPickupSeparationDistance = 50.0f;
 const FLinearColor AntColor(0.8f, 0.8f, 0.8f, 1.0f);
 const FVector AntVisualScale(0.2f, 0.2f, 0.2f);
 }
 
 AAnt::AAnt()
 {
-	PrimaryActorTick.bCanEverTick = true;
-	PrimaryActorTick.bStartWithTickEnabled = true;
+	PrimaryActorTick.bCanEverTick = false;
+	PrimaryActorTick.bStartWithTickEnabled = false;
 
 	USceneComponent* Root = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
 	SetRootComponent(Root);
@@ -50,233 +41,5 @@ AAnt::AAnt()
 			Material->SetVectorParameterValue(TEXT("Color"), AntColor);
 			Visual->SetMaterial(0, Material);
 		}
-	}
-}
-
-void AAnt::Tick(float DeltaSeconds)
-{
-	Super::Tick(DeltaSeconds);
-
-	const FVector CurrentLocation = GetActorLocation();
-	PickupCooldownRemainingSeconds = ComputeRemainingPickupCooldown(PickupCooldownRemainingSeconds, DeltaSeconds);
-
-	if (bUseFullSimulationMode)
-	{
-		FVector NextLocation = ComputeAntHeadingMovementStep(
-			CurrentLocation,
-			MovementDirection,
-			FullSimulationMovementSpeed,
-			AntSafeStepDistance,
-			DeltaSeconds);
-
-		if (FullSimulationBounds.IsValid)
-		{
-			FVector InwardBoundaryNormal = FVector::ZeroVector;
-			if (NextLocation.X < FullSimulationBounds.Min.X)
-			{
-				NextLocation.X = FullSimulationBounds.Min.X;
-				InwardBoundaryNormal += FVector(1.0f, 0.0f, 0.0f);
-			}
-			else if (NextLocation.X > FullSimulationBounds.Max.X)
-			{
-				NextLocation.X = FullSimulationBounds.Max.X;
-				InwardBoundaryNormal += FVector(-1.0f, 0.0f, 0.0f);
-			}
-
-			if (NextLocation.Y < FullSimulationBounds.Min.Y)
-			{
-				NextLocation.Y = FullSimulationBounds.Min.Y;
-				InwardBoundaryNormal += FVector(0.0f, 1.0f, 0.0f);
-			}
-			else if (NextLocation.Y > FullSimulationBounds.Max.Y)
-			{
-				NextLocation.Y = FullSimulationBounds.Max.Y;
-				InwardBoundaryNormal += FVector(0.0f, -1.0f, 0.0f);
-			}
-
-			if (!InwardBoundaryNormal.IsNearlyZero())
-			{
-				MovementDirection = ComputeBoundaryTurnBackDirection(MovementDirection, InwardBoundaryNormal);
-			}
-		}
-
-		SetActorLocation(NextLocation);
-
-		if (PickupCooldownRemainingSeconds > 0.0f)
-		{
-			return;
-		}
-
-		if (AFood* NearbyLooseFood = FindLooseFoodInPickupRadius())
-		{
-			MovementDirection = ComputeAntTurnDirection(
-				MovementDirection,
-				FullSimulationRandomStream.FRandRange(-1.0f, 1.0f),
-				FullSimulationTurnJitterRadians);
-
-			if (IsCarryingFood())
-			{
-				DropFood();
-			}
-			else
-			{
-				PickUpFood(*NearbyLooseFood);
-			}
-		}
-
-		return;
-	}
-
-	if (IsCarryingFood())
-	{
-		SetActorLocation(CurrentLocation + MovementDirection.GetSafeNormal() * AntMovementSpeed * FMath::Max(0.0f, DeltaSeconds));
-
-		AFood* DropTargetFood = FindClosestLooseFood();
-		if (DropTargetFood != nullptr
-			&& ShouldAntPickUpFood(GetActorLocation(), DropTargetFood->GetActorLocation(), AntPickupRadius))
-		{
-			DropFood();
-		}
-
-		return;
-	}
-
-	if (PickupCooldownRemainingSeconds > 0.0f)
-	{
-		SetActorLocation(CurrentLocation + MovementDirection.GetSafeNormal() * AntMovementSpeed * FMath::Max(0.0f, DeltaSeconds));
-		return;
-	}
-
-	AFood* TargetFood = FindClosestLooseFood();
-	if (TargetFood == nullptr)
-	{
-		return;
-	}
-
-	const FVector FoodLocation = TargetFood->GetActorLocation();
-	const FVector ToFood = FoodLocation - CurrentLocation;
-	if (!ToFood.IsNearlyZero())
-	{
-		MovementDirection = ToFood.GetSafeNormal();
-	}
-
-	if (ShouldAntPickUpFood(CurrentLocation, FoodLocation, AntPickupRadius))
-	{
-		MovementDirection = ComputeAntRetargetDirection(MovementDirection, 0.0f);
-		PickUpFood(*TargetFood);
-		return;
-	}
-
-	SetActorLocation(ComputeAntNextLocation(CurrentLocation, FoodLocation, AntMovementSpeed, DeltaSeconds));
-}
-
-void AAnt::ConfigureForFullSimulation(const FVector& InitialDirection, const FBox& PlayAreaBounds, int32 RandomSeed)
-{
-	bUseFullSimulationMode = true;
-	MovementDirection = InitialDirection.GetSafeNormal();
-	if (MovementDirection.IsNearlyZero())
-	{
-		MovementDirection = FVector(1.0f, 0.0f, 0.0f);
-	}
-
-	FullSimulationBounds = PlayAreaBounds;
-	FullSimulationRandomStream.Initialize(RandomSeed);
-}
-
-void AAnt::SetFullSimulationTurnJitterRadians(float InTurnJitterRadians)
-{
-	FullSimulationTurnJitterRadians = FMath::Max(0.0f, InTurnJitterRadians);
-}
-
-void AAnt::SetFullSimulationMovementSpeed(float InMovementSpeed)
-{
-	FullSimulationMovementSpeed = FMath::Max(0.0f, InMovementSpeed);
-}
-
-AFood* AAnt::FindClosestLooseFood() const
-{
-	UWorld* World = GetWorld();
-	if (World == nullptr)
-	{
-		return nullptr;
-	}
-
-	AFood* ClosestFood = nullptr;
-	float ClosestDistanceSquared = TNumericLimits<float>::Max();
-
-	for (TActorIterator<AFood> It(World); It; ++It)
-	{
-		AFood* Food = *It;
-		if (Food == nullptr || Food->GetAttachParentActor() != nullptr)
-		{
-			continue;
-		}
-
-		const float DistanceSquared = FVector::DistSquared(GetActorLocation(), Food->GetActorLocation());
-		if (DistanceSquared < ClosestDistanceSquared)
-		{
-			ClosestDistanceSquared = DistanceSquared;
-			ClosestFood = Food;
-		}
-	}
-
-	return ClosestFood;
-}
-
-AFood* AAnt::FindLooseFoodInPickupRadius() const
-{
-	UWorld* World = GetWorld();
-	if (World == nullptr)
-	{
-		return nullptr;
-	}
-
-	for (TActorIterator<AFood> It(World); It; ++It)
-	{
-		AFood* Food = *It;
-		if (Food == nullptr || Food->GetAttachParentActor() != nullptr)
-		{
-			continue;
-		}
-
-		if (ShouldAntPickUpFood(GetActorLocation(), Food->GetActorLocation(), AntPickupRadius))
-		{
-			return Food;
-		}
-	}
-
-	return nullptr;
-}
-
-bool AAnt::IsCarryingFood() const
-{
-	return CarriedFood != nullptr;
-}
-
-void AAnt::PickUpFood(AFood& Food)
-{
-	CarriedFood = &Food;
-	Food.AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepWorldTransform);
-	Food.SetActorRelativeLocation(ComputeCarriedFoodRelativeLocation(CarriedFoodHeight));
-}
-
-void AAnt::DropFood()
-{
-	if (CarriedFood == nullptr)
-	{
-		return;
-	}
-
-	const FVector DroppedFoodLocation = GetActorLocation();
-	CarriedFood->DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
-	CarriedFood->SetActorLocation(DroppedFoodLocation);
-	CarriedFood = nullptr;
-	PickupCooldownRemainingSeconds = bUseFullSimulationMode
-		? ComputePickupCooldownForSeparationDistance(AntPickupSeparationDistance, FullSimulationMovementSpeed)
-		: AntPickupCooldownSeconds;
-
-	if (!bUseFullSimulationMode)
-	{
-		MovementDirection = ComputeAntRetargetDirection(MovementDirection, 0.0f);
 	}
 }

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
@@ -1,28 +1,5 @@
 #include "Simulation/GatherersAntSimulation.h"
 
-FVector ComputeAntNextLocation(
-	const FVector& CurrentLocation,
-	const FVector& FoodLocation,
-	float MovementSpeed,
-	float DeltaSeconds)
-{
-	const FVector ToFood = FoodLocation - CurrentLocation;
-	const float MaxStepDistance = FMath::Max(0.0f, MovementSpeed) * FMath::Max(0.0f, DeltaSeconds);
-	const float DistanceToFood = ToFood.Length();
-
-	if (DistanceToFood <= KINDA_SMALL_NUMBER || MaxStepDistance <= 0.0f)
-	{
-		return CurrentLocation;
-	}
-
-	if (DistanceToFood <= MaxStepDistance)
-	{
-		return FoodLocation;
-	}
-
-	return CurrentLocation + ToFood.GetSafeNormal() * MaxStepDistance;
-}
-
 FVector ComputeAntHeadingMovementStep(
 	const FVector& CurrentLocation,
 	const FVector& HeadingDirection,
@@ -72,32 +49,6 @@ FVector ComputeAntTurnDirection(
 {
 	const float ClampedJitterAlpha = FMath::Clamp(NormalizedJitterAlpha, -1.0f, 1.0f);
 	return ComputeAntRetargetDirection(CurrentDirection, ClampedJitterAlpha * FMath::Max(0.0f, MaxTurnJitterRadians));
-}
-
-int32 FindClosestLooseFoodTargetIndex(
-	const FVector& AntLocation,
-	const TArray<FGatherersFoodTarget>& FoodTargets)
-{
-	int32 ClosestLooseFoodIndex = INDEX_NONE;
-	float ClosestDistanceSquared = TNumericLimits<float>::Max();
-
-	for (int32 FoodIndex = 0; FoodIndex < FoodTargets.Num(); ++FoodIndex)
-	{
-		const FGatherersFoodTarget& FoodTarget = FoodTargets[FoodIndex];
-		if (!FoodTarget.bIsLoose)
-		{
-			continue;
-		}
-
-		const float DistanceSquared = FVector::DistSquared(AntLocation, FoodTarget.Location);
-		if (DistanceSquared < ClosestDistanceSquared)
-		{
-			ClosestDistanceSquared = DistanceSquared;
-			ClosestLooseFoodIndex = FoodIndex;
-		}
-	}
-
-	return ClosestLooseFoodIndex;
 }
 
 float ComputeRemainingPickupCooldown(

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
@@ -120,6 +120,21 @@ float ComputePickupCooldownForSeparationDistance(
 	return FMath::Max(0.0f, DesiredSeparationDistance) / SafeMovementSpeed;
 }
 
+FVector ComputeBoundaryTurnBackDirection(
+	const FVector& CurrentDirection,
+	const FVector& InwardBoundaryNormal)
+{
+	const FVector SafeDirection = CurrentDirection.GetSafeNormal();
+	const FVector SafeNormal = InwardBoundaryNormal.GetSafeNormal();
+	if (SafeDirection.IsNearlyZero() || SafeNormal.IsNearlyZero())
+	{
+		return FVector::ZeroVector;
+	}
+
+	const FVector ReflectedDirection = SafeDirection - 2.0f * FVector::DotProduct(SafeDirection, SafeNormal) * SafeNormal;
+	return ReflectedDirection.GetSafeNormal();
+}
+
 FVector ComputeCarriedFoodRelativeLocation(float CarriedFoodHeight)
 {
 	return FVector(0.0f, 0.0f, CarriedFoodHeight);

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
@@ -65,6 +65,15 @@ FVector ComputeAntRetargetDirection(
 	return FVector(FMath::Cos(RetargetAngle), FMath::Sin(RetargetAngle), 0.0f).GetSafeNormal();
 }
 
+FVector ComputeAntTurnDirection(
+	const FVector& CurrentDirection,
+	float NormalizedJitterAlpha,
+	float MaxTurnJitterRadians)
+{
+	const float ClampedJitterAlpha = FMath::Clamp(NormalizedJitterAlpha, -1.0f, 1.0f);
+	return ComputeAntRetargetDirection(CurrentDirection, ClampedJitterAlpha * FMath::Max(0.0f, MaxTurnJitterRadians));
+}
+
 int32 FindClosestLooseFoodTargetIndex(
 	const FVector& AntLocation,
 	const TArray<FGatherersFoodTarget>& FoodTargets)

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
@@ -23,6 +23,24 @@ FVector ComputeAntNextLocation(
 	return CurrentLocation + ToFood.GetSafeNormal() * MaxStepDistance;
 }
 
+FVector ComputeAntHeadingMovementStep(
+	const FVector& CurrentLocation,
+	const FVector& HeadingDirection,
+	float MovementSpeed,
+	float SafeStepDistance,
+	float DeltaSeconds)
+{
+	const FVector SafeHeading = HeadingDirection.GetSafeNormal();
+	if (SafeHeading.IsNearlyZero())
+	{
+		return CurrentLocation;
+	}
+
+	const float MaxDistanceThisFrame = FMath::Max(0.0f, MovementSpeed) * FMath::Max(0.0f, DeltaSeconds);
+	const float ClampedStepDistance = FMath::Min(MaxDistanceThisFrame, FMath::Max(0.0f, SafeStepDistance));
+	return CurrentLocation + SafeHeading * ClampedStepDistance;
+}
+
 bool ShouldAntPickUpFood(
 	const FVector& AntLocation,
 	const FVector& FoodLocation,

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersAntSimulation.cpp
@@ -107,6 +107,19 @@ float ComputeRemainingPickupCooldown(
 	return FMath::Max(0.0f, CurrentCooldownSeconds - FMath::Max(0.0f, DeltaSeconds));
 }
 
+float ComputePickupCooldownForSeparationDistance(
+	float DesiredSeparationDistance,
+	float MovementSpeed)
+{
+	const float SafeMovementSpeed = FMath::Max(0.0f, MovementSpeed);
+	if (SafeMovementSpeed <= KINDA_SMALL_NUMBER)
+	{
+		return 0.0f;
+	}
+
+	return FMath::Max(0.0f, DesiredSeparationDistance) / SafeMovementSpeed;
+}
+
 FVector ComputeCarriedFoodRelativeLocation(float CarriedFoodHeight)
 {
 	return FVector(0.0f, 0.0f, CarriedFoodHeight);

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -10,6 +10,43 @@
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 
+namespace
+{
+constexpr float MassPickupRadius = 15.0f;
+constexpr float MassCarriedFoodHeight = 20.0f;
+
+FGatherersMassFoodFragment* FindLooseFoodInPickupRadius(
+	FMassEntityManager& EntityManager,
+	const TArray<FMassEntityHandle>& FoodEntities,
+	const FVector& AntPosition,
+	FMassEntityHandle& OutFoodEntity)
+{
+	for (const FMassEntityHandle FoodEntity : FoodEntities)
+	{
+		if (!EntityManager.IsEntityValid(FoodEntity))
+		{
+			continue;
+		}
+
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		if (!FoodFragment.bIsLoose)
+		{
+			continue;
+		}
+
+		if (ShouldAntPickUpFood(AntPosition, FoodFragment.Position, MassPickupRadius))
+		{
+			OutFoodEntity = FoodEntity;
+			return &FoodFragment;
+		}
+	}
+
+	OutFoodEntity.Reset();
+	return nullptr;
+}
+}
+
 void UGatherersMassSubsystem::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
@@ -51,9 +88,34 @@ void UGatherersMassSubsystem::Tick(float DeltaTime)
 			18.0f,
 			DeltaTime);
 
+		if (!AntFragment.CarriedFoodEntity.IsValid() && AntFragment.PickupCooldownRemainingSeconds <= 0.0f)
+		{
+			FMassEntityHandle NearbyFoodEntity;
+			if (FGatherersMassFoodFragment* NearbyFood = FindLooseFoodInPickupRadius(
+				EntityManager,
+				ManagedFoodEntities,
+				AntFragment.Position,
+				NearbyFoodEntity))
+			{
+				AntFragment.CarriedFoodEntity = NearbyFoodEntity;
+				NearbyFood->bIsLoose = false;
+			}
+		}
+
 		if (AAnt* AntProxy = AntFragment.ProxyActor.Get())
 		{
 			AntProxy->SetActorLocation(AntFragment.Position);
+
+			if (AntFragment.CarriedFoodEntity.IsValid() && EntityManager.IsEntityValid(AntFragment.CarriedFoodEntity))
+			{
+				FMassEntityView FoodView(EntityManager, AntFragment.CarriedFoodEntity);
+				FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+				if (AFood* FoodProxy = FoodFragment.ProxyActor.Get())
+				{
+					FoodProxy->AttachToComponent(AntProxy->GetRootComponent(), FAttachmentTransformRules::KeepWorldTransform);
+					FoodProxy->SetActorRelativeLocation(ComputeCarriedFoodRelativeLocation(MassCarriedFoodHeight));
+				}
+			}
 		}
 	}
 }

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -2,10 +2,15 @@
 
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
+#include "Components/SceneComponent.h"
+#include "Engine/StaticMesh.h"
+#include "GameFramework/Actor.h"
 #include "Math/RandomStream.h"
 #include "MassEntityManager.h"
 #include "MassEntitySubsystem.h"
 #include "MassEntityView.h"
+#include "Materials/MaterialInstanceDynamic.h"
+#include "Materials/MaterialInterface.h"
 #include "StructUtils/InstancedStruct.h"
 #include "Simulation/GatherersAntSimulation.h"
 #include "Simulation/GatherersSpawnPlan.h"
@@ -16,6 +21,16 @@ namespace
 constexpr float MassPickupRadius = 15.0f;
 constexpr float MassCarriedFoodHeight = 20.0f;
 constexpr float MassPickupSeparationDistance = 50.0f;
+const FLinearColor MassAntColor(0.8f, 0.8f, 0.8f, 1.0f);
+const FLinearColor MassFoodColor(192.0f / 255.0f, 2.0f / 255.0f, 2.0f / 255.0f, 1.0f);
+const FVector MassAntVisualScale(0.2f, 0.2f, 0.2f);
+const FVector MassFoodVisualScale(0.1f, 0.1f, 0.1f);
+constexpr TCHAR SphereMeshPath[] = TEXT("/Engine/BasicShapes/Sphere.Sphere");
+constexpr TCHAR BasicShapeMaterialPath[] = TEXT("/Engine/BasicShapes/BasicShapeMaterial.BasicShapeMaterial");
+constexpr TCHAR VisualizerActorName[] = TEXT("GatherersMassVisualizer");
+constexpr TCHAR VisualizerRootName[] = TEXT("Root");
+constexpr TCHAR AntInstancesName[] = TEXT("AntInstances");
+constexpr TCHAR FoodInstancesName[] = TEXT("FoodInstances");
 
 FGatherersMassFoodFragment* FindLooseFoodInPickupRadius(
 	FMassEntityManager& EntityManager,
@@ -58,6 +73,238 @@ FVector ConsumeAntTurnDirection(FGatherersMassAntFragment& AntFragment)
 	AntFragment.RandomSeed = RandomStream.GetCurrentSeed();
 	return TurnDirection;
 }
+
+void ConfigureVisualComponent(
+	UInstancedStaticMeshComponent& Component,
+	USceneComponent& RootComponent,
+	UStaticMesh& Mesh,
+	UMaterialInterface& Material)
+{
+	if (!Component.IsRegistered())
+	{
+		Component.SetupAttachment(&RootComponent);
+		Component.RegisterComponent();
+	}
+
+	Component.SetStaticMesh(&Mesh);
+	Component.SetMaterial(0, &Material);
+	Component.SetMobility(EComponentMobility::Movable);
+	Component.SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	Component.SetCastShadow(false);
+	Component.SetCanEverAffectNavigation(false);
+}
+
+FTransform BuildVisualTransform(const FVector& Position, const FVector& VisualScale)
+{
+	return FTransform(FQuat::Identity, Position, VisualScale);
+}
+
+FVector ComputeFoodVisualPosition(
+	FMassEntityManager& EntityManager,
+	const TArray<FMassEntityHandle>& AntEntities,
+	FMassEntityHandle FoodEntity,
+	const FGatherersMassFoodFragment& FoodFragment)
+{
+	if (FoodFragment.bIsLoose)
+	{
+		return FoodFragment.Position;
+	}
+
+	for (const FMassEntityHandle AntEntity : AntEntities)
+	{
+		if (!EntityManager.IsEntityValid(AntEntity))
+		{
+			continue;
+		}
+
+		FMassEntityView AntView(EntityManager, AntEntity);
+		const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+		if (AntFragment.CarriedFoodEntity == FoodEntity)
+		{
+			return AntFragment.Position + ComputeCarriedFoodRelativeLocation(MassCarriedFoodHeight);
+		}
+	}
+
+	return FoodFragment.Position;
+}
+}
+
+bool UGatherersMassSubsystem::EnsureVisualComponents()
+{
+	if (!VisualSphereMesh)
+	{
+		VisualSphereMesh = LoadObject<UStaticMesh>(nullptr, SphereMeshPath);
+	}
+
+	UMaterialInterface* BaseMaterial = LoadObject<UMaterialInterface>(nullptr, BasicShapeMaterialPath);
+	if (VisualSphereMesh == nullptr || BaseMaterial == nullptr)
+	{
+		return false;
+	}
+
+	if (!AntVisualMaterial)
+	{
+		AntVisualMaterial = UMaterialInstanceDynamic::Create(BaseMaterial, this);
+		if (AntVisualMaterial)
+		{
+			AntVisualMaterial->SetVectorParameterValue(TEXT("Color"), MassAntColor);
+		}
+	}
+
+	if (!FoodVisualMaterial)
+	{
+		FoodVisualMaterial = UMaterialInstanceDynamic::Create(BaseMaterial, this);
+		if (FoodVisualMaterial)
+		{
+			FoodVisualMaterial->SetVectorParameterValue(TEXT("Color"), MassFoodColor);
+		}
+	}
+
+	if (AntVisualMaterial == nullptr || FoodVisualMaterial == nullptr)
+	{
+		return false;
+	}
+
+	UWorld* World = GetWorld();
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	if (!VisualizerActor)
+	{
+		FActorSpawnParameters SpawnParameters;
+		SpawnParameters.Name = VisualizerActorName;
+		SpawnParameters.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+		VisualizerActor = World->SpawnActor<AActor>(AActor::StaticClass(), FTransform::Identity, SpawnParameters);
+	}
+
+	if (VisualizerActor == nullptr)
+	{
+		return false;
+	}
+
+	USceneComponent* RootComponent = VisualizerActor->GetRootComponent();
+	if (RootComponent == nullptr)
+	{
+		RootComponent = NewObject<USceneComponent>(VisualizerActor, VisualizerRootName);
+		VisualizerActor->AddInstanceComponent(RootComponent);
+		RootComponent->RegisterComponent();
+		VisualizerActor->SetRootComponent(RootComponent);
+	}
+
+	if (!AntVisualComponent)
+	{
+		AntVisualComponent = NewObject<UInstancedStaticMeshComponent>(VisualizerActor, AntInstancesName);
+		VisualizerActor->AddInstanceComponent(AntVisualComponent);
+	}
+
+	if (!FoodVisualComponent)
+	{
+		FoodVisualComponent = NewObject<UInstancedStaticMeshComponent>(VisualizerActor, FoodInstancesName);
+		VisualizerActor->AddInstanceComponent(FoodVisualComponent);
+	}
+
+	ConfigureVisualComponent(*AntVisualComponent, *RootComponent, *VisualSphereMesh, *AntVisualMaterial);
+	ConfigureVisualComponent(*FoodVisualComponent, *RootComponent, *VisualSphereMesh, *FoodVisualMaterial);
+
+	return true;
+}
+
+void UGatherersMassSubsystem::RebuildVisualInstances(UMassEntitySubsystem& MassEntitySubsystem)
+{
+	if (!EnsureVisualComponents())
+	{
+		return;
+	}
+
+	AntVisualComponent->ClearInstances();
+	FoodVisualComponent->ClearInstances();
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem.GetMutableEntityManager();
+	for (const FMassEntityHandle AntEntity : ManagedAntEntities)
+	{
+		if (!EntityManager.IsEntityValid(AntEntity))
+		{
+			continue;
+		}
+
+		FMassEntityView AntView(EntityManager, AntEntity);
+		const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+		AntVisualComponent->AddInstance(BuildVisualTransform(AntFragment.Position, MassAntVisualScale), true);
+	}
+
+	for (const FMassEntityHandle FoodEntity : ManagedFoodEntities)
+	{
+		if (!EntityManager.IsEntityValid(FoodEntity))
+		{
+			continue;
+		}
+
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		FoodVisualComponent->AddInstance(
+			BuildVisualTransform(
+				ComputeFoodVisualPosition(EntityManager, ManagedAntEntities, FoodEntity, FoodFragment),
+				MassFoodVisualScale),
+			true);
+	}
+}
+
+void UGatherersMassSubsystem::SyncVisualInstances(UMassEntitySubsystem& MassEntitySubsystem)
+{
+	if (!EnsureVisualComponents())
+	{
+		return;
+	}
+
+	if (AntVisualComponent->GetInstanceCount() != ManagedAntEntities.Num()
+		|| FoodVisualComponent->GetInstanceCount() != ManagedFoodEntities.Num())
+	{
+		RebuildVisualInstances(MassEntitySubsystem);
+		return;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem.GetMutableEntityManager();
+	for (int32 AntIndex = 0; AntIndex < ManagedAntEntities.Num(); ++AntIndex)
+	{
+		const FMassEntityHandle AntEntity = ManagedAntEntities[AntIndex];
+		if (!EntityManager.IsEntityValid(AntEntity))
+		{
+			RebuildVisualInstances(MassEntitySubsystem);
+			return;
+		}
+
+		FMassEntityView AntView(EntityManager, AntEntity);
+		const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+		AntVisualComponent->UpdateInstanceTransform(
+			AntIndex,
+			BuildVisualTransform(AntFragment.Position, MassAntVisualScale),
+			true,
+			AntIndex == ManagedAntEntities.Num() - 1 && ManagedFoodEntities.Num() == 0,
+			true);
+	}
+
+	for (int32 FoodIndex = 0; FoodIndex < ManagedFoodEntities.Num(); ++FoodIndex)
+	{
+		const FMassEntityHandle FoodEntity = ManagedFoodEntities[FoodIndex];
+		if (!EntityManager.IsEntityValid(FoodEntity))
+		{
+			RebuildVisualInstances(MassEntitySubsystem);
+			return;
+		}
+
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		FoodVisualComponent->UpdateInstanceTransform(
+			FoodIndex,
+			BuildVisualTransform(
+				ComputeFoodVisualPosition(EntityManager, ManagedAntEntities, FoodEntity, FoodFragment),
+				MassFoodVisualScale),
+			true,
+			FoodIndex == ManagedFoodEntities.Num() - 1,
+			true);
+	}
 }
 
 void UGatherersMassSubsystem::Tick(float DeltaTime)
@@ -171,23 +418,9 @@ void UGatherersMassSubsystem::Tick(float DeltaTime)
 				NearbyFood->bIsLoose = false;
 			}
 		}
-
-		if (AAnt* AntProxy = AntFragment.ProxyActor.Get())
-		{
-			AntProxy->SetActorLocation(AntFragment.Position);
-
-			if (AntFragment.CarriedFoodEntity.IsValid() && EntityManager.IsEntityValid(AntFragment.CarriedFoodEntity))
-			{
-				FMassEntityView FoodView(EntityManager, AntFragment.CarriedFoodEntity);
-				FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
-				if (AFood* FoodProxy = FoodFragment.ProxyActor.Get())
-				{
-					FoodProxy->AttachToComponent(AntProxy->GetRootComponent(), FAttachmentTransformRules::KeepWorldTransform);
-					FoodProxy->SetActorRelativeLocation(ComputeCarriedFoodRelativeLocation(MassCarriedFoodHeight));
-				}
-			}
-		}
 	}
+
+	SyncVisualInstances(*MassEntitySubsystem);
 }
 
 TStatId UGatherersMassSubsystem::GetStatId() const
@@ -214,32 +447,21 @@ void UGatherersMassSubsystem::InitializeHybridSimulation(const FGatherersSpawnRe
 	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
 	SimulationBounds = Plan.PlayAreaBounds;
 
-	for (AFood* FoodProxy : SpawnResult.Foods)
+	for (int32 FoodIndex = 0; FoodIndex < Plan.FoodSpawns.Num(); ++FoodIndex)
 	{
-		if (FoodProxy == nullptr)
-		{
-			continue;
-		}
-
 		FGatherersMassFoodFragment FoodFragment;
-		FoodFragment.Position = FoodProxy->GetActorLocation();
-		FoodFragment.ProxyActor = FoodProxy;
+		FoodFragment.Position = Plan.FoodSpawns[FoodIndex].GetLocation();
+		FoodFragment.ProxyActor = SpawnResult.Foods.IsValidIndex(FoodIndex) ? SpawnResult.Foods[FoodIndex] : nullptr;
 
 		TArray<FInstancedStruct, TInlineAllocator<1>> FoodFragments;
 		FoodFragments.Add(FInstancedStruct::Make(FoodFragment));
 		ManagedFoodEntities.Add(EntityManager.CreateEntity(FoodFragments));
 	}
 
-	for (int32 AntIndex = 0; AntIndex < SpawnResult.Ants.Num(); ++AntIndex)
+	for (int32 AntIndex = 0; AntIndex < Plan.AntSpawns.Num(); ++AntIndex)
 	{
-		AAnt* AntProxy = SpawnResult.Ants[AntIndex];
-		if (AntProxy == nullptr)
-		{
-			continue;
-		}
-
 		FGatherersMassAntFragment AntFragment;
-		AntFragment.Position = AntProxy->GetActorLocation();
+		AntFragment.Position = Plan.AntSpawns[AntIndex].GetLocation();
 		AntFragment.Direction = Plan.AntInitialDirections.IsValidIndex(AntIndex)
 			? Plan.AntInitialDirections[AntIndex].GetSafeNormal()
 			: FVector(1.0f, 0.0f, 0.0f);
@@ -248,7 +470,7 @@ void UGatherersMassSubsystem::InitializeHybridSimulation(const FGatherersSpawnRe
 			AntFragment.Direction = FVector(1.0f, 0.0f, 0.0f);
 		}
 
-		AntFragment.ProxyActor = AntProxy;
+		AntFragment.ProxyActor = SpawnResult.Ants.IsValidIndex(AntIndex) ? SpawnResult.Ants[AntIndex] : nullptr;
 		AntFragment.RandomSeed = Plan.RandomSeedBase + AntIndex;
 		AntFragment.MovementSpeed = FMath::Max(0.0f, Plan.FullSimulationMovementSpeed);
 		AntFragment.TurnJitterRadians = FMath::Max(0.0f, Plan.FullSimulationTurnJitterRadians);
@@ -256,8 +478,9 @@ void UGatherersMassSubsystem::InitializeHybridSimulation(const FGatherersSpawnRe
 		TArray<FInstancedStruct, TInlineAllocator<1>> AntFragments;
 		AntFragments.Add(FInstancedStruct::Make(AntFragment));
 		ManagedAntEntities.Add(EntityManager.CreateEntity(AntFragments));
-		AntProxy->SetActorTickEnabled(false);
 	}
+
+	RebuildVisualInstances(*MassEntitySubsystem);
 }
 
 void UGatherersMassSubsystem::ResetSimulation()
@@ -279,6 +502,15 @@ void UGatherersMassSubsystem::ResetSimulation()
 	}
 
 	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	if (AntVisualComponent != nullptr)
+	{
+		AntVisualComponent->ClearInstances();
+	}
+	if (FoodVisualComponent != nullptr)
+	{
+		FoodVisualComponent->ClearInstances();
+	}
+
 	for (const FMassEntityHandle Entity : ManagedAntEntities)
 	{
 		if (EntityManager.IsEntityValid(Entity))
@@ -318,4 +550,14 @@ bool UGatherersMassSubsystem::HasManagedSimulation() const
 const FBox& UGatherersMassSubsystem::GetSimulationBounds() const
 {
 	return SimulationBounds;
+}
+
+const UInstancedStaticMeshComponent* UGatherersMassSubsystem::GetAntVisualComponent() const
+{
+	return AntVisualComponent;
+}
+
+const UInstancedStaticMeshComponent* UGatherersMassSubsystem::GetFoodVisualComponent() const
+{
+	return FoodVisualComponent;
 }

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -4,13 +4,58 @@
 #include "Actors/Food.h"
 #include "MassEntityManager.h"
 #include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "StructUtils/InstancedStruct.h"
+#include "Simulation/GatherersAntSimulation.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 
 void UGatherersMassSubsystem::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
+
+	if (!HasManagedSimulation())
+	{
+		return;
+	}
+
+	UWorld* World = GetWorld();
+	if (World == nullptr)
+	{
+		return;
+	}
+
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	if (MassEntitySubsystem == nullptr)
+	{
+		return;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	for (const FMassEntityHandle Entity : ManagedAntEntities)
+	{
+		if (!EntityManager.IsEntityValid(Entity))
+		{
+			continue;
+		}
+
+		FMassEntityView AntView(EntityManager, Entity);
+		FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+		AntFragment.PickupCooldownRemainingSeconds = ComputeRemainingPickupCooldown(
+			AntFragment.PickupCooldownRemainingSeconds,
+			DeltaTime);
+		AntFragment.Position = ComputeAntHeadingMovementStep(
+			AntFragment.Position,
+			AntFragment.Direction,
+			AntFragment.MovementSpeed,
+			18.0f,
+			DeltaTime);
+
+		if (AAnt* AntProxy = AntFragment.ProxyActor.Get())
+		{
+			AntProxy->SetActorLocation(AntFragment.Position);
+		}
+	}
 }
 
 TStatId UGatherersMassSubsystem::GetStatId() const

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -89,6 +89,37 @@ void UGatherersMassSubsystem::Tick(float DeltaTime)
 			18.0f,
 			DeltaTime);
 
+		if (AntFragment.PlayAreaBounds.IsValid)
+		{
+			FVector InwardBoundaryNormal = FVector::ZeroVector;
+			if (AntFragment.Position.X < AntFragment.PlayAreaBounds.Min.X)
+			{
+				AntFragment.Position.X = AntFragment.PlayAreaBounds.Min.X;
+				InwardBoundaryNormal += FVector(1.0f, 0.0f, 0.0f);
+			}
+			else if (AntFragment.Position.X > AntFragment.PlayAreaBounds.Max.X)
+			{
+				AntFragment.Position.X = AntFragment.PlayAreaBounds.Max.X;
+				InwardBoundaryNormal += FVector(-1.0f, 0.0f, 0.0f);
+			}
+
+			if (AntFragment.Position.Y < AntFragment.PlayAreaBounds.Min.Y)
+			{
+				AntFragment.Position.Y = AntFragment.PlayAreaBounds.Min.Y;
+				InwardBoundaryNormal += FVector(0.0f, 1.0f, 0.0f);
+			}
+			else if (AntFragment.Position.Y > AntFragment.PlayAreaBounds.Max.Y)
+			{
+				AntFragment.Position.Y = AntFragment.PlayAreaBounds.Max.Y;
+				InwardBoundaryNormal += FVector(0.0f, -1.0f, 0.0f);
+			}
+
+			if (!InwardBoundaryNormal.IsNearlyZero())
+			{
+				AntFragment.Direction = ComputeBoundaryTurnBackDirection(AntFragment.Direction, InwardBoundaryNormal);
+			}
+		}
+
 		FMassEntityHandle NearbyFoodEntity;
 		FGatherersMassFoodFragment* NearbyFood = FindLooseFoodInPickupRadius(
 			EntityManager,

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -14,6 +14,7 @@ namespace
 {
 constexpr float MassPickupRadius = 15.0f;
 constexpr float MassCarriedFoodHeight = 20.0f;
+constexpr float MassPickupSeparationDistance = 50.0f;
 
 FGatherersMassFoodFragment* FindLooseFoodInPickupRadius(
 	FMassEntityManager& EntityManager,
@@ -88,14 +89,37 @@ void UGatherersMassSubsystem::Tick(float DeltaTime)
 			18.0f,
 			DeltaTime);
 
-		if (!AntFragment.CarriedFoodEntity.IsValid() && AntFragment.PickupCooldownRemainingSeconds <= 0.0f)
+		FMassEntityHandle NearbyFoodEntity;
+		FGatherersMassFoodFragment* NearbyFood = FindLooseFoodInPickupRadius(
+			EntityManager,
+			ManagedFoodEntities,
+			AntFragment.Position,
+			NearbyFoodEntity);
+
+		if (AntFragment.CarriedFoodEntity.IsValid() && NearbyFood != nullptr)
 		{
-			FMassEntityHandle NearbyFoodEntity;
-			if (FGatherersMassFoodFragment* NearbyFood = FindLooseFoodInPickupRadius(
-				EntityManager,
-				ManagedFoodEntities,
-				AntFragment.Position,
-				NearbyFoodEntity))
+			if (EntityManager.IsEntityValid(AntFragment.CarriedFoodEntity))
+			{
+				FMassEntityView CarriedFoodView(EntityManager, AntFragment.CarriedFoodEntity);
+				FGatherersMassFoodFragment& CarriedFoodFragment = CarriedFoodView.GetFragmentData<FGatherersMassFoodFragment>();
+				CarriedFoodFragment.bIsLoose = true;
+				CarriedFoodFragment.Position = AntFragment.Position;
+
+				if (AFood* CarriedFoodProxy = CarriedFoodFragment.ProxyActor.Get())
+				{
+					CarriedFoodProxy->DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
+					CarriedFoodProxy->SetActorLocation(AntFragment.Position);
+				}
+			}
+
+			AntFragment.CarriedFoodEntity.Reset();
+			AntFragment.PickupCooldownRemainingSeconds = ComputePickupCooldownForSeparationDistance(
+				MassPickupSeparationDistance,
+				AntFragment.MovementSpeed);
+		}
+		else if (!AntFragment.CarriedFoodEntity.IsValid() && AntFragment.PickupCooldownRemainingSeconds <= 0.0f)
+		{
+			if (NearbyFood != nullptr)
 			{
 				AntFragment.CarriedFoodEntity = NearbyFoodEntity;
 				NearbyFood->bIsLoose = false;

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -2,6 +2,7 @@
 
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
+#include "Math/RandomStream.h"
 #include "MassEntityManager.h"
 #include "MassEntitySubsystem.h"
 #include "MassEntityView.h"
@@ -46,6 +47,17 @@ FGatherersMassFoodFragment* FindLooseFoodInPickupRadius(
 	OutFoodEntity.Reset();
 	return nullptr;
 }
+
+FVector ConsumeAntTurnDirection(FGatherersMassAntFragment& AntFragment)
+{
+	FRandomStream RandomStream(AntFragment.RandomSeed);
+	const FVector TurnDirection = ComputeAntTurnDirection(
+		AntFragment.Direction,
+		RandomStream.FRandRange(-1.0f, 1.0f),
+		AntFragment.TurnJitterRadians);
+	AntFragment.RandomSeed = RandomStream.GetCurrentSeed();
+	return TurnDirection;
+}
 }
 
 void UGatherersMassSubsystem::Tick(float DeltaTime)
@@ -89,28 +101,28 @@ void UGatherersMassSubsystem::Tick(float DeltaTime)
 			18.0f,
 			DeltaTime);
 
-		if (AntFragment.PlayAreaBounds.IsValid)
+		if (SimulationBounds.IsValid)
 		{
 			FVector InwardBoundaryNormal = FVector::ZeroVector;
-			if (AntFragment.Position.X < AntFragment.PlayAreaBounds.Min.X)
+			if (AntFragment.Position.X < SimulationBounds.Min.X)
 			{
-				AntFragment.Position.X = AntFragment.PlayAreaBounds.Min.X;
+				AntFragment.Position.X = SimulationBounds.Min.X;
 				InwardBoundaryNormal += FVector(1.0f, 0.0f, 0.0f);
 			}
-			else if (AntFragment.Position.X > AntFragment.PlayAreaBounds.Max.X)
+			else if (AntFragment.Position.X > SimulationBounds.Max.X)
 			{
-				AntFragment.Position.X = AntFragment.PlayAreaBounds.Max.X;
+				AntFragment.Position.X = SimulationBounds.Max.X;
 				InwardBoundaryNormal += FVector(-1.0f, 0.0f, 0.0f);
 			}
 
-			if (AntFragment.Position.Y < AntFragment.PlayAreaBounds.Min.Y)
+			if (AntFragment.Position.Y < SimulationBounds.Min.Y)
 			{
-				AntFragment.Position.Y = AntFragment.PlayAreaBounds.Min.Y;
+				AntFragment.Position.Y = SimulationBounds.Min.Y;
 				InwardBoundaryNormal += FVector(0.0f, 1.0f, 0.0f);
 			}
-			else if (AntFragment.Position.Y > AntFragment.PlayAreaBounds.Max.Y)
+			else if (AntFragment.Position.Y > SimulationBounds.Max.Y)
 			{
-				AntFragment.Position.Y = AntFragment.PlayAreaBounds.Max.Y;
+				AntFragment.Position.Y = SimulationBounds.Max.Y;
 				InwardBoundaryNormal += FVector(0.0f, -1.0f, 0.0f);
 			}
 
@@ -129,6 +141,8 @@ void UGatherersMassSubsystem::Tick(float DeltaTime)
 
 		if (AntFragment.CarriedFoodEntity.IsValid() && NearbyFood != nullptr)
 		{
+			AntFragment.Direction = ConsumeAntTurnDirection(AntFragment);
+
 			if (EntityManager.IsEntityValid(AntFragment.CarriedFoodEntity))
 			{
 				FMassEntityView CarriedFoodView(EntityManager, AntFragment.CarriedFoodEntity);
@@ -152,6 +166,7 @@ void UGatherersMassSubsystem::Tick(float DeltaTime)
 		{
 			if (NearbyFood != nullptr)
 			{
+				AntFragment.Direction = ConsumeAntTurnDirection(AntFragment);
 				AntFragment.CarriedFoodEntity = NearbyFoodEntity;
 				NearbyFood->bIsLoose = false;
 			}
@@ -197,6 +212,7 @@ void UGatherersMassSubsystem::InitializeHybridSimulation(const FGatherersSpawnRe
 	}
 
 	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	SimulationBounds = Plan.PlayAreaBounds;
 
 	for (AFood* FoodProxy : SpawnResult.Foods)
 	{
@@ -232,9 +248,10 @@ void UGatherersMassSubsystem::InitializeHybridSimulation(const FGatherersSpawnRe
 			AntFragment.Direction = FVector(1.0f, 0.0f, 0.0f);
 		}
 
-		AntFragment.PlayAreaBounds = Plan.PlayAreaBounds;
 		AntFragment.ProxyActor = AntProxy;
 		AntFragment.RandomSeed = Plan.RandomSeedBase + AntIndex;
+		AntFragment.MovementSpeed = FMath::Max(0.0f, Plan.FullSimulationMovementSpeed);
+		AntFragment.TurnJitterRadians = FMath::Max(0.0f, Plan.FullSimulationTurnJitterRadians);
 
 		TArray<FInstancedStruct, TInlineAllocator<1>> AntFragments;
 		AntFragments.Add(FInstancedStruct::Make(AntFragment));
@@ -280,6 +297,7 @@ void UGatherersMassSubsystem::ResetSimulation()
 
 	ManagedAntEntities.Reset();
 	ManagedFoodEntities.Reset();
+	SimulationBounds = FBox(EForceInit::ForceInit);
 }
 
 int32 UGatherersMassSubsystem::GetManagedAntCount() const
@@ -295,4 +313,9 @@ int32 UGatherersMassSubsystem::GetManagedFoodCount() const
 bool UGatherersMassSubsystem::HasManagedSimulation() const
 {
 	return ManagedAntEntities.Num() > 0 || ManagedFoodEntities.Num() > 0;
+}
+
+const FBox& UGatherersMassSubsystem::GetSimulationBounds() const
+{
+	return SimulationBounds;
 }

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -1,0 +1,136 @@
+#include "Simulation/GatherersMassSubsystem.h"
+
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "MassEntityManager.h"
+#include "MassEntitySubsystem.h"
+#include "StructUtils/InstancedStruct.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+void UGatherersMassSubsystem::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+}
+
+TStatId UGatherersMassSubsystem::GetStatId() const
+{
+	RETURN_QUICK_DECLARE_CYCLE_STAT(UGatherersMassSubsystem, STATGROUP_Tickables);
+}
+
+void UGatherersMassSubsystem::InitializeHybridSimulation(const FGatherersSpawnResult& SpawnResult, const FGatherersSpawnPlan& Plan)
+{
+	ResetSimulation();
+
+	UWorld* World = GetWorld();
+	if (World == nullptr)
+	{
+		return;
+	}
+
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	if (MassEntitySubsystem == nullptr)
+	{
+		return;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+
+	for (AFood* FoodProxy : SpawnResult.Foods)
+	{
+		if (FoodProxy == nullptr)
+		{
+			continue;
+		}
+
+		FGatherersMassFoodFragment FoodFragment;
+		FoodFragment.Position = FoodProxy->GetActorLocation();
+		FoodFragment.ProxyActor = FoodProxy;
+
+		TArray<FInstancedStruct, TInlineAllocator<1>> FoodFragments;
+		FoodFragments.Add(FInstancedStruct::Make(FoodFragment));
+		ManagedFoodEntities.Add(EntityManager.CreateEntity(FoodFragments));
+	}
+
+	for (int32 AntIndex = 0; AntIndex < SpawnResult.Ants.Num(); ++AntIndex)
+	{
+		AAnt* AntProxy = SpawnResult.Ants[AntIndex];
+		if (AntProxy == nullptr)
+		{
+			continue;
+		}
+
+		FGatherersMassAntFragment AntFragment;
+		AntFragment.Position = AntProxy->GetActorLocation();
+		AntFragment.Direction = Plan.AntInitialDirections.IsValidIndex(AntIndex)
+			? Plan.AntInitialDirections[AntIndex].GetSafeNormal()
+			: FVector(1.0f, 0.0f, 0.0f);
+		if (AntFragment.Direction.IsNearlyZero())
+		{
+			AntFragment.Direction = FVector(1.0f, 0.0f, 0.0f);
+		}
+
+		AntFragment.PlayAreaBounds = Plan.PlayAreaBounds;
+		AntFragment.ProxyActor = AntProxy;
+		AntFragment.RandomSeed = Plan.RandomSeedBase + AntIndex;
+
+		TArray<FInstancedStruct, TInlineAllocator<1>> AntFragments;
+		AntFragments.Add(FInstancedStruct::Make(AntFragment));
+		ManagedAntEntities.Add(EntityManager.CreateEntity(AntFragments));
+		AntProxy->SetActorTickEnabled(false);
+	}
+}
+
+void UGatherersMassSubsystem::ResetSimulation()
+{
+	UWorld* World = GetWorld();
+	if (World == nullptr)
+	{
+		ManagedAntEntities.Reset();
+		ManagedFoodEntities.Reset();
+		return;
+	}
+
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	if (MassEntitySubsystem == nullptr)
+	{
+		ManagedAntEntities.Reset();
+		ManagedFoodEntities.Reset();
+		return;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	for (const FMassEntityHandle Entity : ManagedAntEntities)
+	{
+		if (EntityManager.IsEntityValid(Entity))
+		{
+			EntityManager.DestroyEntity(Entity);
+		}
+	}
+
+	for (const FMassEntityHandle Entity : ManagedFoodEntities)
+	{
+		if (EntityManager.IsEntityValid(Entity))
+		{
+			EntityManager.DestroyEntity(Entity);
+		}
+	}
+
+	ManagedAntEntities.Reset();
+	ManagedFoodEntities.Reset();
+}
+
+int32 UGatherersMassSubsystem::GetManagedAntCount() const
+{
+	return ManagedAntEntities.Num();
+}
+
+int32 UGatherersMassSubsystem::GetManagedFoodCount() const
+{
+	return ManagedFoodEntities.Num();
+}
+
+bool UGatherersMassSubsystem::HasManagedSimulation() const
+{
+	return ManagedAntEntities.Num() > 0 || ManagedFoodEntities.Num() > 0;
+}

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
@@ -25,6 +25,7 @@ FGatherersSpawnPlan BuildDefaultGameFullSimulationSpawnPlan(
 {
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bUseMassSimulation = true;
 	Plan.PlayAreaBounds = PlayAreaBounds;
 	Plan.RandomSeedBase = RandomSeed;
 

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
@@ -13,7 +13,12 @@ constexpr float SpawnZ = 50.0f;
 FGatherersSpawnPlan BuildInitialGatherersSpawnPlan()
 {
 	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.RandomSeedBase = 123;
+	Plan.FullSimulationTurnJitterRadians = 0.0f;
 	Plan.AntSpawns.Add(FTransform(FVector(0.0f, 0.0f, 50.0f)));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
 	Plan.FoodSpawns.Add(FTransform(FVector(200.0f, 0.0f, 50.0f)));
 	Plan.FoodSpawns.Add(FTransform(FVector(-200.0f, 0.0f, 50.0f)));
 	return Plan;
@@ -25,7 +30,6 @@ FGatherersSpawnPlan BuildDefaultGameFullSimulationSpawnPlan(
 {
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
-	Plan.bUseMassSimulation = true;
 	Plan.PlayAreaBounds = PlayAreaBounds;
 	Plan.RandomSeedBase = RandomSeed;
 
@@ -104,6 +108,7 @@ FGatherersSpawnPlan BuildFullSimulationVisualSpawnPlan()
 	Plan.bUseFullSimulationMode = true;
 	Plan.PlayAreaBounds = FBox(FVector(-120.0f, -100.0f, -100.0f), FVector(120.0f, 100.0f, 100.0f));
 	Plan.RandomSeedBase = 123;
+	Plan.FullSimulationTurnJitterRadians = 0.0f;
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
 	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
@@ -14,6 +14,7 @@ FGatherersSpawnPlan BuildInitialGatherersSpawnPlan()
 {
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.RandomSeedBase = 123;
 	Plan.FullSimulationTurnJitterRadians = 0.0f;
@@ -30,6 +31,7 @@ FGatherersSpawnPlan BuildDefaultGameFullSimulationSpawnPlan(
 {
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = PlayAreaBounds;
 	Plan.RandomSeedBase = RandomSeed;
 
@@ -68,6 +70,7 @@ FGatherersSpawnPlan BuildFullSimulationSpawnPlan(
 {
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = PlayAreaBounds;
 	Plan.RandomSeedBase = RandomSeed;
 
@@ -106,6 +109,7 @@ FGatherersSpawnPlan BuildFullSimulationVisualSpawnPlan()
 {
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = FBox(FVector(-120.0f, -100.0f, -100.0f), FVector(120.0f, 100.0f, 100.0f));
 	Plan.RandomSeedBase = 123;
 	Plan.FullSimulationTurnJitterRadians = 0.0f;

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
@@ -8,3 +8,45 @@ FGatherersSpawnPlan BuildInitialGatherersSpawnPlan()
 	Plan.FoodSpawns.Add(FTransform(FVector(-200.0f, 0.0f, 50.0f)));
 	return Plan;
 }
+
+FGatherersSpawnPlan BuildFullSimulationSpawnPlan(
+	int32 AntCount,
+	int32 FoodCount,
+	int32 RandomSeed,
+	const FBox& PlayAreaBounds)
+{
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = PlayAreaBounds;
+	Plan.RandomSeedBase = RandomSeed;
+
+	FRandomStream RandomStream(RandomSeed);
+	const int32 SafeAntCount = FMath::Max(0, AntCount);
+	const int32 SafeFoodCount = FMath::Max(0, FoodCount);
+	const float AntZ = 50.0f;
+	const float FoodZ = 50.0f;
+	const float MinX = PlayAreaBounds.Min.X;
+	const float MaxX = PlayAreaBounds.Max.X;
+	const float MidY = (PlayAreaBounds.Min.Y + PlayAreaBounds.Max.Y) * 0.5f;
+
+	for (int32 AntIndex = 0; AntIndex < SafeAntCount; ++AntIndex)
+	{
+		const float AntX = SafeAntCount <= 1
+			? (MinX + MaxX) * 0.5f
+			: FMath::Lerp(MinX, MaxX, static_cast<float>(AntIndex) / static_cast<float>(SafeAntCount - 1));
+		Plan.AntSpawns.Add(FTransform(FVector(AntX, MidY, AntZ)));
+
+		const float HeadingAngle = RandomStream.FRandRange(0.0f, 2.0f * PI);
+		Plan.AntInitialDirections.Add(FVector(FMath::Cos(HeadingAngle), FMath::Sin(HeadingAngle), 0.0f));
+	}
+
+	for (int32 FoodIndex = 0; FoodIndex < SafeFoodCount; ++FoodIndex)
+	{
+		Plan.FoodSpawns.Add(FTransform(FVector(
+			RandomStream.FRandRange(PlayAreaBounds.Min.X, PlayAreaBounds.Max.X),
+			RandomStream.FRandRange(PlayAreaBounds.Min.Y, PlayAreaBounds.Max.Y),
+			FoodZ)));
+	}
+
+	return Plan;
+}

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
@@ -2,12 +2,56 @@
 
 #include "Math/RandomStream.h"
 
+namespace
+{
+constexpr int32 RustFoodCount = 80;
+constexpr int32 RustAntSpawnStep = 50;
+constexpr float RustAntSpawnY = 100.0f;
+constexpr float SpawnZ = 50.0f;
+}
+
 FGatherersSpawnPlan BuildInitialGatherersSpawnPlan()
 {
 	FGatherersSpawnPlan Plan;
 	Plan.AntSpawns.Add(FTransform(FVector(0.0f, 0.0f, 50.0f)));
 	Plan.FoodSpawns.Add(FTransform(FVector(200.0f, 0.0f, 50.0f)));
 	Plan.FoodSpawns.Add(FTransform(FVector(-200.0f, 0.0f, 50.0f)));
+	return Plan;
+}
+
+FGatherersSpawnPlan BuildDefaultGameFullSimulationSpawnPlan(
+	const FBox& PlayAreaBounds,
+	int32 RandomSeed)
+{
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = PlayAreaBounds;
+	Plan.RandomSeedBase = RandomSeed;
+
+	FRandomStream RandomStream(RandomSeed);
+	const FVector BoundsCenter = PlayAreaBounds.GetCenter();
+	const FVector BoundsExtent = PlayAreaBounds.GetExtent();
+	const int32 HalfX = static_cast<int32>(BoundsExtent.X);
+	const int32 HalfY = static_cast<int32>(BoundsExtent.Y);
+
+	for (int32 AntX = -HalfX; AntX < HalfX; AntX += RustAntSpawnStep)
+	{
+		Plan.AntSpawns.Add(FTransform(FVector(BoundsCenter.X + static_cast<float>(AntX), BoundsCenter.Y + RustAntSpawnY, SpawnZ)));
+
+		const float HeadingAngle = RandomStream.FRandRange(0.0f, 2.0f * PI);
+		Plan.AntInitialDirections.Add(FVector(FMath::Cos(HeadingAngle), FMath::Sin(HeadingAngle), 0.0f));
+	}
+
+	for (int32 FoodIndex = 0; FoodIndex < RustFoodCount; ++FoodIndex)
+	{
+		const int32 FoodX = RandomStream.RandRange(-HalfX, HalfX - 1);
+		const int32 FoodY = RandomStream.RandRange(-HalfY, HalfY - 1);
+		Plan.FoodSpawns.Add(FTransform(FVector(
+			BoundsCenter.X + static_cast<float>(FoodX),
+			BoundsCenter.Y + static_cast<float>(FoodY),
+			SpawnZ)));
+	}
+
 	return Plan;
 }
 

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersSpawnPlan.cpp
@@ -1,5 +1,7 @@
 #include "Simulation/GatherersSpawnPlan.h"
 
+#include "Math/RandomStream.h"
+
 FGatherersSpawnPlan BuildInitialGatherersSpawnPlan()
 {
 	FGatherersSpawnPlan Plan;
@@ -48,5 +50,19 @@ FGatherersSpawnPlan BuildFullSimulationSpawnPlan(
 			FoodZ)));
 	}
 
+	return Plan;
+}
+
+FGatherersSpawnPlan BuildFullSimulationVisualSpawnPlan()
+{
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-120.0f, -100.0f, -100.0f), FVector(120.0f, 100.0f, 100.0f));
+	Plan.RandomSeedBase = 123;
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(-10.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(50.0f, 0.0f, 0.0f)));
 	return Plan;
 }

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersWorldSpawner.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersWorldSpawner.cpp
@@ -3,6 +3,7 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Engine/World.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 
 FGatherersSpawnResult SpawnGatherersActors(UWorld& World, const FGatherersSpawnPlan& Plan)
@@ -31,6 +32,14 @@ FGatherersSpawnResult SpawnGatherersActors(UWorld& World, const FGatherersSpawnP
 		if (AFood* Food = World.SpawnActor<AFood>(AFood::StaticClass(), SpawnTransform))
 		{
 			Result.Foods.Add(Food);
+		}
+	}
+
+	if (Plan.bUseMassSimulation)
+	{
+		if (UGatherersMassSubsystem* MassSubsystem = World.GetSubsystem<UGatherersMassSubsystem>())
+		{
+			MassSubsystem->InitializeHybridSimulation(Result, Plan);
 		}
 	}
 

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersWorldSpawner.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersWorldSpawner.cpp
@@ -14,15 +14,6 @@ FGatherersSpawnResult SpawnGatherersActors(UWorld& World, const FGatherersSpawnP
 	{
 		if (AAnt* Ant = World.SpawnActor<AAnt>(AAnt::StaticClass(), SpawnTransform))
 		{
-			if (Plan.bUseFullSimulationMode)
-			{
-				const int32 SpawnIndex = Result.Ants.Num();
-				const FVector InitialDirection = Plan.AntInitialDirections.IsValidIndex(SpawnIndex)
-					? Plan.AntInitialDirections[SpawnIndex]
-					: FVector(1.0f, 0.0f, 0.0f);
-				Ant->ConfigureForFullSimulation(InitialDirection, Plan.PlayAreaBounds, Plan.RandomSeedBase + SpawnIndex);
-			}
-
 			Result.Ants.Add(Ant);
 		}
 	}
@@ -35,7 +26,7 @@ FGatherersSpawnResult SpawnGatherersActors(UWorld& World, const FGatherersSpawnP
 		}
 	}
 
-	if (Plan.bUseMassSimulation)
+	if (Plan.bUseFullSimulationMode)
 	{
 		if (UGatherersMassSubsystem* MassSubsystem = World.GetSubsystem<UGatherersMassSubsystem>())
 		{

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersWorldSpawner.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersWorldSpawner.cpp
@@ -10,19 +10,22 @@ FGatherersSpawnResult SpawnGatherersActors(UWorld& World, const FGatherersSpawnP
 {
 	FGatherersSpawnResult Result;
 
-	for (const FTransform& SpawnTransform : Plan.AntSpawns)
+	if (Plan.bSpawnActorVisuals)
 	{
-		if (AAnt* Ant = World.SpawnActor<AAnt>(AAnt::StaticClass(), SpawnTransform))
+		for (const FTransform& SpawnTransform : Plan.AntSpawns)
 		{
-			Result.Ants.Add(Ant);
+			if (AAnt* Ant = World.SpawnActor<AAnt>(AAnt::StaticClass(), SpawnTransform))
+			{
+				Result.Ants.Add(Ant);
+			}
 		}
-	}
 
-	for (const FTransform& SpawnTransform : Plan.FoodSpawns)
-	{
-		if (AFood* Food = World.SpawnActor<AFood>(AFood::StaticClass(), SpawnTransform))
+		for (const FTransform& SpawnTransform : Plan.FoodSpawns)
 		{
-			Result.Foods.Add(Food);
+			if (AFood* Food = World.SpawnActor<AFood>(AFood::StaticClass(), SpawnTransform))
+			{
+				Result.Foods.Add(Food);
+			}
 		}
 	}
 

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersWorldSpawner.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersWorldSpawner.cpp
@@ -13,6 +13,15 @@ FGatherersSpawnResult SpawnGatherersActors(UWorld& World, const FGatherersSpawnP
 	{
 		if (AAnt* Ant = World.SpawnActor<AAnt>(AAnt::StaticClass(), SpawnTransform))
 		{
+			if (Plan.bUseFullSimulationMode)
+			{
+				const int32 SpawnIndex = Result.Ants.Num();
+				const FVector InitialDirection = Plan.AntInitialDirections.IsValidIndex(SpawnIndex)
+					? Plan.AntInitialDirections[SpawnIndex]
+					: FVector(1.0f, 0.0f, 0.0f);
+				Ant->ConfigureForFullSimulation(InitialDirection, Plan.PlayAreaBounds, Plan.RandomSeedBase + SpawnIndex);
+			}
+
 			Result.Ants.Add(Ant);
 		}
 	}

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Actors/Ant.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Actors/Ant.h
@@ -15,6 +15,7 @@ public:
 	AAnt();
 	virtual void Tick(float DeltaSeconds) override;
 	void ConfigureForFullSimulation(const FVector& InitialDirection, const FBox& PlayAreaBounds, int32 RandomSeed);
+	void SetFullSimulationTurnJitterRadians(float InTurnJitterRadians);
 
 private:
 	AFood* FindClosestLooseFood() const;
@@ -28,5 +29,6 @@ private:
 	FBox FullSimulationBounds = FBox(EForceInit::ForceInit);
 	TObjectPtr<AFood> CarriedFood = nullptr;
 	float PickupCooldownRemainingSeconds = 0.0f;
+	float FullSimulationTurnJitterRadians = PI / 2.0f;
 	FRandomStream FullSimulationRandomStream;
 };

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Actors/Ant.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Actors/Ant.h
@@ -4,8 +4,6 @@
 #include "GameFramework/Actor.h"
 #include "Ant.generated.h"
 
-class AFood;
-
 UCLASS()
 class UNREAL_GATHERERS_API AAnt : public AActor
 {
@@ -13,24 +11,4 @@ class UNREAL_GATHERERS_API AAnt : public AActor
 
 public:
 	AAnt();
-	virtual void Tick(float DeltaSeconds) override;
-	void ConfigureForFullSimulation(const FVector& InitialDirection, const FBox& PlayAreaBounds, int32 RandomSeed);
-	void SetFullSimulationTurnJitterRadians(float InTurnJitterRadians);
-	void SetFullSimulationMovementSpeed(float InMovementSpeed);
-
-private:
-	AFood* FindClosestLooseFood() const;
-	AFood* FindLooseFoodInPickupRadius() const;
-	bool IsCarryingFood() const;
-	void PickUpFood(AFood& Food);
-	void DropFood();
-
-	bool bUseFullSimulationMode = false;
-	FVector MovementDirection = FVector(1.0f, 0.0f, 0.0f);
-	FBox FullSimulationBounds = FBox(EForceInit::ForceInit);
-	TObjectPtr<AFood> CarriedFood = nullptr;
-	float PickupCooldownRemainingSeconds = 0.0f;
-	float FullSimulationMovementSpeed = 100.0f;
-	float FullSimulationTurnJitterRadians = PI / 2.0f;
-	FRandomStream FullSimulationRandomStream;
 };

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Actors/Ant.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Actors/Ant.h
@@ -14,14 +14,19 @@ class UNREAL_GATHERERS_API AAnt : public AActor
 public:
 	AAnt();
 	virtual void Tick(float DeltaSeconds) override;
+	void ConfigureForFullSimulation(const FVector& InitialDirection, const FBox& PlayAreaBounds, int32 RandomSeed);
 
 private:
 	AFood* FindClosestLooseFood() const;
+	AFood* FindLooseFoodInPickupRadius() const;
 	bool IsCarryingFood() const;
 	void PickUpFood(AFood& Food);
 	void DropFood();
 
+	bool bUseFullSimulationMode = false;
 	FVector MovementDirection = FVector(1.0f, 0.0f, 0.0f);
+	FBox FullSimulationBounds = FBox(EForceInit::ForceInit);
 	TObjectPtr<AFood> CarriedFood = nullptr;
 	float PickupCooldownRemainingSeconds = 0.0f;
+	FRandomStream FullSimulationRandomStream;
 };

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Actors/Ant.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Actors/Ant.h
@@ -16,6 +16,7 @@ public:
 	virtual void Tick(float DeltaSeconds) override;
 	void ConfigureForFullSimulation(const FVector& InitialDirection, const FBox& PlayAreaBounds, int32 RandomSeed);
 	void SetFullSimulationTurnJitterRadians(float InTurnJitterRadians);
+	void SetFullSimulationMovementSpeed(float InMovementSpeed);
 
 private:
 	AFood* FindClosestLooseFood() const;
@@ -29,6 +30,7 @@ private:
 	FBox FullSimulationBounds = FBox(EForceInit::ForceInit);
 	TObjectPtr<AFood> CarriedFood = nullptr;
 	float PickupCooldownRemainingSeconds = 0.0f;
+	float FullSimulationMovementSpeed = 100.0f;
 	float FullSimulationTurnJitterRadians = PI / 2.0f;
 	FRandomStream FullSimulationRandomStream;
 };

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
@@ -14,6 +14,13 @@ UNREAL_GATHERERS_API FVector ComputeAntNextLocation(
 	float MovementSpeed,
 	float DeltaSeconds);
 
+UNREAL_GATHERERS_API FVector ComputeAntHeadingMovementStep(
+	const FVector& CurrentLocation,
+	const FVector& HeadingDirection,
+	float MovementSpeed,
+	float SafeStepDistance,
+	float DeltaSeconds);
+
 UNREAL_GATHERERS_API bool ShouldAntPickUpFood(
 	const FVector& AntLocation,
 	const FVector& FoodLocation,

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
@@ -30,6 +30,11 @@ UNREAL_GATHERERS_API FVector ComputeAntRetargetDirection(
 	const FVector& CurrentDirection,
 	float RetargetJitterRadians);
 
+UNREAL_GATHERERS_API FVector ComputeAntTurnDirection(
+	const FVector& CurrentDirection,
+	float NormalizedJitterAlpha,
+	float MaxTurnJitterRadians);
+
 UNREAL_GATHERERS_API int32 FindClosestLooseFoodTargetIndex(
 	const FVector& AntLocation,
 	const TArray<FGatherersFoodTarget>& FoodTargets);

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
@@ -47,4 +47,8 @@ UNREAL_GATHERERS_API float ComputePickupCooldownForSeparationDistance(
 	float DesiredSeparationDistance,
 	float MovementSpeed);
 
+UNREAL_GATHERERS_API FVector ComputeBoundaryTurnBackDirection(
+	const FVector& CurrentDirection,
+	const FVector& InwardBoundaryNormal);
+
 UNREAL_GATHERERS_API FVector ComputeCarriedFoodRelativeLocation(float CarriedFoodHeight);

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
@@ -2,18 +2,6 @@
 
 #include "CoreMinimal.h"
 
-struct UNREAL_GATHERERS_API FGatherersFoodTarget
-{
-	FVector Location;
-	bool bIsLoose = false;
-};
-
-UNREAL_GATHERERS_API FVector ComputeAntNextLocation(
-	const FVector& CurrentLocation,
-	const FVector& FoodLocation,
-	float MovementSpeed,
-	float DeltaSeconds);
-
 UNREAL_GATHERERS_API FVector ComputeAntHeadingMovementStep(
 	const FVector& CurrentLocation,
 	const FVector& HeadingDirection,
@@ -34,10 +22,6 @@ UNREAL_GATHERERS_API FVector ComputeAntTurnDirection(
 	const FVector& CurrentDirection,
 	float NormalizedJitterAlpha,
 	float MaxTurnJitterRadians);
-
-UNREAL_GATHERERS_API int32 FindClosestLooseFoodTargetIndex(
-	const FVector& AntLocation,
-	const TArray<FGatherersFoodTarget>& FoodTargets);
 
 UNREAL_GATHERERS_API float ComputeRemainingPickupCooldown(
 	float CurrentCooldownSeconds,

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersAntSimulation.h
@@ -43,4 +43,8 @@ UNREAL_GATHERERS_API float ComputeRemainingPickupCooldown(
 	float CurrentCooldownSeconds,
 	float DeltaSeconds);
 
+UNREAL_GATHERERS_API float ComputePickupCooldownForSeparationDistance(
+	float DesiredSeparationDistance,
+	float MovementSpeed);
+
 UNREAL_GATHERERS_API FVector ComputeCarriedFoodRelativeLocation(float CarriedFoodHeight);

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Components/InstancedStaticMeshComponent.h"
 #include "CoreMinimal.h"
 #include "MassEntityElementTypes.h"
 #include "MassEntityHandle.h"
@@ -8,7 +9,10 @@
 
 class AAnt;
 class AFood;
+class AActor;
 class UMassEntitySubsystem;
+class UMaterialInstanceDynamic;
+class UStaticMesh;
 struct FGatherersSpawnPlan;
 struct FGatherersSpawnResult;
 
@@ -65,8 +69,35 @@ public:
 	int32 GetManagedFoodCount() const;
 	bool HasManagedSimulation() const;
 	const FBox& GetSimulationBounds() const;
+	const UInstancedStaticMeshComponent* GetAntVisualComponent() const;
+	const UInstancedStaticMeshComponent* GetFoodVisualComponent() const;
 
+private:
+	bool EnsureVisualComponents();
+	void RebuildVisualInstances(UMassEntitySubsystem& MassEntitySubsystem);
+	void SyncVisualInstances(UMassEntitySubsystem& MassEntitySubsystem);
+
+public:
 	TArray<FMassEntityHandle> ManagedAntEntities;
 	TArray<FMassEntityHandle> ManagedFoodEntities;
 	FBox SimulationBounds = FBox(EForceInit::ForceInit);
+
+private:
+	UPROPERTY(Transient)
+	TObjectPtr<AActor> VisualizerActor = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UInstancedStaticMeshComponent> AntVisualComponent = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UInstancedStaticMeshComponent> FoodVisualComponent = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UStaticMesh> VisualSphereMesh = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UMaterialInstanceDynamic> AntVisualMaterial = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UMaterialInstanceDynamic> FoodVisualMaterial = nullptr;
 };

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
@@ -31,7 +31,6 @@ struct UNREAL_GATHERERS_API FGatherersMassAntFragment : public FMassFragment
 
 	FVector Position = FVector::ZeroVector;
 	FVector Direction = FVector(1.0f, 0.0f, 0.0f);
-	FBox PlayAreaBounds = FBox(EForceInit::ForceInit);
 	FMassEntityHandle CarriedFoodEntity;
 	TWeakObjectPtr<AAnt> ProxyActor = nullptr;
 	float PickupCooldownRemainingSeconds = 0.0f;
@@ -65,7 +64,9 @@ public:
 	int32 GetManagedAntCount() const;
 	int32 GetManagedFoodCount() const;
 	bool HasManagedSimulation() const;
+	const FBox& GetSimulationBounds() const;
 
 	TArray<FMassEntityHandle> ManagedAntEntities;
 	TArray<FMassEntityHandle> ManagedFoodEntities;
+	FBox SimulationBounds = FBox(EForceInit::ForceInit);
 };

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MassEntityElementTypes.h"
+#include "MassEntityHandle.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "GatherersMassSubsystem.generated.h"
+
+class AAnt;
+class AFood;
+class UMassEntitySubsystem;
+struct FGatherersSpawnPlan;
+struct FGatherersSpawnResult;
+
+USTRUCT()
+struct UNREAL_GATHERERS_API FGatherersMassAntTag : public FMassTag
+{
+	GENERATED_BODY()
+};
+
+USTRUCT()
+struct UNREAL_GATHERERS_API FGatherersMassFoodTag : public FMassTag
+{
+	GENERATED_BODY()
+};
+
+USTRUCT()
+struct UNREAL_GATHERERS_API FGatherersMassAntFragment : public FMassFragment
+{
+	GENERATED_BODY()
+
+	FVector Position = FVector::ZeroVector;
+	FVector Direction = FVector(1.0f, 0.0f, 0.0f);
+	FBox PlayAreaBounds = FBox(EForceInit::ForceInit);
+	FMassEntityHandle CarriedFoodEntity;
+	TWeakObjectPtr<AAnt> ProxyActor = nullptr;
+	float PickupCooldownRemainingSeconds = 0.0f;
+	float MovementSpeed = 100.0f;
+	float TurnJitterRadians = PI / 2.0f;
+	int32 RandomSeed = 0;
+};
+
+USTRUCT()
+struct UNREAL_GATHERERS_API FGatherersMassFoodFragment : public FMassFragment
+{
+	GENERATED_BODY()
+
+	FVector Position = FVector::ZeroVector;
+	TWeakObjectPtr<AFood> ProxyActor = nullptr;
+	bool bIsLoose = true;
+};
+
+UCLASS()
+class UNREAL_GATHERERS_API UGatherersMassSubsystem : public UTickableWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Tick(float DeltaTime) override;
+	virtual TStatId GetStatId() const override;
+
+	void InitializeHybridSimulation(const FGatherersSpawnResult& SpawnResult, const FGatherersSpawnPlan& Plan);
+	void ResetSimulation();
+
+	int32 GetManagedAntCount() const;
+	int32 GetManagedFoodCount() const;
+	bool HasManagedSimulation() const;
+
+	TArray<FMassEntityHandle> ManagedAntEntities;
+	TArray<FMassEntityHandle> ManagedFoodEntities;
+};

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
@@ -8,6 +8,7 @@ struct UNREAL_GATHERERS_API FGatherersSpawnPlan
 	TArray<FVector> AntInitialDirections;
 	TArray<FTransform> FoodSpawns;
 	bool bUseFullSimulationMode = false;
+	bool bUseMassSimulation = false;
 	FBox PlayAreaBounds = FBox(EForceInit::ForceInit);
 	int32 RandomSeedBase = 0;
 };

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
@@ -8,6 +8,7 @@ struct UNREAL_GATHERERS_API FGatherersSpawnPlan
 	TArray<FVector> AntInitialDirections;
 	TArray<FTransform> FoodSpawns;
 	bool bUseFullSimulationMode = false;
+	bool bSpawnActorVisuals = false;
 	FBox PlayAreaBounds = FBox(EForceInit::ForceInit);
 	int32 RandomSeedBase = 0;
 	float FullSimulationMovementSpeed = 100.0f;

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
@@ -18,3 +18,4 @@ UNREAL_GATHERERS_API FGatherersSpawnPlan BuildFullSimulationSpawnPlan(
 	int32 FoodCount,
 	int32 RandomSeed,
 	const FBox& PlayAreaBounds);
+UNREAL_GATHERERS_API FGatherersSpawnPlan BuildFullSimulationVisualSpawnPlan();

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
@@ -8,9 +8,10 @@ struct UNREAL_GATHERERS_API FGatherersSpawnPlan
 	TArray<FVector> AntInitialDirections;
 	TArray<FTransform> FoodSpawns;
 	bool bUseFullSimulationMode = false;
-	bool bUseMassSimulation = false;
 	FBox PlayAreaBounds = FBox(EForceInit::ForceInit);
 	int32 RandomSeedBase = 0;
+	float FullSimulationMovementSpeed = 100.0f;
+	float FullSimulationTurnJitterRadians = PI / 2.0f;
 };
 
 UNREAL_GATHERERS_API FGatherersSpawnPlan BuildInitialGatherersSpawnPlan();

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
@@ -18,4 +18,7 @@ UNREAL_GATHERERS_API FGatherersSpawnPlan BuildFullSimulationSpawnPlan(
 	int32 FoodCount,
 	int32 RandomSeed,
 	const FBox& PlayAreaBounds);
+UNREAL_GATHERERS_API FGatherersSpawnPlan BuildDefaultGameFullSimulationSpawnPlan(
+	const FBox& PlayAreaBounds,
+	int32 RandomSeed);
 UNREAL_GATHERERS_API FGatherersSpawnPlan BuildFullSimulationVisualSpawnPlan();

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersSpawnPlan.h
@@ -5,7 +5,16 @@
 struct UNREAL_GATHERERS_API FGatherersSpawnPlan
 {
 	TArray<FTransform> AntSpawns;
+	TArray<FVector> AntInitialDirections;
 	TArray<FTransform> FoodSpawns;
+	bool bUseFullSimulationMode = false;
+	FBox PlayAreaBounds = FBox(EForceInit::ForceInit);
+	int32 RandomSeedBase = 0;
 };
 
 UNREAL_GATHERERS_API FGatherersSpawnPlan BuildInitialGatherersSpawnPlan();
+UNREAL_GATHERERS_API FGatherersSpawnPlan BuildFullSimulationSpawnPlan(
+	int32 AntCount,
+	int32 FoodCount,
+	int32 RandomSeed,
+	const FBox& PlayAreaBounds);

--- a/unreal_gatherers/Source/unreal_gatherers/unreal_gatherers.Build.cs
+++ b/unreal_gatherers/Source/unreal_gatherers/unreal_gatherers.Build.cs
@@ -18,6 +18,7 @@ public class unreal_gatherers : ModuleRules
 			"MassCommon",
 			"MassActors",
 			"MassSimulation",
+			"MassRepresentation",
 		});
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });

--- a/unreal_gatherers/Source/unreal_gatherers/unreal_gatherers.Build.cs
+++ b/unreal_gatherers/Source/unreal_gatherers/unreal_gatherers.Build.cs
@@ -8,7 +8,17 @@ public class unreal_gatherers : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore" });
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine",
+			"InputCore",
+			"MassEntity",
+			"MassCommon",
+			"MassActors",
+			"MassSimulation",
+		});
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 

--- a/unreal_gatherers/Source/unreal_gatherers/unreal_gatherersGameModeBase.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/unreal_gatherersGameModeBase.cpp
@@ -3,8 +3,14 @@
 
 #include "unreal_gatherersGameModeBase.h"
 
+#include "HAL/PlatformTime.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
+
+namespace
+{
+const FBox DefaultGamePlayAreaBounds(FVector(-640.0f, -360.0f, -100.0f), FVector(640.0f, 360.0f, 100.0f));
+}
 
 void Aunreal_gatherersGameModeBase::StartPlay()
 {
@@ -12,7 +18,9 @@ void Aunreal_gatherersGameModeBase::StartPlay()
 
 	if (UWorld* World = GetWorld())
 	{
-		SpawnGatherersActors(*World, BuildInitialGatherersSpawnPlan());
+		SpawnGatherersActors(
+			*World,
+			BuildDefaultGameFullSimulationSpawnPlan(DefaultGamePlayAreaBounds, static_cast<int32>(FPlatformTime::Cycles())));
 	}
 }
 

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/ActorVisuals.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/ActorVisuals.spec.cpp
@@ -1,9 +1,7 @@
-#include "Actors/Ant.h"
-#include "Actors/Food.h"
-#include "Components/StaticMeshComponent.h"
 #include "Editor.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 
@@ -21,7 +19,7 @@ bool ColorsMatch(const FLinearColor& Left, const FLinearColor& Right)
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersActorVisualsAutomationTest,
-	"default.unreal_gatherers.Visual.ActorsExposeRustColorVisuals",
+	"default.unreal_gatherers.Visual.MassInstancedVisualsExposeRustColorVisuals",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FGatherersActorVisualsAutomationTest::RunTest(const FString& Parameters)
@@ -34,20 +32,34 @@ bool FGatherersActorVisualsAutomationTest::RunTest(const FString& Parameters)
 		return false;
 	}
 
-	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, BuildInitialGatherersSpawnPlan());
-	TestEqual(TEXT("spawned ant count"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("spawned food count"), Result.Foods.Num(), 2);
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 2)
+	if (MassSubsystem == nullptr)
 	{
 		return false;
 	}
 
-	UStaticMeshComponent* AntVisual = Result.Ants[0]->FindComponentByClass<UStaticMeshComponent>();
-	UStaticMeshComponent* FoodVisual = Result.Foods[0]->FindComponentByClass<UStaticMeshComponent>();
+	MassSubsystem->ResetSimulation();
 
-	TestNotNull(TEXT("ant should have a visible mesh component"), AntVisual);
-	TestNotNull(TEXT("food should have a visible mesh component"), FoodVisual);
+	FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+	Plan.bSpawnActorVisuals = false;
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("Mass subsystem tracks one ant entity"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("Mass subsystem tracks two food entities"), MassSubsystem->GetManagedFoodCount(), 2);
+	MassSubsystem->Tick(0.1f);
+
+	if (MassSubsystem->ManagedAntEntities.Num() != 1 || MassSubsystem->ManagedFoodEntities.Num() != 2)
+	{
+		return false;
+	}
+
+	const UInstancedStaticMeshComponent* AntVisual = MassSubsystem->GetAntVisualComponent();
+	const UInstancedStaticMeshComponent* FoodVisual = MassSubsystem->GetFoodVisualComponent();
+	TestNotNull(TEXT("ant should have a visible instanced mesh component"), const_cast<UInstancedStaticMeshComponent*>(AntVisual));
+	TestNotNull(TEXT("food should have a visible instanced mesh component"), const_cast<UInstancedStaticMeshComponent*>(FoodVisual));
 
 	if (AntVisual != nullptr)
 	{
@@ -76,22 +88,6 @@ bool FGatherersActorVisualsAutomationTest::RunTest(const FString& Parameters)
 				ColorsMatch(FoodMaterial->K2_GetVectorParameterValue(ColorParameterName), ExpectedFoodColor));
 		}
 	}
-
-	for (AAnt* Ant : Result.Ants)
-	{
-		if (Ant != nullptr)
-		{
-			Ant->Destroy();
-		}
-	}
-
-	for (AFood* Food : Result.Foods)
-	{
-		if (Food != nullptr)
-		{
-			Food->Destroy();
-		}
-	}
-
+	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntPickupActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntPickupActor.spec.cpp
@@ -1,9 +1,11 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "EngineUtils.h"
 #include "HAL/PlatformTime.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
 #include "TestLogic/GatherersWorldAssertions.h"
 #include "Tests/AutomationCommon.h"
 #include "Tests/AutomationEditorCommon.h"
@@ -26,6 +28,50 @@ DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(
 	FGatherersQueueSecondDropSimulationRunCommand,
 	FAutomationTestBase*,
 	Test);
+
+class FGatherersPrepareDeterministicSimulationFixtureCommand : public IAutomationLatentCommand
+{
+public:
+	explicit FGatherersPrepareDeterministicSimulationFixtureCommand(FAutomationTestBase* InTest)
+		: Test(InTest)
+	{
+	}
+
+	virtual bool Update() override
+	{
+		UWorld* World = GEditor ? GEditor->PlayWorld : nullptr;
+		Test->TestNotNull(TEXT("simulation world should exist for deterministic fixture setup"), World);
+		if (World == nullptr)
+		{
+			return true;
+		}
+
+		const GatherersWorldAssertions::FObservedWorldState ExistingWorldState = GatherersWorldAssertions::Observe(World);
+		for (AAnt* Ant : ExistingWorldState.Ants)
+		{
+			if (Ant != nullptr)
+			{
+				Ant->Destroy();
+			}
+		}
+
+		for (AFood* Food : ExistingWorldState.Foods)
+		{
+			if (Food != nullptr)
+			{
+				Food->Destroy();
+			}
+		}
+
+		const FGatherersSpawnResult SpawnResult = SpawnGatherersActors(*World, BuildInitialGatherersSpawnPlan());
+		Test->TestEqual(TEXT("deterministic simulation fixture ant count"), SpawnResult.Ants.Num(), 1);
+		Test->TestEqual(TEXT("deterministic simulation fixture food count"), SpawnResult.Foods.Num(), 2);
+		return true;
+	}
+
+private:
+	FAutomationTestBase* Test;
+};
 
 class FGatherersWaitForSimulationPIECleanupCommand : public IAutomationLatentCommand
 {
@@ -200,6 +246,7 @@ bool FGatherersQueueSecondSimulationRunCommand::Update()
 		return true;
 	}
 
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareDeterministicSimulationFixtureCommand(Test));
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPickupCommand(Test, FPlatformTime::Seconds(), 5.0));
 	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPIECleanupCommand(Test, 5.0));
@@ -216,6 +263,7 @@ bool FGatherersQueueSecondDropSimulationRunCommand::Update()
 		return true;
 	}
 
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareDeterministicSimulationFixtureCommand(Test));
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForDropStateCommand(Test, FPlatformTime::Seconds(), 8.0));
 	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPIECleanupCommand(Test, 5.0));

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntPickupActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntPickupActor.spec.cpp
@@ -71,9 +71,11 @@ public:
 			}
 		}
 
-		const FGatherersSpawnResult SpawnResult = SpawnGatherersActors(*World, BuildInitialGatherersSpawnPlan());
-		Test->TestEqual(TEXT("deterministic simulation fixture ant count"), SpawnResult.Ants.Num(), 1);
-		Test->TestEqual(TEXT("deterministic simulation fixture food count"), SpawnResult.Foods.Num(), 2);
+		FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+		Plan.bSpawnActorVisuals = false;
+		const FGatherersSpawnResult SpawnResult = SpawnGatherersActors(*World, Plan);
+		Test->TestEqual(TEXT("deterministic simulation fixture ant actor count"), SpawnResult.Ants.Num(), 0);
+		Test->TestEqual(TEXT("deterministic simulation fixture food actor count"), SpawnResult.Foods.Num(), 0);
 		if (MassSubsystem != nullptr)
 		{
 			Test->TestEqual(TEXT("deterministic simulation fixture managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
@@ -135,22 +137,19 @@ public:
 			return true;
 		}
 
-		const GatherersWorldAssertions::FObservedWorldState WorldState = GatherersWorldAssertions::Observe(World);
-		AAnt* Ant = WorldState.GetSingleAnt();
-		AFood* AttachedFood = WorldState.GetFirstAttachedFood();
-		const bool bPickedUpFood = Ant != nullptr && AttachedFood != nullptr && AttachedFood->GetAttachParentActor() == Ant
-			&& WorldState.CountAttachedFoods() == 1;
+		const GatherersWorldAssertions::FObservedMassVisualState VisualState = GatherersWorldAssertions::ObserveMassVisuals(World);
+		const bool bPickedUpFood = VisualState.HasCarriedFoodVisual(20.0f);
 
 		if (bPickedUpFood && !PickupLocation.IsSet())
 		{
-			PickupLocation = Ant->GetActorLocation();
+			PickupLocation = VisualState.AntPositions[0];
 			return false;
 		}
 
 		if (bPickedUpFood && PickupLocation.IsSet())
 		{
 			const bool bAntMovedWhileCarrying =
-				!Ant->GetActorLocation().Equals(PickupLocation.GetValue(), KINDA_SMALL_NUMBER);
+				!VisualState.AntPositions[0].Equals(PickupLocation.GetValue(), KINDA_SMALL_NUMBER);
 			if (bAntMovedWhileCarrying)
 			{
 				Test->TestTrue(TEXT("ant keeps moving after pickup while carrying food"), true);
@@ -193,22 +192,17 @@ public:
 			return true;
 		}
 
-		const FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
-		const GatherersWorldAssertions::FObservedWorldState WorldState = GatherersWorldAssertions::Observe(World);
-		const bool bHasOneAntAndTwoFoods = WorldState.Ants.Num() == 1 && WorldState.Foods.Num() == 2;
-		bool bAnyFoodAttached = false;
+		FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+		Plan.bSpawnActorVisuals = false;
+		const GatherersWorldAssertions::FObservedMassVisualState VisualState = GatherersWorldAssertions::ObserveMassVisuals(World);
+		const bool bHasOneAntAndTwoFoods = VisualState.HasSingleAntAndTwoFoods();
+		const bool bAnyFoodAttached = VisualState.HasCarriedFoodVisual(20.0f);
 		bool bDroppedFoodLeftInitialForwardSpawn = false;
 
-		for (AFood* Food : WorldState.Foods)
+		for (const FVector& FoodPosition : VisualState.FoodPositions)
 		{
-			if (Food == nullptr)
-			{
-				continue;
-			}
-
-			bAnyFoodAttached |= Food->GetAttachParentActor() != nullptr;
 			bDroppedFoodLeftInitialForwardSpawn |=
-				!Food->GetActorLocation().Equals(Plan.FoodSpawns[0].GetLocation(), KINDA_SMALL_NUMBER);
+				!FoodPosition.Equals(Plan.FoodSpawns[0].GetLocation(), KINDA_SMALL_NUMBER);
 		}
 
 		if (bAnyFoodAttached)
@@ -240,13 +234,19 @@ private:
 
 bool FGatherersWaitForSimulationPickupCommand::Update()
 {
-	return GatherersWorldAssertions::PollForPickupState(
+	return GatherersWorldAssertions::PollForMassPickupState(
 		*Test,
 		GEditor ? GEditor->PlayWorld : nullptr,
-		BuildInitialGatherersSpawnPlan(),
+		[]()
+		{
+			FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+			Plan.bSpawnActorVisuals = false;
+			return Plan;
+		}(),
 		StartTimeSeconds,
 		TimeoutSeconds,
-		TEXT("simulation"));
+		TEXT("simulation"),
+		20.0f);
 }
 
 bool FGatherersQueueSecondSimulationRunCommand::Update()

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntPickupActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntPickupActor.spec.cpp
@@ -4,6 +4,7 @@
 #include "EngineUtils.h"
 #include "HAL/PlatformTime.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 #include "TestLogic/GatherersWorldAssertions.h"
@@ -46,6 +47,13 @@ public:
 			return true;
 		}
 
+		UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+		Test->TestNotNull(TEXT("simulation world should expose the gatherers Mass subsystem"), MassSubsystem);
+		if (MassSubsystem != nullptr)
+		{
+			MassSubsystem->ResetSimulation();
+		}
+
 		const GatherersWorldAssertions::FObservedWorldState ExistingWorldState = GatherersWorldAssertions::Observe(World);
 		for (AAnt* Ant : ExistingWorldState.Ants)
 		{
@@ -66,6 +74,11 @@ public:
 		const FGatherersSpawnResult SpawnResult = SpawnGatherersActors(*World, BuildInitialGatherersSpawnPlan());
 		Test->TestEqual(TEXT("deterministic simulation fixture ant count"), SpawnResult.Ants.Num(), 1);
 		Test->TestEqual(TEXT("deterministic simulation fixture food count"), SpawnResult.Foods.Num(), 2);
+		if (MassSubsystem != nullptr)
+		{
+			Test->TestEqual(TEXT("deterministic simulation fixture managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+			Test->TestEqual(TEXT("deterministic simulation fixture managed food count"), MassSubsystem->GetManagedFoodCount(), 2);
+		}
 		return true;
 	}
 

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntPickupActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntPickupActor.spec.cpp
@@ -237,6 +237,7 @@ bool FGatherersAntPickupActorAutomationTest::RunTest(const FString& Parameters)
 		return false;
 	}
 
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareDeterministicSimulationFixtureCommand(this));
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPickupCommand(this, FPlatformTime::Seconds(), 5.0));
 	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPIECleanupCommand(this, 5.0));
@@ -258,6 +259,7 @@ bool FGatherersAntPickupActorRerunAutomationTest::RunTest(const FString& Paramet
 		return false;
 	}
 
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareDeterministicSimulationFixtureCommand(this));
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPickupCommand(this, FPlatformTime::Seconds(), 5.0));
 	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPIECleanupCommand(this, 5.0));
@@ -280,6 +282,7 @@ bool FGatherersAntCarryMovementAutomationTest::RunTest(const FString& Parameters
 		return false;
 	}
 
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareDeterministicSimulationFixtureCommand(this));
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForCarryMovementCommand(this, FPlatformTime::Seconds(), 5.0));
 	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPIECleanupCommand(this, 5.0));
@@ -301,6 +304,7 @@ bool FGatherersAntDropFoodAutomationTest::RunTest(const FString& Parameters)
 		return false;
 	}
 
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareDeterministicSimulationFixtureCommand(this));
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForDropStateCommand(this, FPlatformTime::Seconds(), 8.0));
 	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPIECleanupCommand(this, 20.0));
@@ -322,6 +326,7 @@ bool FGatherersAntDropFoodRerunAutomationTest::RunTest(const FString& Parameters
 		return false;
 	}
 
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareDeterministicSimulationFixtureCommand(this));
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForDropStateCommand(this, FPlatformTime::Seconds(), 8.0));
 	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSimulationPIECleanupCommand(this, 5.0));

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
@@ -3,24 +3,6 @@
 #include "Simulation/GatherersAntSimulation.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
-	FGatherersAntMovementStepAutomationTest,
-	"default.unreal_gatherers.Simulation.AntMovementStepMovesTowardFood",
-	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
-
-bool FGatherersAntMovementStepAutomationTest::RunTest(const FString& Parameters)
-{
-	const FVector CurrentLocation(-50.0f, 0.0f, 0.0f);
-	const FVector FoodLocation(50.0f, 0.0f, 0.0f);
-
-	const FVector NextLocation = ComputeAntNextLocation(CurrentLocation, FoodLocation, 100.0f, 0.1f);
-
-	TestTrue(
-		TEXT("ant moves ten units toward food in one step"),
-		NextLocation.Equals(FVector(-40.0f, 0.0f, 0.0f), KINDA_SMALL_NUMBER));
-	return true;
-}
-
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersAntPickupRadiusAutomationTest,
 	"default.unreal_gatherers.Simulation.AntPickupTriggersWithinRadius",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
@@ -49,24 +31,6 @@ bool FGatherersAntRetargetDirectionAutomationTest::RunTest(const FString& Parame
 	TestTrue(
 		TEXT("ant reverses heading when retarget jitter is zero"),
 		RetargetedDirection.Equals(FVector(-1.0f, 0.0f, 0.0f), KINDA_SMALL_NUMBER));
-	return true;
-}
-
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(
-	FGatherersClosestLooseFoodAutomationTest,
-	"default.unreal_gatherers.Simulation.AntTargetsNearestLooseFood",
-	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
-
-bool FGatherersClosestLooseFoodAutomationTest::RunTest(const FString& Parameters)
-{
-	TArray<FGatherersFoodTarget> FoodTargets;
-	FoodTargets.Add({FVector(400.0f, 0.0f, 0.0f), true});
-	FoodTargets.Add({FVector(100.0f, 0.0f, 0.0f), false});
-	FoodTargets.Add({FVector(200.0f, 0.0f, 0.0f), true});
-
-	const int32 ClosestLooseFoodIndex = FindClosestLooseFoodTargetIndex(FVector::ZeroVector, FoodTargets);
-
-	TestEqual(TEXT("ant picks the nearest loose food and ignores carried food"), ClosestLooseFoodIndex, 2);
 	return true;
 }
 

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
@@ -131,3 +131,19 @@ bool FGatherersFullSimTurnDirectionAutomationTest::RunTest(const FString& Parame
 		TurnedDirection.Equals(FVector(0.0f, -1.0f, 0.0f), KINDA_SMALL_NUMBER));
 	return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersPickupSeparationCooldownAutomationTest,
+	"default.unreal_gatherers.Simulation.FullSimPickupCooldownPreservesDropSeparationDistance",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersPickupSeparationCooldownAutomationTest::RunTest(const FString& Parameters)
+{
+	const float CooldownSeconds = ComputePickupCooldownForSeparationDistance(50.0f, 100.0f);
+
+	TestEqual(
+		TEXT("full-sim cooldown can be derived from the desired separation distance and movement speed"),
+		CooldownSeconds,
+		0.5f);
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
@@ -115,3 +115,19 @@ bool FGatherersHeadingMovementStepAutomationTest::RunTest(const FString& Paramet
 		NextLocation.Equals(FVector(18.0f, 0.0f, 0.0f), KINDA_SMALL_NUMBER));
 	return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersFullSimTurnDirectionAutomationTest,
+	"default.unreal_gatherers.Simulation.FullSimTurnDirectionUsesAboutFacePlusBoundedJitter",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersFullSimTurnDirectionAutomationTest::RunTest(const FString& Parameters)
+{
+	const FVector CurrentDirection(1.0f, 0.0f, 0.0f);
+	const FVector TurnedDirection = ComputeAntTurnDirection(CurrentDirection, 1.0f, PI / 2.0f);
+
+	TestTrue(
+		TEXT("full-sim pickup/drop turn can rotate up to the positive jitter bound around an about-face turn"),
+		TurnedDirection.Equals(FVector(0.0f, -1.0f, 0.0f), KINDA_SMALL_NUMBER));
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
@@ -97,3 +97,21 @@ bool FGatherersCarriedFoodOffsetAutomationTest::RunTest(const FString& Parameter
 		CarriedFoodOffset.Equals(FVector(0.0f, 0.0f, 20.0f), KINDA_SMALL_NUMBER));
 	return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersHeadingMovementStepAutomationTest,
+	"default.unreal_gatherers.Simulation.FullSimHeadingMovementUsesSafeStepCap",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersHeadingMovementStepAutomationTest::RunTest(const FString& Parameters)
+{
+	const FVector CurrentLocation(0.0f, 0.0f, 0.0f);
+	const FVector HeadingDirection(1.0f, 0.0f, 0.0f);
+
+	const FVector NextLocation = ComputeAntHeadingMovementStep(CurrentLocation, HeadingDirection, 1000.0f, 18.0f, 0.1f);
+
+	TestTrue(
+		TEXT("full-sim movement clamps to the safe step distance instead of tunneling past it"),
+		NextLocation.Equals(FVector(18.0f, 0.0f, 0.0f), KINDA_SMALL_NUMBER));
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/AntSimulation.spec.cpp
@@ -147,3 +147,21 @@ bool FGatherersPickupSeparationCooldownAutomationTest::RunTest(const FString& Pa
 		0.5f);
 	return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersBoundaryTurnBackAutomationTest,
+	"default.unreal_gatherers.Simulation.FullSimBoundaryTurnBackReflectsHeadingInward",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersBoundaryTurnBackAutomationTest::RunTest(const FString& Parameters)
+{
+	const FVector CurrentDirection(1.0f, 0.0f, 0.0f);
+	const FVector InwardBoundaryNormal(-1.0f, 0.0f, 0.0f);
+
+	const FVector TurnedDirection = ComputeBoundaryTurnBackDirection(CurrentDirection, InwardBoundaryNormal);
+
+	TestTrue(
+		TEXT("boundary turn-back reflects the heading back into the play area"),
+		TurnedDirection.Equals(FVector(-1.0f, 0.0f, 0.0f), KINDA_SMALL_NUMBER));
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
@@ -43,3 +43,39 @@ bool FGatherersFullSimulationIgnoresOffPathFoodAutomationTest::RunTest(const FSt
 	Food->Destroy();
 	return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersFullSimulationBorderTurnBackAutomationTest,
+	"default.unreal_gatherers.FullSimulation.AntTurnsBackAtPlayAreaBorder",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersFullSimulationBorderTurnBackAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
+	TestNotNull(TEXT("full-sim border ant should spawn"), Ant);
+
+	if (Ant == nullptr)
+	{
+		return false;
+	}
+
+	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-10.0f, -100.0f, -100.0f), FVector(10.0f, 100.0f, 100.0f)), 123);
+	Ant->Tick(0.1f);
+	Ant->Tick(0.1f);
+	Ant->Tick(0.1f);
+
+	TestTrue(
+		TEXT("full-sim ant stays inside the play area after touching the border"),
+		Ant->GetActorLocation().X <= 10.0f + KINDA_SMALL_NUMBER);
+
+	Ant->Destroy();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
@@ -2,119 +2,174 @@
 #include "Actors/Food.h"
 #include "Editor.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+namespace
+{
+UGatherersMassSubsystem* RequireMassSubsystem(FAutomationTestBase& Test, UWorld* World)
+{
+	Test.TestNotNull(TEXT("editor world should exist"), World);
+	if (World == nullptr)
+	{
+		return nullptr;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	Test.TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+	if (MassSubsystem != nullptr)
+	{
+		MassSubsystem->ResetSimulation();
+	}
+
+	return MassSubsystem;
+}
+
+void DestroySpawnedActors(const FGatherersSpawnResult& Result)
+{
+	for (AAnt* Ant : Result.Ants)
+	{
+		if (Ant != nullptr)
+		{
+			Ant->Destroy();
+		}
+	}
+
+	for (AFood* Food : Result.Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+}
+}
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersFullSimulationIgnoresOffPathFoodAutomationTest,
-	"default.unreal_gatherers.FullSimulation.AntKeepsHeadingWhenFoodIsOffPath",
+	"default.unreal_gatherers.FullSimulationActorFixture.AntKeepsHeadingWhenFoodIsOffPath",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FGatherersFullSimulationIgnoresOffPathFoodAutomationTest::RunTest(const FString& Parameters)
 {
 	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
-	TestNotNull(TEXT("editor world should exist"), World);
-
-	if (World == nullptr)
+	UGatherersMassSubsystem* MassSubsystem = RequireMassSubsystem(*this, World);
+	if (MassSubsystem == nullptr)
 	{
 		return false;
 	}
 
-	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
-	AFood* Food = World->SpawnActor<AFood>(AFood::StaticClass(), FTransform(FVector(0.0f, 200.0f, 0.0f)));
-	TestNotNull(TEXT("full-sim ant should spawn"), Ant);
-	TestNotNull(TEXT("full-sim food should spawn"), Food);
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(0.0f, 200.0f, 0.0f)));
 
-	if (Ant == nullptr || Food == nullptr)
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("full-sim spawned ant count"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("full-sim spawned food count"), Result.Foods.Num(), 1);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
 	{
 		return false;
 	}
-
-	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f)), 123);
 
 	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
 	{
-		Ant->Tick(0.1f);
+		MassSubsystem->Tick(0.1f);
 	}
 
 	TestTrue(
 		TEXT("full-sim ant keeps moving forward instead of steering toward off-path food"),
-		Ant->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
+		Result.Ants[0]->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
 
-	Ant->Destroy();
-	Food->Destroy();
+	DestroySpawnedActors(Result);
+	MassSubsystem->ResetSimulation();
 	return true;
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersFullSimulationBorderTurnBackAutomationTest,
-	"default.unreal_gatherers.FullSimulation.AntTurnsBackAtPlayAreaBorder",
+	"default.unreal_gatherers.FullSimulationActorFixture.AntTurnsBackAtPlayAreaBorder",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FGatherersFullSimulationBorderTurnBackAutomationTest::RunTest(const FString& Parameters)
 {
 	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
-	TestNotNull(TEXT("editor world should exist"), World);
-
-	if (World == nullptr)
+	UGatherersMassSubsystem* MassSubsystem = RequireMassSubsystem(*this, World);
+	if (MassSubsystem == nullptr)
 	{
 		return false;
 	}
 
-	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
-	TestNotNull(TEXT("full-sim border ant should spawn"), Ant);
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-10.0f, -100.0f, -100.0f), FVector(10.0f, 100.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
 
-	if (Ant == nullptr)
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("full-sim border spawned ant count"), Result.Ants.Num(), 1);
+
+	if (Result.Ants.Num() != 1)
 	{
 		return false;
 	}
 
-	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-10.0f, -100.0f, -100.0f), FVector(10.0f, 100.0f, 100.0f)), 123);
-	Ant->Tick(0.1f);
-	Ant->Tick(0.1f);
-	Ant->Tick(0.1f);
+	MassSubsystem->Tick(0.1f);
+	MassSubsystem->Tick(0.1f);
+	MassSubsystem->Tick(0.1f);
 
 	TestTrue(
 		TEXT("full-sim ant stays inside the play area after touching the border"),
-		Ant->GetActorLocation().X <= 10.0f + KINDA_SMALL_NUMBER);
+		Result.Ants[0]->GetActorLocation().X <= 10.0f + KINDA_SMALL_NUMBER);
 
-	Ant->Destroy();
+	DestroySpawnedActors(Result);
+	MassSubsystem->ResetSimulation();
 	return true;
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersFullSimulationHighSpeedPickupAutomationTest,
-	"default.unreal_gatherers.FullSimulation.HighSpeedMovementStillPicksUpWithoutTunneling",
+	"default.unreal_gatherers.FullSimulationActorFixture.HighSpeedMovementStillPicksUpWithoutTunneling",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FGatherersFullSimulationHighSpeedPickupAutomationTest::RunTest(const FString& Parameters)
 {
 	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
-	TestNotNull(TEXT("editor world should exist"), World);
-
-	if (World == nullptr)
+	UGatherersMassSubsystem* MassSubsystem = RequireMassSubsystem(*this, World);
+	if (MassSubsystem == nullptr)
 	{
 		return false;
 	}
 
-	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
-	AFood* Food = World->SpawnActor<AFood>(AFood::StaticClass(), FTransform(FVector(15.0f, 0.0f, 0.0f)));
-	TestNotNull(TEXT("high-speed ant should spawn"), Ant);
-	TestNotNull(TEXT("high-speed food should spawn"), Food);
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(15.0f, 0.0f, 0.0f)));
+	Plan.FullSimulationMovementSpeed = 5000.0f;
+	Plan.FullSimulationTurnJitterRadians = 0.0f;
 
-	if (Ant == nullptr || Food == nullptr)
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("high-speed spawned ant count"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("high-speed spawned food count"), Result.Foods.Num(), 1);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
 	{
 		return false;
 	}
 
-	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f)), 123);
-	Ant->SetFullSimulationTurnJitterRadians(0.0f);
-	Ant->SetFullSimulationMovementSpeed(5000.0f);
-	Ant->Tick(1.0f);
+	MassSubsystem->Tick(1.0f);
 
 	TestTrue(
 		TEXT("safe-step movement still lets a nearby food be picked up during a long high-speed frame"),
-		Food->GetAttachParentActor() == Ant);
+		Result.Foods[0]->GetAttachParentActor() == Result.Ants[0]);
 
-	Ant->Destroy();
-	Food->Destroy();
+	DestroySpawnedActors(Result);
+	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
@@ -79,3 +79,42 @@ bool FGatherersFullSimulationBorderTurnBackAutomationTest::RunTest(const FString
 	Ant->Destroy();
 	return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersFullSimulationHighSpeedPickupAutomationTest,
+	"default.unreal_gatherers.FullSimulation.HighSpeedMovementStillPicksUpWithoutTunneling",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersFullSimulationHighSpeedPickupAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
+	AFood* Food = World->SpawnActor<AFood>(AFood::StaticClass(), FTransform(FVector(15.0f, 0.0f, 0.0f)));
+	TestNotNull(TEXT("high-speed ant should spawn"), Ant);
+	TestNotNull(TEXT("high-speed food should spawn"), Food);
+
+	if (Ant == nullptr || Food == nullptr)
+	{
+		return false;
+	}
+
+	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f)), 123);
+	Ant->SetFullSimulationTurnJitterRadians(0.0f);
+	Ant->SetFullSimulationMovementSpeed(5000.0f);
+	Ant->Tick(1.0f);
+
+	TestTrue(
+		TEXT("safe-step movement still lets a nearby food be picked up during a long high-speed frame"),
+		Food->GetAttachParentActor() == Ant);
+
+	Ant->Destroy();
+	Food->Destroy();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
@@ -1,0 +1,45 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersFullSimulationIgnoresOffPathFoodAutomationTest,
+	"default.unreal_gatherers.FullSimulation.AntKeepsHeadingWhenFoodIsOffPath",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersFullSimulationIgnoresOffPathFoodAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
+	AFood* Food = World->SpawnActor<AFood>(AFood::StaticClass(), FTransform(FVector(0.0f, 200.0f, 0.0f)));
+	TestNotNull(TEXT("full-sim ant should spawn"), Ant);
+	TestNotNull(TEXT("full-sim food should spawn"), Food);
+
+	if (Ant == nullptr || Food == nullptr)
+	{
+		return false;
+	}
+
+	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f)), 123);
+
+	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
+	{
+		Ant->Tick(0.1f);
+	}
+
+	TestTrue(
+		TEXT("full-sim ant keeps moving forward instead of steering toward off-path food"),
+		Ant->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
+
+	Ant->Destroy();
+	Food->Destroy();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
@@ -1,6 +1,6 @@
-#include "Actors/Ant.h"
-#include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
@@ -25,25 +25,6 @@ UGatherersMassSubsystem* RequireMassSubsystem(FAutomationTestBase& Test, UWorld*
 
 	return MassSubsystem;
 }
-
-void DestroySpawnedActors(const FGatherersSpawnResult& Result)
-{
-	for (AAnt* Ant : Result.Ants)
-	{
-		if (Ant != nullptr)
-		{
-			Ant->Destroy();
-		}
-	}
-
-	for (AFood* Food : Result.Foods)
-	{
-		if (Food != nullptr)
-		{
-			Food->Destroy();
-		}
-	}
-}
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
@@ -62,16 +43,19 @@ bool FGatherersFullSimulationIgnoresOffPathFoodAutomationTest::RunTest(const FSt
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
 	Plan.FoodSpawns.Add(FTransform(FVector(0.0f, 200.0f, 0.0f)));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("full-sim spawned ant count"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("full-sim spawned food count"), Result.Foods.Num(), 1);
+	TestEqual(TEXT("full-sim spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("full-sim spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("full-sim managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("full-sim managed food count"), MassSubsystem->GetManagedFoodCount(), 1);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 1)
 	{
 		return false;
 	}
@@ -81,11 +65,20 @@ bool FGatherersFullSimulationIgnoresOffPathFoodAutomationTest::RunTest(const FSt
 		MassSubsystem->Tick(0.1f);
 	}
 
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 	TestTrue(
 		TEXT("full-sim ant keeps moving forward instead of steering toward off-path food"),
-		Result.Ants[0]->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
+		AntFragment.Position.Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
 
-	DestroySpawnedActors(Result);
 	MassSubsystem->ResetSimulation();
 	return true;
 }
@@ -106,14 +99,16 @@ bool FGatherersFullSimulationBorderTurnBackAutomationTest::RunTest(const FString
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = FBox(FVector(-10.0f, -100.0f, -100.0f), FVector(10.0f, 100.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("full-sim border spawned ant count"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("full-sim border spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("full-sim border managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
 
-	if (Result.Ants.Num() != 1)
+	if (MassSubsystem->GetManagedAntCount() != 1)
 	{
 		return false;
 	}
@@ -122,11 +117,20 @@ bool FGatherersFullSimulationBorderTurnBackAutomationTest::RunTest(const FString
 	MassSubsystem->Tick(0.1f);
 	MassSubsystem->Tick(0.1f);
 
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 	TestTrue(
 		TEXT("full-sim ant stays inside the play area after touching the border"),
-		Result.Ants[0]->GetActorLocation().X <= 10.0f + KINDA_SMALL_NUMBER);
+		AntFragment.Position.X <= 10.0f + KINDA_SMALL_NUMBER);
 
-	DestroySpawnedActors(Result);
 	MassSubsystem->ResetSimulation();
 	return true;
 }
@@ -147,6 +151,7 @@ bool FGatherersFullSimulationHighSpeedPickupAutomationTest::RunTest(const FStrin
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
@@ -155,21 +160,34 @@ bool FGatherersFullSimulationHighSpeedPickupAutomationTest::RunTest(const FStrin
 	Plan.FullSimulationTurnJitterRadians = 0.0f;
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("high-speed spawned ant count"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("high-speed spawned food count"), Result.Foods.Num(), 1);
+	TestEqual(TEXT("high-speed spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("high-speed spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("high-speed managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("high-speed managed food count"), MassSubsystem->GetManagedFoodCount(), 1);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 1)
 	{
 		return false;
 	}
 
 	MassSubsystem->Tick(1.0f);
 
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	FMassEntityView FoodView(EntityManager, MassSubsystem->ManagedFoodEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+	const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
 	TestTrue(
 		TEXT("safe-step movement still lets a nearby food be picked up during a long high-speed frame"),
-		Result.Foods[0]->GetAttachParentActor() == Result.Ants[0]);
+		AntFragment.CarriedFoodEntity == MassSubsystem->ManagedFoodEntities[0] && !FoodFragment.bIsLoose);
 
-	DestroySpawnedActors(Result);
 	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationObservation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationObservation.spec.cpp
@@ -2,21 +2,28 @@
 #include "Actors/Food.h"
 #include "Editor.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
 
 namespace
 {
-TArray<AFood*> SpawnFoods(UWorld& World, std::initializer_list<FVector> Locations)
+UGatherersMassSubsystem* RequireMassSubsystem(FAutomationTestBase& Test, UWorld* World)
 {
-	TArray<AFood*> Foods;
-	for (const FVector& Location : Locations)
+	Test.TestNotNull(TEXT("editor world should exist"), World);
+	if (World == nullptr)
 	{
-		if (AFood* Food = World.SpawnActor<AFood>(AFood::StaticClass(), FTransform(Location)))
-		{
-			Foods.Add(Food);
-		}
+		return nullptr;
 	}
 
-	return Foods;
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	Test.TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+	if (MassSubsystem != nullptr)
+	{
+		MassSubsystem->ResetSimulation();
+	}
+
+	return MassSubsystem;
 }
 
 int32 CountAttachedFoods(const TArray<AFood*>& Foods)
@@ -32,107 +39,124 @@ int32 CountAttachedFoods(const TArray<AFood*>& Foods)
 
 	return AttachedFoodCount;
 }
+
+void DestroySpawnedActors(const FGatherersSpawnResult& Result)
+{
+	for (AAnt* Ant : Result.Ants)
+	{
+		if (Ant != nullptr)
+		{
+			Ant->Destroy();
+		}
+	}
+
+	for (AFood* Food : Result.Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+}
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersFullSimulationFirstDropAutomationTest,
-	"default.unreal_gatherers.FullSimulation.FirstDropLeavesFoodLooseAndPreservesFoodCount",
+	"default.unreal_gatherers.FullSimulationActorFixture.FirstDropLeavesFoodLooseAndPreservesFoodCount",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FGatherersFullSimulationFirstDropAutomationTest::RunTest(const FString& Parameters)
 {
 	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
-	TestNotNull(TEXT("editor world should exist"), World);
-
-	if (World == nullptr)
+	UGatherersMassSubsystem* MassSubsystem = RequireMassSubsystem(*this, World);
+	if (MassSubsystem == nullptr)
 	{
 		return false;
 	}
 
-	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
-	TArray<AFood*> Foods = SpawnFoods(*World, {FVector(8.0f, 0.0f, 0.0f), FVector(-10.0f, 0.0f, 0.0f), FVector(50.0f, 0.0f, 0.0f)});
-	TestNotNull(TEXT("full-sim observation ant should spawn"), Ant);
-	TestEqual(TEXT("full-sim observation food count"), Foods.Num(), 3);
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f));
+	Plan.RandomSeedBase = 123;
+	Plan.FullSimulationTurnJitterRadians = 0.0f;
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(-10.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(50.0f, 0.0f, 0.0f)));
 
-	if (Ant == nullptr || Foods.Num() != 3)
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("full-sim observation ant count"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("full-sim observation food count"), Result.Foods.Num(), 3);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 3)
 	{
 		return false;
 	}
 
-	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f)), 123);
-	Ant->SetFullSimulationTurnJitterRadians(0.0f);
+	MassSubsystem->Tick(0.1f);
+	MassSubsystem->Tick(0.1f);
 
-	Ant->Tick(0.1f);
-	Ant->Tick(0.1f);
-
-	TestEqual(TEXT("food count stays constant after pickup then first drop"), Foods.Num(), 3);
-	TestEqual(TEXT("first drop leaves all food loose again"), CountAttachedFoods(Foods), 0);
+	TestEqual(TEXT("food count stays constant after pickup then first drop"), Result.Foods.Num(), 3);
+	TestEqual(TEXT("first drop leaves all food loose again"), CountAttachedFoods(Result.Foods), 0);
 	TestTrue(
 		TEXT("one loose food stays near the ant after the first drop"),
-		Foods[0]->GetActorLocation().Equals(Ant->GetActorLocation(), 1.0f));
+		Result.Foods[0]->GetActorLocation().Equals(Result.Ants[0]->GetActorLocation(), 1.0f));
 
-	Ant->Destroy();
-	for (AFood* Food : Foods)
-	{
-		if (Food != nullptr)
-		{
-			Food->Destroy();
-		}
-	}
-
+	DestroySpawnedActors(Result);
+	MassSubsystem->ResetSimulation();
 	return true;
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersFullSimulationCooldownAutomationTest,
-	"default.unreal_gatherers.FullSimulation.CooldownBlocksImmediateRepickupAndAllowsLaterPickup",
+	"default.unreal_gatherers.FullSimulationActorFixture.CooldownBlocksImmediateRepickupAndAllowsLaterPickup",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FGatherersFullSimulationCooldownAutomationTest::RunTest(const FString& Parameters)
 {
 	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
-	TestNotNull(TEXT("editor world should exist"), World);
-
-	if (World == nullptr)
+	UGatherersMassSubsystem* MassSubsystem = RequireMassSubsystem(*this, World);
+	if (MassSubsystem == nullptr)
 	{
 		return false;
 	}
 
-	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
-	TArray<AFood*> Foods = SpawnFoods(*World, {FVector(8.0f, 0.0f, 0.0f), FVector(-10.0f, 0.0f, 0.0f), FVector(50.0f, 0.0f, 0.0f)});
-	TestNotNull(TEXT("full-sim cooldown ant should spawn"), Ant);
-	TestEqual(TEXT("full-sim cooldown food count"), Foods.Num(), 3);
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f));
+	Plan.RandomSeedBase = 123;
+	Plan.FullSimulationTurnJitterRadians = 0.0f;
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(-10.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(50.0f, 0.0f, 0.0f)));
 
-	if (Ant == nullptr || Foods.Num() != 3)
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("full-sim cooldown ant count"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("full-sim cooldown food count"), Result.Foods.Num(), 3);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 3)
 	{
 		return false;
 	}
-
-	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f)), 123);
-	Ant->SetFullSimulationTurnJitterRadians(0.0f);
 
 	for (int32 StepIndex = 0; StepIndex < 3; ++StepIndex)
 	{
-		Ant->Tick(0.1f);
+		MassSubsystem->Tick(0.1f);
 	}
 
-	TestEqual(TEXT("cooldown blocks immediate re-pickup right after the first drop"), CountAttachedFoods(Foods), 0);
+	TestEqual(TEXT("cooldown blocks immediate re-pickup right after the first drop"), CountAttachedFoods(Result.Foods), 0);
 
 	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
 	{
-		Ant->Tick(0.1f);
+		MassSubsystem->Tick(0.1f);
 	}
 
-	TestEqual(TEXT("after cooldown the ant can gather again"), CountAttachedFoods(Foods), 1);
+	TestEqual(TEXT("after cooldown the ant can gather again"), CountAttachedFoods(Result.Foods), 1);
 
-	Ant->Destroy();
-	for (AFood* Food : Foods)
-	{
-		if (Food != nullptr)
-		{
-			Food->Destroy();
-		}
-	}
-
+	DestroySpawnedActors(Result);
+	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationObservation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationObservation.spec.cpp
@@ -1,0 +1,138 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
+#include "Misc/AutomationTest.h"
+
+namespace
+{
+TArray<AFood*> SpawnFoods(UWorld& World, std::initializer_list<FVector> Locations)
+{
+	TArray<AFood*> Foods;
+	for (const FVector& Location : Locations)
+	{
+		if (AFood* Food = World.SpawnActor<AFood>(AFood::StaticClass(), FTransform(Location)))
+		{
+			Foods.Add(Food);
+		}
+	}
+
+	return Foods;
+}
+
+int32 CountAttachedFoods(const TArray<AFood*>& Foods)
+{
+	int32 AttachedFoodCount = 0;
+	for (AFood* Food : Foods)
+	{
+		if (Food != nullptr && Food->GetAttachParentActor() != nullptr)
+		{
+			++AttachedFoodCount;
+		}
+	}
+
+	return AttachedFoodCount;
+}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersFullSimulationFirstDropAutomationTest,
+	"default.unreal_gatherers.FullSimulation.FirstDropLeavesFoodLooseAndPreservesFoodCount",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersFullSimulationFirstDropAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
+	TArray<AFood*> Foods = SpawnFoods(*World, {FVector(8.0f, 0.0f, 0.0f), FVector(-10.0f, 0.0f, 0.0f), FVector(-50.0f, 0.0f, 0.0f)});
+	TestNotNull(TEXT("full-sim observation ant should spawn"), Ant);
+	TestEqual(TEXT("full-sim observation food count"), Foods.Num(), 3);
+
+	if (Ant == nullptr || Foods.Num() != 3)
+	{
+		return false;
+	}
+
+	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f)), 123);
+	Ant->SetFullSimulationTurnJitterRadians(0.0f);
+
+	Ant->Tick(0.1f);
+	Ant->Tick(0.1f);
+
+	TestEqual(TEXT("food count stays constant after pickup then first drop"), Foods.Num(), 3);
+	TestEqual(TEXT("first drop leaves all food loose again"), CountAttachedFoods(Foods), 0);
+	TestTrue(
+		TEXT("one loose food stays near the ant after the first drop"),
+		Foods[0]->GetActorLocation().Equals(Ant->GetActorLocation(), 1.0f));
+
+	Ant->Destroy();
+	for (AFood* Food : Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersFullSimulationCooldownAutomationTest,
+	"default.unreal_gatherers.FullSimulation.CooldownBlocksImmediateRepickupAndAllowsLaterPickup",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersFullSimulationCooldownAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
+	TArray<AFood*> Foods = SpawnFoods(*World, {FVector(8.0f, 0.0f, 0.0f), FVector(-10.0f, 0.0f, 0.0f), FVector(-50.0f, 0.0f, 0.0f)});
+	TestNotNull(TEXT("full-sim cooldown ant should spawn"), Ant);
+	TestEqual(TEXT("full-sim cooldown food count"), Foods.Num(), 3);
+
+	if (Ant == nullptr || Foods.Num() != 3)
+	{
+		return false;
+	}
+
+	Ant->ConfigureForFullSimulation(FVector(1.0f, 0.0f, 0.0f), FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f)), 123);
+	Ant->SetFullSimulationTurnJitterRadians(0.0f);
+
+	for (int32 StepIndex = 0; StepIndex < 3; ++StepIndex)
+	{
+		Ant->Tick(0.1f);
+	}
+
+	TestEqual(TEXT("cooldown blocks immediate re-pickup right after the first drop"), CountAttachedFoods(Foods), 0);
+
+	for (int32 StepIndex = 0; StepIndex < 4; ++StepIndex)
+	{
+		Ant->Tick(0.1f);
+	}
+
+	TestEqual(TEXT("after cooldown the ant can gather again"), CountAttachedFoods(Foods), 1);
+
+	Ant->Destroy();
+	for (AFood* Food : Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationObservation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationObservation.spec.cpp
@@ -50,7 +50,7 @@ bool FGatherersFullSimulationFirstDropAutomationTest::RunTest(const FString& Par
 	}
 
 	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
-	TArray<AFood*> Foods = SpawnFoods(*World, {FVector(8.0f, 0.0f, 0.0f), FVector(-10.0f, 0.0f, 0.0f), FVector(-50.0f, 0.0f, 0.0f)});
+	TArray<AFood*> Foods = SpawnFoods(*World, {FVector(8.0f, 0.0f, 0.0f), FVector(-10.0f, 0.0f, 0.0f), FVector(50.0f, 0.0f, 0.0f)});
 	TestNotNull(TEXT("full-sim observation ant should spawn"), Ant);
 	TestEqual(TEXT("full-sim observation food count"), Foods.Num(), 3);
 
@@ -99,7 +99,7 @@ bool FGatherersFullSimulationCooldownAutomationTest::RunTest(const FString& Para
 	}
 
 	AAnt* Ant = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector::ZeroVector));
-	TArray<AFood*> Foods = SpawnFoods(*World, {FVector(8.0f, 0.0f, 0.0f), FVector(-10.0f, 0.0f, 0.0f), FVector(-50.0f, 0.0f, 0.0f)});
+	TArray<AFood*> Foods = SpawnFoods(*World, {FVector(8.0f, 0.0f, 0.0f), FVector(-10.0f, 0.0f, 0.0f), FVector(50.0f, 0.0f, 0.0f)});
 	TestNotNull(TEXT("full-sim cooldown ant should spawn"), Ant);
 	TestEqual(TEXT("full-sim cooldown food count"), Foods.Num(), 3);
 
@@ -118,7 +118,7 @@ bool FGatherersFullSimulationCooldownAutomationTest::RunTest(const FString& Para
 
 	TestEqual(TEXT("cooldown blocks immediate re-pickup right after the first drop"), CountAttachedFoods(Foods), 0);
 
-	for (int32 StepIndex = 0; StepIndex < 4; ++StepIndex)
+	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
 	{
 		Ant->Tick(0.1f);
 	}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationObservation.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationObservation.spec.cpp
@@ -1,6 +1,6 @@
-#include "Actors/Ant.h"
-#include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
@@ -26,37 +26,24 @@ UGatherersMassSubsystem* RequireMassSubsystem(FAutomationTestBase& Test, UWorld*
 	return MassSubsystem;
 }
 
-int32 CountAttachedFoods(const TArray<AFood*>& Foods)
+bool AnyFoodAtLocation(const TArray<FMassEntityHandle>& FoodEntities, FMassEntityManager& EntityManager, const FVector& ExpectedLocation)
 {
-	int32 AttachedFoodCount = 0;
-	for (AFood* Food : Foods)
+	for (const FMassEntityHandle FoodEntity : FoodEntities)
 	{
-		if (Food != nullptr && Food->GetAttachParentActor() != nullptr)
+		if (!EntityManager.IsEntityValid(FoodEntity))
 		{
-			++AttachedFoodCount;
+			continue;
+		}
+
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		if (FoodFragment.Position.Equals(ExpectedLocation, 1.0f))
+		{
+			return true;
 		}
 	}
 
-	return AttachedFoodCount;
-}
-
-void DestroySpawnedActors(const FGatherersSpawnResult& Result)
-{
-	for (AAnt* Ant : Result.Ants)
-	{
-		if (Ant != nullptr)
-		{
-			Ant->Destroy();
-		}
-	}
-
-	for (AFood* Food : Result.Foods)
-	{
-		if (Food != nullptr)
-		{
-			Food->Destroy();
-		}
-	}
+	return false;
 }
 }
 
@@ -76,6 +63,7 @@ bool FGatherersFullSimulationFirstDropAutomationTest::RunTest(const FString& Par
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f));
 	Plan.RandomSeedBase = 123;
 	Plan.FullSimulationTurnJitterRadians = 0.0f;
@@ -86,10 +74,12 @@ bool FGatherersFullSimulationFirstDropAutomationTest::RunTest(const FString& Par
 	Plan.FoodSpawns.Add(FTransform(FVector(50.0f, 0.0f, 0.0f)));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("full-sim observation ant count"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("full-sim observation food count"), Result.Foods.Num(), 3);
+	TestEqual(TEXT("full-sim observation ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("full-sim observation food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("full-sim observation managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("full-sim observation managed food count"), MassSubsystem->GetManagedFoodCount(), 3);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 3)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 3)
 	{
 		return false;
 	}
@@ -97,13 +87,33 @@ bool FGatherersFullSimulationFirstDropAutomationTest::RunTest(const FString& Par
 	MassSubsystem->Tick(0.1f);
 	MassSubsystem->Tick(0.1f);
 
-	TestEqual(TEXT("food count stays constant after pickup then first drop"), Result.Foods.Num(), 3);
-	TestEqual(TEXT("first drop leaves all food loose again"), CountAttachedFoods(Result.Foods), 0);
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+	int32 LooseFoodCount = 0;
+	for (const FMassEntityHandle FoodEntity : MassSubsystem->ManagedFoodEntities)
+	{
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		if (FoodFragment.bIsLoose)
+		{
+			++LooseFoodCount;
+		}
+	}
+
+	TestEqual(TEXT("food count stays constant after pickup then first drop"), MassSubsystem->GetManagedFoodCount(), 3);
+	TestEqual(TEXT("first drop leaves all food loose again"), LooseFoodCount, 3);
 	TestTrue(
 		TEXT("one loose food stays near the ant after the first drop"),
-		Result.Foods[0]->GetActorLocation().Equals(Result.Ants[0]->GetActorLocation(), 1.0f));
+		AnyFoodAtLocation(MassSubsystem->ManagedFoodEntities, EntityManager, AntFragment.Position));
 
-	DestroySpawnedActors(Result);
 	MassSubsystem->ResetSimulation();
 	return true;
 }
@@ -124,6 +134,7 @@ bool FGatherersFullSimulationCooldownAutomationTest::RunTest(const FString& Para
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
 	Plan.PlayAreaBounds = FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f));
 	Plan.RandomSeedBase = 123;
 	Plan.FullSimulationTurnJitterRadians = 0.0f;
@@ -134,10 +145,12 @@ bool FGatherersFullSimulationCooldownAutomationTest::RunTest(const FString& Para
 	Plan.FoodSpawns.Add(FTransform(FVector(50.0f, 0.0f, 0.0f)));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("full-sim cooldown ant count"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("full-sim cooldown food count"), Result.Foods.Num(), 3);
+	TestEqual(TEXT("full-sim cooldown ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("full-sim cooldown food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("full-sim cooldown managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("full-sim cooldown managed food count"), MassSubsystem->GetManagedFoodCount(), 3);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 3)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 3)
 	{
 		return false;
 	}
@@ -147,16 +160,43 @@ bool FGatherersFullSimulationCooldownAutomationTest::RunTest(const FString& Para
 		MassSubsystem->Tick(0.1f);
 	}
 
-	TestEqual(TEXT("cooldown blocks immediate re-pickup right after the first drop"), CountAttachedFoods(Result.Foods), 0);
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	int32 LooseFoodCount = 0;
+	for (const FMassEntityHandle FoodEntity : MassSubsystem->ManagedFoodEntities)
+	{
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		if (FoodFragment.bIsLoose)
+		{
+			++LooseFoodCount;
+		}
+	}
+	TestEqual(TEXT("cooldown blocks immediate re-pickup right after the first drop"), LooseFoodCount, 3);
 
 	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
 	{
 		MassSubsystem->Tick(0.1f);
 	}
 
-	TestEqual(TEXT("after cooldown the ant can gather again"), CountAttachedFoods(Result.Foods), 1);
+	LooseFoodCount = 0;
+	for (const FMassEntityHandle FoodEntity : MassSubsystem->ManagedFoodEntities)
+	{
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		if (FoodFragment.bIsLoose)
+		{
+			++LooseFoodCount;
+		}
+	}
+	TestEqual(TEXT("after cooldown the ant can gather again"), LooseFoodCount, 2);
 
-	DestroySpawnedActors(Result);
 	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationSpawn.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationSpawn.spec.cpp
@@ -1,0 +1,23 @@
+#include "Math/Box.h"
+#include "Misc/AutomationTest.h"
+#include "Simulation/GatherersSpawnPlan.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersFullSimulationSpawnPlanAutomationTest,
+	"default.unreal_gatherers.FullSimulation.SpawnPlanBuildsConfiguredAntAndFoodCounts",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersFullSimulationSpawnPlanAutomationTest::RunTest(const FString& Parameters)
+{
+	const FGatherersSpawnPlan Plan = BuildFullSimulationSpawnPlan(
+		4,
+		12,
+		1234,
+		FBox(FVector(-400.0f, -300.0f, 0.0f), FVector(400.0f, 300.0f, 100.0f)));
+
+	TestEqual(TEXT("full-sim ant spawn count"), Plan.AntSpawns.Num(), 4);
+	TestEqual(TEXT("full-sim ant heading count"), Plan.AntInitialDirections.Num(), 4);
+	TestEqual(TEXT("full-sim food spawn count"), Plan.FoodSpawns.Num(), 12);
+	TestTrue(TEXT("full-sim spawn plan is flagged for full-simulation configuration"), Plan.bUseFullSimulationMode);
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationSpawn.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationSpawn.spec.cpp
@@ -1,6 +1,10 @@
 #include "Math/Box.h"
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersFullSimulationSpawnPlanAutomationTest,
@@ -19,5 +23,50 @@ bool FGatherersFullSimulationSpawnPlanAutomationTest::RunTest(const FString& Par
 	TestEqual(TEXT("full-sim ant heading count"), Plan.AntInitialDirections.Num(), 4);
 	TestEqual(TEXT("full-sim food spawn count"), Plan.FoodSpawns.Num(), 12);
 	TestTrue(TEXT("full-sim spawn plan is flagged for full-simulation configuration"), Plan.bUseFullSimulationMode);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersFullSimulationSpawnerAutomationTest,
+	"default.unreal_gatherers.FullSimulation.WorldSpawnerConfiguresAntsForFullSimMode",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersFullSimulationSpawnerAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(0.0f, 200.0f, 0.0f)));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("full-sim spawned ant count"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("full-sim spawned food count"), Result.Foods.Num(), 1);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
+	{
+		return false;
+	}
+
+	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
+	{
+		Result.Ants[0]->Tick(0.1f);
+	}
+
+	TestTrue(
+		TEXT("world spawner configures spawned ant for full-sim heading movement instead of food seeking"),
+		Result.Ants[0]->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
+
+	Result.Ants[0]->Destroy();
+	Result.Foods[0]->Destroy();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationSpawn.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationSpawn.spec.cpp
@@ -2,6 +2,8 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
@@ -60,10 +62,12 @@ bool FGatherersFullSimulationSpawnerAutomationTest::RunTest(const FString& Param
 	MassSubsystem->ResetSimulation();
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("full-sim spawned ant count"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("full-sim spawned food count"), Result.Foods.Num(), 1);
+	TestEqual(TEXT("full-sim spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("full-sim spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("full-sim managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("full-sim managed food count"), MassSubsystem->GetManagedFoodCount(), 1);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 1)
 	{
 		return false;
 	}
@@ -73,12 +77,20 @@ bool FGatherersFullSimulationSpawnerAutomationTest::RunTest(const FString& Param
 		MassSubsystem->Tick(0.1f);
 	}
 
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 	TestTrue(
 		TEXT("world spawner routes spawned full-sim ant through Mass-backed heading movement instead of actor food seeking"),
-		Result.Ants[0]->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
+		AntFragment.Position.Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
 
-	Result.Ants[0]->Destroy();
-	Result.Foods[0]->Destroy();
 	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationSpawn.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationSpawn.spec.cpp
@@ -3,6 +3,7 @@
 #include "Actors/Food.h"
 #include "Editor.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 
@@ -48,6 +49,16 @@ bool FGatherersFullSimulationSpawnerAutomationTest::RunTest(const FString& Param
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
 	Plan.FoodSpawns.Add(FTransform(FVector(0.0f, 200.0f, 0.0f)));
 
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
 	TestEqual(TEXT("full-sim spawned ant count"), Result.Ants.Num(), 1);
 	TestEqual(TEXT("full-sim spawned food count"), Result.Foods.Num(), 1);
@@ -59,14 +70,15 @@ bool FGatherersFullSimulationSpawnerAutomationTest::RunTest(const FString& Param
 
 	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
 	{
-		Result.Ants[0]->Tick(0.1f);
+		MassSubsystem->Tick(0.1f);
 	}
 
 	TestTrue(
-		TEXT("world spawner configures spawned ant for full-sim heading movement instead of food seeking"),
+		TEXT("world spawner routes spawned full-sim ant through Mass-backed heading movement instead of actor food seeking"),
 		Result.Ants[0]->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
 
 	Result.Ants[0]->Destroy();
 	Result.Foods[0]->Destroy();
+	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassAvailability.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassAvailability.spec.cpp
@@ -1,0 +1,22 @@
+#include "MassEntitySubsystem.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassEntityAvailabilityAutomationTest,
+	"default.unreal_gatherers.Mass.MassEntitySubsystemIsAvailable",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassEntityAvailabilityAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GWorld;
+	TestNotNull(TEXT("test world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("MassEntity subsystem should be available once the project enables Mass"), MassEntitySubsystem);
+	return MassEntitySubsystem != nullptr;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBoundary.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBoundary.spec.cpp
@@ -1,0 +1,58 @@
+#include "Actors/Ant.h"
+#include "Editor.h"
+#include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassBoundaryAutomationTest,
+	"default.unreal_gatherers.Mass.AntTurnsBackAtBoundaryInMassSimulation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassBoundaryAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bUseMassSimulation = true;
+	Plan.PlayAreaBounds = FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector(95.0f, 0.0f, 0.0f)));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+
+	if (Result.Ants.Num() != 1)
+	{
+		return false;
+	}
+
+	MassSubsystem->Tick(0.1f);
+	MassSubsystem->Tick(0.1f);
+
+	TestTrue(
+		TEXT("Mass-backed ant should stay within the play area and head back inward after the boundary hit"),
+		Result.Ants[0]->GetActorLocation().Equals(FVector(90.0f, 0.0f, 0.0f), 1.0f));
+
+	Result.Ants[0]->Destroy();
+	MassSubsystem->ResetSimulation();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBoundary.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBoundary.spec.cpp
@@ -32,7 +32,6 @@ bool FGatherersMassBoundaryAutomationTest::RunTest(const FString& Parameters)
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
-	Plan.bUseMassSimulation = true;
 	Plan.PlayAreaBounds = FBox(FVector(-100.0f, -100.0f, -100.0f), FVector(100.0f, 100.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector(95.0f, 0.0f, 0.0f)));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
@@ -44,6 +43,11 @@ bool FGatherersMassBoundaryAutomationTest::RunTest(const FString& Parameters)
 	{
 		return false;
 	}
+
+	TestTrue(
+		TEXT("Mass subsystem should store the active shared play area bounds for the simulation"),
+		MassSubsystem->GetSimulationBounds().Min.Equals(Plan.PlayAreaBounds.Min, KINDA_SMALL_NUMBER)
+			&& MassSubsystem->GetSimulationBounds().Max.Equals(Plan.PlayAreaBounds.Max, KINDA_SMALL_NUMBER));
 
 	MassSubsystem->Tick(0.1f);
 	MassSubsystem->Tick(0.1f);

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBoundary.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBoundary.spec.cpp
@@ -1,5 +1,7 @@
 #include "Actors/Ant.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
@@ -37,9 +39,10 @@ bool FGatherersMassBoundaryAutomationTest::RunTest(const FString& Parameters)
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
 
-	if (Result.Ants.Num() != 1)
+	if (MassSubsystem->GetManagedAntCount() != 1)
 	{
 		return false;
 	}
@@ -52,11 +55,20 @@ bool FGatherersMassBoundaryAutomationTest::RunTest(const FString& Parameters)
 	MassSubsystem->Tick(0.1f);
 	MassSubsystem->Tick(0.1f);
 
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 	TestTrue(
 		TEXT("Mass-backed ant should stay within the play area and head back inward after the boundary hit"),
-		Result.Ants[0]->GetActorLocation().Equals(FVector(90.0f, 0.0f, 0.0f), 1.0f));
+		AntFragment.Position.Equals(FVector(90.0f, 0.0f, 0.0f), 1.0f));
 
-	Result.Ants[0]->Destroy();
 	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBridge.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBridge.spec.cpp
@@ -11,6 +11,11 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	"default.unreal_gatherers.Mass.WorldSpawnerRegistersMassBackedFullSimState",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassProxyAuthorityAutomationTest,
+	"default.unreal_gatherers.Mass.FullSimProxyDoesNotOwnActorRuntimeState",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
 bool FGatherersMassBridgeAutomationTest::RunTest(const FString& Parameters)
 {
 	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
@@ -33,7 +38,6 @@ bool FGatherersMassBridgeAutomationTest::RunTest(const FString& Parameters)
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
-	Plan.bUseMassSimulation = true;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
@@ -45,6 +49,65 @@ bool FGatherersMassBridgeAutomationTest::RunTest(const FString& Parameters)
 	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 2);
 	TestEqual(TEXT("Mass subsystem tracks one ant entity"), MassSubsystem->GetManagedAntCount(), 1);
 	TestEqual(TEXT("Mass subsystem tracks two food entities"), MassSubsystem->GetManagedFoodCount(), 2);
+
+	for (AAnt* Ant : Result.Ants)
+	{
+		if (Ant != nullptr)
+		{
+			Ant->Destroy();
+		}
+	}
+
+	for (AFood* Food : Result.Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+
+	MassSubsystem->ResetSimulation();
+	return true;
+}
+
+bool FGatherersMassProxyAuthorityAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(0.0f, 200.0f, 0.0f)));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+
+	if (Result.Ants.Num() != 1)
+	{
+		return false;
+	}
+
+	TestTrue(
+		TEXT("Mass-backed proxy actor should have tick disabled so it does not move independently"),
+		!Result.Ants[0]->IsActorTickEnabled());
 
 	for (AAnt* Ant : Result.Ants)
 	{

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBridge.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBridge.spec.cpp
@@ -1,0 +1,67 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
+#include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassBridgeAutomationTest,
+	"default.unreal_gatherers.Mass.WorldSpawnerRegistersMassBackedFullSimState",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassBridgeAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bUseMassSimulation = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(100.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(-100.0f, 0.0f, 0.0f)));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 2);
+	TestEqual(TEXT("Mass subsystem tracks one ant entity"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("Mass subsystem tracks two food entities"), MassSubsystem->GetManagedFoodCount(), 2);
+
+	for (AAnt* Ant : Result.Ants)
+	{
+		if (Ant != nullptr)
+		{
+			Ant->Destroy();
+		}
+	}
+
+	for (AFood* Food : Result.Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+
+	MassSubsystem->ResetSimulation();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBridge.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBridge.spec.cpp
@@ -1,6 +1,8 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
@@ -14,6 +16,11 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersMassProxyAuthorityAutomationTest,
 	"default.unreal_gatherers.Mass.FullSimProxyDoesNotOwnActorRuntimeState",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassRepresentationBridgeAutomationTest,
+	"default.unreal_gatherers.Mass.EntitiesAdvanceWithoutActorVisualProxies",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FGatherersMassBridgeAutomationTest::RunTest(const FString& Parameters)
@@ -38,6 +45,7 @@ bool FGatherersMassBridgeAutomationTest::RunTest(const FString& Parameters)
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = true;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
@@ -92,6 +100,7 @@ bool FGatherersMassProxyAuthorityAutomationTest::RunTest(const FString& Paramete
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = true;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
@@ -124,6 +133,68 @@ bool FGatherersMassProxyAuthorityAutomationTest::RunTest(const FString& Paramete
 			Food->Destroy();
 		}
 	}
+
+	MassSubsystem->ResetSimulation();
+	return true;
+}
+
+bool FGatherersMassRepresentationBridgeAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+
+	if (MassSubsystem == nullptr || MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(100.0f, 0.0f, 0.0f)));
+	Plan.bSpawnActorVisuals = false;
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("Mass-instanced visual path should not spawn ant actors"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("Mass-instanced visual path should not spawn food actors"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("Mass subsystem tracks one ant entity"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("Mass subsystem tracks one food entity"), MassSubsystem->GetManagedFoodCount(), 1);
+
+	if (MassSubsystem->ManagedAntEntities.Num() != 1)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	TestNotNull(
+		TEXT("Mass ant path should expose a dedicated ant instanced visual component"),
+		const_cast<UInstancedStaticMeshComponent*>(MassSubsystem->GetAntVisualComponent()));
+	TestNotNull(
+		TEXT("Mass food path should expose a dedicated food instanced visual component"),
+		const_cast<UInstancedStaticMeshComponent*>(MassSubsystem->GetFoodVisualComponent()));
+
+	MassSubsystem->Tick(0.1f);
+
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+	TestTrue(
+		TEXT("Mass ant can still advance without spawned actor proxies"),
+		AntFragment.Position.Equals(FVector(10.0f, 0.0f, 0.0f), 1.0f));
 
 	MassSubsystem->ResetSimulation();
 	return true;

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassDrop.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassDrop.spec.cpp
@@ -1,0 +1,64 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
+#include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassDropAutomationTest,
+	"default.unreal_gatherers.Mass.CarryingAntDropsFoodAtNextLooseFood",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassDropAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bUseMassSimulation = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(26.0f, 0.0f, 0.0f)));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 2);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 2)
+	{
+		return false;
+	}
+
+	MassSubsystem->Tick(0.1f);
+	MassSubsystem->Tick(0.1f);
+
+	TestTrue(TEXT("first food should be loose again after the drop"), Result.Foods[0]->GetAttachParentActor() == nullptr);
+	TestTrue(TEXT("second food should stay loose in the world"), Result.Foods[1]->GetAttachParentActor() == nullptr);
+	TestTrue(TEXT("dropped food should appear at the ant drop location"), Result.Foods[0]->GetActorLocation().Equals(FVector(20.0f, 0.0f, 0.0f), 1.0f));
+
+	Result.Ants[0]->Destroy();
+	Result.Foods[0]->Destroy();
+	Result.Foods[1]->Destroy();
+	MassSubsystem->ResetSimulation();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassDrop.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassDrop.spec.cpp
@@ -1,6 +1,8 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Math/RandomStream.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersAntSimulation.h"
@@ -51,10 +53,12 @@ bool FGatherersMassDropAutomationTest::RunTest(const FString& Parameters)
 	Plan.FoodSpawns.Add(FTransform(ExpectedDropLocation));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 2);
+	TestEqual(TEXT("spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("managed food count"), MassSubsystem->GetManagedFoodCount(), 2);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 2)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 2)
 	{
 		return false;
 	}
@@ -62,13 +66,22 @@ bool FGatherersMassDropAutomationTest::RunTest(const FString& Parameters)
 	MassSubsystem->Tick(0.1f);
 	MassSubsystem->Tick(0.1f);
 
-	TestTrue(TEXT("first food should be loose again after the drop"), Result.Foods[0]->GetAttachParentActor() == nullptr);
-	TestTrue(TEXT("second food should stay loose in the world"), Result.Foods[1]->GetAttachParentActor() == nullptr);
-	TestTrue(TEXT("dropped food should appear at the deterministic turn-based drop location"), Result.Foods[0]->GetActorLocation().Equals(ExpectedDropLocation, 1.0f));
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
 
-	Result.Ants[0]->Destroy();
-	Result.Foods[0]->Destroy();
-	Result.Foods[1]->Destroy();
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView FirstFoodView(EntityManager, MassSubsystem->ManagedFoodEntities[0]);
+	FMassEntityView SecondFoodView(EntityManager, MassSubsystem->ManagedFoodEntities[1]);
+	const FGatherersMassFoodFragment& FirstFoodFragment = FirstFoodView.GetFragmentData<FGatherersMassFoodFragment>();
+	const FGatherersMassFoodFragment& SecondFoodFragment = SecondFoodView.GetFragmentData<FGatherersMassFoodFragment>();
+	TestTrue(TEXT("first food should be loose again after the drop"), FirstFoodFragment.bIsLoose);
+	TestTrue(TEXT("second food should stay loose in the world"), SecondFoodFragment.bIsLoose);
+	TestTrue(TEXT("dropped food should appear at the deterministic turn-based drop location"), FirstFoodFragment.Position.Equals(ExpectedDropLocation, 1.0f));
+
 	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassDrop.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassDrop.spec.cpp
@@ -1,7 +1,9 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "Math/RandomStream.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersAntSimulation.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
@@ -33,12 +35,20 @@ bool FGatherersMassDropAutomationTest::RunTest(const FString& Parameters)
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
-	Plan.bUseMassSimulation = true;
+	Plan.RandomSeedBase = 123;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+
+	FRandomStream RandomStream(Plan.RandomSeedBase);
+	const FVector FirstTurnDirection = ComputeAntTurnDirection(
+		FVector(1.0f, 0.0f, 0.0f),
+		RandomStream.FRandRange(-1.0f, 1.0f),
+		PI / 2.0f);
+	const FVector ExpectedDropLocation = FVector(10.0f, 0.0f, 0.0f) + FirstTurnDirection * 10.0f;
+
 	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
-	Plan.FoodSpawns.Add(FTransform(FVector(26.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(ExpectedDropLocation));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
 	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
@@ -54,7 +64,7 @@ bool FGatherersMassDropAutomationTest::RunTest(const FString& Parameters)
 
 	TestTrue(TEXT("first food should be loose again after the drop"), Result.Foods[0]->GetAttachParentActor() == nullptr);
 	TestTrue(TEXT("second food should stay loose in the world"), Result.Foods[1]->GetAttachParentActor() == nullptr);
-	TestTrue(TEXT("dropped food should appear at the ant drop location"), Result.Foods[0]->GetActorLocation().Equals(FVector(20.0f, 0.0f, 0.0f), 1.0f));
+	TestTrue(TEXT("dropped food should appear at the deterministic turn-based drop location"), Result.Foods[0]->GetActorLocation().Equals(ExpectedDropLocation, 1.0f));
 
 	Result.Ants[0]->Destroy();
 	Result.Foods[0]->Destroy();

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassMovement.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassMovement.spec.cpp
@@ -1,0 +1,77 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
+#include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassHeadingMovementAutomationTest,
+	"default.unreal_gatherers.Mass.AntMovesByHeadingInMassSimulation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassHeadingMovementAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bUseMassSimulation = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(0.0f, 200.0f, 0.0f)));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+
+	if (Result.Ants.Num() != 1)
+	{
+		return false;
+	}
+
+	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
+	{
+		MassSubsystem->Tick(0.1f);
+	}
+
+	TestTrue(
+		TEXT("Mass-backed ant proxy advances along its heading instead of seeking off-path food"),
+		Result.Ants[0]->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
+
+	for (AAnt* Ant : Result.Ants)
+	{
+		if (Ant != nullptr)
+		{
+			Ant->Destroy();
+		}
+	}
+
+	for (AFood* Food : Result.Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+
+	MassSubsystem->ResetSimulation();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassMovement.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassMovement.spec.cpp
@@ -1,6 +1,8 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
@@ -39,9 +41,10 @@ bool FGatherersMassHeadingMovementAutomationTest::RunTest(const FString& Paramet
 	Plan.FoodSpawns.Add(FTransform(FVector(0.0f, 200.0f, 0.0f)));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
 
-	if (Result.Ants.Num() != 1)
+	if (MassSubsystem->GetManagedAntCount() != 1)
 	{
 		return false;
 	}
@@ -51,25 +54,19 @@ bool FGatherersMassHeadingMovementAutomationTest::RunTest(const FString& Paramet
 		MassSubsystem->Tick(0.1f);
 	}
 
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 	TestTrue(
-		TEXT("Mass-backed ant proxy advances along its heading instead of seeking off-path food"),
-		Result.Ants[0]->GetActorLocation().Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
-
-	for (AAnt* Ant : Result.Ants)
-	{
-		if (Ant != nullptr)
-		{
-			Ant->Destroy();
-		}
-	}
-
-	for (AFood* Food : Result.Foods)
-	{
-		if (Food != nullptr)
-		{
-			Food->Destroy();
-		}
-	}
+		TEXT("Mass-backed ant advances along its heading instead of seeking off-path food"),
+		AntFragment.Position.Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
 
 	MassSubsystem->ResetSimulation();
 	return true;

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassMovement.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassMovement.spec.cpp
@@ -33,7 +33,6 @@ bool FGatherersMassHeadingMovementAutomationTest::RunTest(const FString& Paramet
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
-	Plan.bUseMassSimulation = true;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassPickup.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassPickup.spec.cpp
@@ -1,6 +1,8 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
@@ -39,20 +41,33 @@ bool FGatherersMassPickupAutomationTest::RunTest(const FString& Parameters)
 	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 1);
+	TestEqual(TEXT("spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("managed food count"), MassSubsystem->GetManagedFoodCount(), 1);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 1)
 	{
 		return false;
 	}
 
 	MassSubsystem->Tick(0.1f);
 
-	TestTrue(TEXT("food proxy should now be attached to the ant proxy"), Result.Foods[0]->GetAttachParentActor() == Result.Ants[0]);
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
 
-	Result.Ants[0]->Destroy();
-	Result.Foods[0]->Destroy();
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	FMassEntityView FoodView(EntityManager, MassSubsystem->ManagedFoodEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+	const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+	TestTrue(TEXT("Mass ant should now carry the food entity"), AntFragment.CarriedFoodEntity == MassSubsystem->ManagedFoodEntities[0]);
+	TestFalse(TEXT("picked-up food is no longer loose"), FoodFragment.bIsLoose);
+
 	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassPickup.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassPickup.spec.cpp
@@ -1,0 +1,59 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
+#include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassPickupAutomationTest,
+	"default.unreal_gatherers.Mass.AntPicksUpFoodInMassSimulation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassPickupAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bUseMassSimulation = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 1);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
+	{
+		return false;
+	}
+
+	MassSubsystem->Tick(0.1f);
+
+	TestTrue(TEXT("food proxy should now be attached to the ant proxy"), Result.Foods[0]->GetAttachParentActor() == Result.Ants[0]);
+
+	Result.Ants[0]->Destroy();
+	Result.Foods[0]->Destroy();
+	MassSubsystem->ResetSimulation();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassRepeat.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassRepeat.spec.cpp
@@ -1,6 +1,8 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Math/RandomStream.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersAntSimulation.h"
@@ -57,10 +59,12 @@ bool FGatherersMassRepeatAutomationTest::RunTest(const FString& Parameters)
 	Plan.FoodSpawns.Add(FTransform(RepeatPickupLocation));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 3);
+	TestEqual(TEXT("spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("managed food count"), MassSubsystem->GetManagedFoodCount(), 3);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 3)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 3)
 	{
 		return false;
 	}
@@ -70,25 +74,25 @@ bool FGatherersMassRepeatAutomationTest::RunTest(const FString& Parameters)
 		MassSubsystem->Tick(0.1f);
 	}
 
-	int32 AttachedFoodCount = 0;
-	for (AFood* Food : Result.Foods)
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
 	{
-		if (Food != nullptr && Food->GetAttachParentActor() == Result.Ants[0])
-		{
-			++AttachedFoodCount;
-		}
+		return false;
 	}
 
-	TestEqual(TEXT("one food should be carried again after the cooldown window"), AttachedFoodCount, 1);
-
-	Result.Ants[0]->Destroy();
-	for (AFood* Food : Result.Foods)
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	int32 CarriedFoodCount = 0;
+	for (const FMassEntityHandle FoodEntity : MassSubsystem->ManagedFoodEntities)
 	{
-		if (Food != nullptr)
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		if (!FoodFragment.bIsLoose)
 		{
-			Food->Destroy();
+			++CarriedFoodCount;
 		}
 	}
+	TestEqual(TEXT("one food should be carried again after the cooldown window"), CarriedFoodCount, 1);
 
 	MassSubsystem->ResetSimulation();
 	return true;

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassRepeat.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassRepeat.spec.cpp
@@ -1,0 +1,80 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
+#include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassRepeatAutomationTest,
+	"default.unreal_gatherers.Mass.AntCanPickUpAgainAfterDropCooldown",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassRepeatAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bUseMassSimulation = true;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(65.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(FVector(108.0f, 0.0f, 0.0f)));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 3);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 3)
+	{
+		return false;
+	}
+
+	for (int32 StepIndex = 0; StepIndex < 11; ++StepIndex)
+	{
+		MassSubsystem->Tick(0.1f);
+	}
+
+	int32 AttachedFoodCount = 0;
+	for (AFood* Food : Result.Foods)
+	{
+		if (Food != nullptr && Food->GetAttachParentActor() == Result.Ants[0])
+		{
+			++AttachedFoodCount;
+		}
+	}
+
+	TestEqual(TEXT("one food should be carried again after the cooldown window"), AttachedFoodCount, 1);
+
+	Result.Ants[0]->Destroy();
+	for (AFood* Food : Result.Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+
+	MassSubsystem->ResetSimulation();
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassRepeat.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassRepeat.spec.cpp
@@ -1,7 +1,9 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "Math/RandomStream.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersAntSimulation.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
@@ -33,13 +35,26 @@ bool FGatherersMassRepeatAutomationTest::RunTest(const FString& Parameters)
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
-	Plan.bUseMassSimulation = true;
+	Plan.RandomSeedBase = 123;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+
+	FRandomStream RandomStream(Plan.RandomSeedBase);
+	const FVector FirstTurnDirection = ComputeAntTurnDirection(
+		FVector(1.0f, 0.0f, 0.0f),
+		RandomStream.FRandRange(-1.0f, 1.0f),
+		PI / 2.0f);
+	const FVector DropLocation = FVector(10.0f, 0.0f, 0.0f) + FirstTurnDirection * 10.0f;
+	const FVector SecondTurnDirection = ComputeAntTurnDirection(
+		FirstTurnDirection,
+		RandomStream.FRandRange(-1.0f, 1.0f),
+		PI / 2.0f);
+	const FVector RepeatPickupLocation = DropLocation + SecondTurnDirection * 50.0f;
+
 	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
-	Plan.FoodSpawns.Add(FTransform(FVector(65.0f, 0.0f, 0.0f)));
-	Plan.FoodSpawns.Add(FTransform(FVector(108.0f, 0.0f, 0.0f)));
+	Plan.FoodSpawns.Add(FTransform(DropLocation));
+	Plan.FoodSpawns.Add(FTransform(RepeatPickupLocation));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
 	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
@@ -50,7 +65,7 @@ bool FGatherersMassRepeatAutomationTest::RunTest(const FString& Parameters)
 		return false;
 	}
 
-	for (int32 StepIndex = 0; StepIndex < 11; ++StepIndex)
+	for (int32 StepIndex = 0; StepIndex < 8; ++StepIndex)
 	{
 		MassSubsystem->Tick(0.1f);
 	}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassRepresentationAvailability.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassRepresentationAvailability.spec.cpp
@@ -1,0 +1,23 @@
+#include "Editor.h"
+#include "MassRepresentationSubsystem.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassRepresentationAvailabilityAutomationTest,
+	"default.unreal_gatherers.Mass.MassRepresentationSubsystemIsAvailable",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassRepresentationAvailabilityAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UMassRepresentationSubsystem* RepresentationSubsystem = World->GetSubsystem<UMassRepresentationSubsystem>();
+	TestNotNull(TEXT("Mass representation subsystem should exist"), RepresentationSubsystem);
+	return RepresentationSubsystem != nullptr;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassTurn.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassTurn.spec.cpp
@@ -1,6 +1,8 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Math/RandomStream.h"
 #include "Misc/AutomationTest.h"
 #include "Simulation/GatherersAntSimulation.h"
@@ -42,10 +44,12 @@ bool FGatherersMassTurnAutomationTest::RunTest(const FString& Parameters)
 	Plan.FoodSpawns.Add(FTransform(FVector(8.0f, 0.0f, 0.0f)));
 
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("spawned ant proxies"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("spawned food proxies"), Result.Foods.Num(), 1);
+	TestEqual(TEXT("spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("managed food count"), MassSubsystem->GetManagedFoodCount(), 1);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 1)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 1)
 	{
 		return false;
 	}
@@ -60,12 +64,20 @@ bool FGatherersMassTurnAutomationTest::RunTest(const FString& Parameters)
 	MassSubsystem->Tick(0.1f);
 	MassSubsystem->Tick(0.1f);
 
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+	if (MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
+	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 	TestTrue(
 		TEXT("pickup should consume the stored Mass turn state and move on the turned heading next frame"),
-		Result.Ants[0]->GetActorLocation().Equals(ExpectedLocationAfterSecondTick, 1.0f));
+		AntFragment.Position.Equals(ExpectedLocationAfterSecondTick, 1.0f));
 
-	Result.Ants[0]->Destroy();
-	Result.Foods[0]->Destroy();
 	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassTurn.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassTurn.spec.cpp
@@ -1,17 +1,19 @@
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
 #include "Editor.h"
+#include "Math/RandomStream.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersAntSimulation.h"
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
-	FGatherersMassPickupAutomationTest,
-	"default.unreal_gatherers.Mass.AntPicksUpFoodInMassSimulation",
+	FGatherersMassTurnAutomationTest,
+	"default.unreal_gatherers.Mass.PickupUsesStoredTurnState",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
-bool FGatherersMassPickupAutomationTest::RunTest(const FString& Parameters)
+bool FGatherersMassTurnAutomationTest::RunTest(const FString& Parameters)
 {
 	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
 	TestNotNull(TEXT("editor world should exist"), World);
@@ -33,6 +35,7 @@ bool FGatherersMassPickupAutomationTest::RunTest(const FString& Parameters)
 
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
+	Plan.RandomSeedBase = 123;
 	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
 	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
 	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
@@ -47,9 +50,19 @@ bool FGatherersMassPickupAutomationTest::RunTest(const FString& Parameters)
 		return false;
 	}
 
+	FRandomStream RandomStream(Plan.RandomSeedBase);
+	const FVector ExpectedTurnDirection = ComputeAntTurnDirection(
+		FVector(1.0f, 0.0f, 0.0f),
+		RandomStream.FRandRange(-1.0f, 1.0f),
+		PI / 2.0f);
+	const FVector ExpectedLocationAfterSecondTick = FVector(10.0f, 0.0f, 0.0f) + ExpectedTurnDirection * 10.0f;
+
+	MassSubsystem->Tick(0.1f);
 	MassSubsystem->Tick(0.1f);
 
-	TestTrue(TEXT("food proxy should now be attached to the ant proxy"), Result.Foods[0]->GetAttachParentActor() == Result.Ants[0]);
+	TestTrue(
+		TEXT("pickup should consume the stored Mass turn state and move on the turned heading next frame"),
+		Result.Ants[0]->GetActorLocation().Equals(ExpectedLocationAfterSecondTick, 1.0f));
 
 	Result.Ants[0]->Destroy();
 	Result.Foods[0]->Destroy();

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassVisuals.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassVisuals.spec.cpp
@@ -1,0 +1,233 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Editor.h"
+#include "HAL/PlatformTime.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
+#include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+#include "TestLogic/GatherersWorldAssertions.h"
+#include "Tests/AutomationCommon.h"
+#include "Tests/AutomationEditorCommon.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassVisualsAutomationTest,
+	"default.unreal_gatherers.Mass.MassInstancedVisualsCreateVisibleAntAndFoodInstances",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(
+	FGatherersPrepareMassVisualStabilityFixtureCommand,
+	FAutomationTestBase*,
+	Test);
+
+class FGatherersWaitForStableMassVisualFramesCommand : public IAutomationLatentCommand
+{
+public:
+	FGatherersWaitForStableMassVisualFramesCommand(FAutomationTestBase* InTest, double InTimeoutSeconds)
+		: Test(InTest),
+		  TimeoutSeconds(InTimeoutSeconds),
+		  StartTimeSeconds(FPlatformTime::Seconds())
+	{
+	}
+
+	virtual bool Update() override
+	{
+		UWorld* World = GEditor ? GEditor->PlayWorld : nullptr;
+		Test->TestNotNull(TEXT("Mass visual stability world should exist"), World);
+		if (World == nullptr)
+		{
+			return true;
+		}
+
+		const GatherersWorldAssertions::FObservedMassVisualState VisualState = GatherersWorldAssertions::ObserveMassVisuals(World);
+		if (VisualState.HasSingleAntAndOneFood())
+		{
+			const bool bVisualsMatchSimulation = VisualState.SingleAntAndFoodVisualsMatchSimulation(20.0f, 0.001f);
+			Test->TestTrue(TEXT("Mass visuals should match simulation transforms every live frame"), bVisualsMatchSimulation);
+			if (!bVisualsMatchSimulation)
+			{
+				return true;
+			}
+
+			if (PreviousFoodVisualPosition.IsSet())
+			{
+				const bool bLooseFoodVisualStable = VisualState.FoodVisualPositions[0].Equals(
+					PreviousFoodVisualPosition.GetValue(),
+					0.001f);
+				Test->TestTrue(TEXT("loose food visual should remain stable across live frames"), bLooseFoodVisualStable);
+				if (!bLooseFoodVisualStable)
+				{
+					return true;
+				}
+			}
+
+			PreviousFoodVisualPosition = VisualState.FoodVisualPositions[0];
+			++ObservedFrames;
+			if (ObservedFrames >= 60)
+			{
+				return true;
+			}
+		}
+
+		if (FPlatformTime::Seconds() - StartTimeSeconds < TimeoutSeconds)
+		{
+			return false;
+		}
+
+		Test->AddError(TEXT("Mass visual stability fixture did not produce enough observed frames"));
+		return true;
+	}
+
+private:
+	FAutomationTestBase* Test;
+	double TimeoutSeconds;
+	double StartTimeSeconds;
+	int32 ObservedFrames = 0;
+	TOptional<FVector> PreviousFoodVisualPosition;
+};
+
+DEFINE_LATENT_AUTOMATION_COMMAND_THREE_PARAMETER(
+	FGatherersWaitForMassVisualStabilityPIECleanupCommand,
+	FAutomationTestBase*,
+	Test,
+	double,
+	StartTimeSeconds,
+	double,
+	TimeoutSeconds);
+
+bool FGatherersWaitForMassVisualStabilityPIECleanupCommand::Update()
+{
+	return GatherersWorldAssertions::PollForPIEToEnd(
+		*Test,
+		TEXT("/Game/SimBlank/Levels/SimBlank"),
+		StartTimeSeconds,
+		TimeoutSeconds,
+		TEXT("mass-visual-stability"));
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassVisualStabilityAutomationTest,
+	"supplemental.unreal_gatherers.Mass.MassVisualsStayStableAcrossLiveFrames",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersMassVisualsAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+	TestNotNull(TEXT("Mass entity subsystem should exist"), MassEntitySubsystem);
+
+	if (MassSubsystem == nullptr || MassEntitySubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(100.0f, 0.0f, 0.0f)));
+
+	SpawnGatherersActors(*World, Plan);
+	MassSubsystem->Tick(0.1f);
+
+	const UInstancedStaticMeshComponent* AntVisual = MassSubsystem->GetAntVisualComponent();
+	const UInstancedStaticMeshComponent* FoodVisual = MassSubsystem->GetFoodVisualComponent();
+	TestNotNull(TEXT("ant instanced visual should exist on the gatherers Mass subsystem"), const_cast<UInstancedStaticMeshComponent*>(AntVisual));
+	TestNotNull(TEXT("food instanced visual should exist on the gatherers Mass subsystem"), const_cast<UInstancedStaticMeshComponent*>(FoodVisual));
+
+	if (AntVisual != nullptr)
+	{
+		TestEqual(TEXT("ant instanced visual should contain one rendered ant instance"), AntVisual->GetInstanceCount(), 1);
+	}
+
+	if (FoodVisual != nullptr)
+	{
+		TestEqual(TEXT("food instanced visual should contain one rendered food instance"), FoodVisual->GetInstanceCount(), 1);
+	}
+
+	MassSubsystem->ResetSimulation();
+	return true;
+}
+
+bool FGatherersPrepareMassVisualStabilityFixtureCommand::Update()
+{
+	UWorld* World = GEditor ? GEditor->PlayWorld : nullptr;
+	Test->TestNotNull(TEXT("Mass visual stability play world should exist"), World);
+	if (World == nullptr)
+	{
+		return true;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	Test->TestNotNull(TEXT("Mass visual stability world should expose the gatherers Mass subsystem"), MassSubsystem);
+	if (MassSubsystem == nullptr)
+	{
+		return true;
+	}
+
+	MassSubsystem->ResetSimulation();
+	const GatherersWorldAssertions::FObservedWorldState ExistingActorState = GatherersWorldAssertions::Observe(World);
+	for (AAnt* Ant : ExistingActorState.Ants)
+	{
+		if (Ant != nullptr)
+		{
+			Ant->Destroy();
+		}
+	}
+
+	for (AFood* Food : ExistingActorState.Foods)
+	{
+		if (Food != nullptr)
+		{
+			Food->Destroy();
+		}
+	}
+
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.AntSpawns.Add(FTransform(FVector::ZeroVector));
+	Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	Plan.FoodSpawns.Add(FTransform(FVector(0.0f, 200.0f, 0.0f)));
+
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	Test->TestEqual(TEXT("Mass visual stability fixture should not spawn ant actors"), Result.Ants.Num(), 0);
+	Test->TestEqual(TEXT("Mass visual stability fixture should not spawn food actors"), Result.Foods.Num(), 0);
+	Test->TestEqual(TEXT("Mass visual stability fixture managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	Test->TestEqual(TEXT("Mass visual stability fixture managed food count"), MassSubsystem->GetManagedFoodCount(), 1);
+	return true;
+}
+
+bool FGatherersMassVisualStabilityAutomationTest::RunTest(const FString& Parameters)
+{
+	const bool bOpenedMap = AutomationOpenMap(TEXT("/Game/SimBlank/Levels/SimBlank"));
+	TestTrue(TEXT("should open SimBlank map"), bOpenedMap);
+
+	if (!bOpenedMap)
+	{
+		return false;
+	}
+
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareMassVisualStabilityFixtureCommand(this));
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForStableMassVisualFramesCommand(this, 5.0));
+	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForMassVisualStabilityPIECleanupCommand(this, FPlatformTime::Seconds(), 5.0));
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/SpawnPlan.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/SpawnPlan.spec.cpp
@@ -12,6 +12,7 @@ bool FGatherersSpawnPlanAutomationTest::RunTest(const FString& Parameters)
 
 	TestEqual(TEXT("ant spawn count"), Plan.AntSpawns.Num(), 1);
 	TestEqual(TEXT("food spawn count"), Plan.FoodSpawns.Num(), 2);
+	TestFalse(TEXT("initial Mass-backed spawn plan does not request actor visuals"), Plan.bSpawnActorVisuals);
 	TestTrue(
 		TEXT("first food spawn is the initial forward target"),
 		Plan.FoodSpawns[0].GetLocation().Equals(FVector(200.0f, 0.0f, 50.0f), KINDA_SMALL_NUMBER));
@@ -33,6 +34,7 @@ bool FGatherersDefaultGameFullSimulationSpawnPlanAutomationTest::RunTest(const F
 		123);
 
 	TestTrue(TEXT("default game spawn plan uses full simulation mode"), Plan.bUseFullSimulationMode);
+	TestFalse(TEXT("default game spawn plan does not request actor visuals"), Plan.bSpawnActorVisuals);
 	TestEqual(TEXT("default game ant spawn count follows the Rust row spacing"), Plan.AntSpawns.Num(), 26);
 	TestEqual(TEXT("default game ant heading count matches the spawned ants"), Plan.AntInitialDirections.Num(), 26);
 	TestEqual(TEXT("default game food count follows the Rust default"), Plan.FoodSpawns.Num(), 80);

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/SpawnPlan.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/SpawnPlan.spec.cpp
@@ -20,3 +20,27 @@ bool FGatherersSpawnPlanAutomationTest::RunTest(const FString& Parameters)
 		Plan.FoodSpawns[1].GetLocation().Equals(FVector(-200.0f, 0.0f, 50.0f), KINDA_SMALL_NUMBER));
 	return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersDefaultGameFullSimulationSpawnPlanAutomationTest,
+	"default.unreal_gatherers.FullSimulation.DefaultGameSpawnPlanUsesRustLikeDefaults",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersDefaultGameFullSimulationSpawnPlanAutomationTest::RunTest(const FString& Parameters)
+{
+	const FGatherersSpawnPlan Plan = BuildDefaultGameFullSimulationSpawnPlan(
+		FBox(FVector(-640.0f, -360.0f, -100.0f), FVector(640.0f, 360.0f, 100.0f)),
+		123);
+
+	TestTrue(TEXT("default game spawn plan uses full simulation mode"), Plan.bUseFullSimulationMode);
+	TestEqual(TEXT("default game ant spawn count follows the Rust row spacing"), Plan.AntSpawns.Num(), 26);
+	TestEqual(TEXT("default game ant heading count matches the spawned ants"), Plan.AntInitialDirections.Num(), 26);
+	TestEqual(TEXT("default game food count follows the Rust default"), Plan.FoodSpawns.Num(), 80);
+	TestTrue(
+		TEXT("default game spawn plan starts the first ant at the left edge row position"),
+		Plan.AntSpawns[0].GetLocation().Equals(FVector(-640.0f, 100.0f, 50.0f), KINDA_SMALL_NUMBER));
+	TestTrue(
+		TEXT("default game spawn plan uses the Rust ant row spacing"),
+		Plan.AntSpawns[1].GetLocation().Equals(FVector(-590.0f, 100.0f, 50.0f), KINDA_SMALL_NUMBER));
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/StartupSmokeTest.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/StartupSmokeTest.cpp
@@ -28,13 +28,25 @@ DEFINE_LATENT_AUTOMATION_COMMAND_THREE_PARAMETER(
 
 bool FGatherersWaitForStartupActorsCommand::Update()
 {
-	return GatherersWorldAssertions::PollForPickupState(
-		*Test,
-		GEditor ? GEditor->PlayWorld : nullptr,
-		BuildInitialGatherersSpawnPlan(),
-		StartTimeSeconds,
-		TimeoutSeconds,
-		TEXT("startup"));
+	UWorld* World = GEditor ? GEditor->PlayWorld : nullptr;
+	Test->TestNotNull(TEXT("startup world should exist"), World);
+	if (World == nullptr)
+	{
+		return true;
+	}
+
+	const GatherersWorldAssertions::FObservedWorldState WorldState = GatherersWorldAssertions::Observe(World);
+	if (WorldState.Ants.Num() != 26 || WorldState.Foods.Num() != 80)
+	{
+		if (FPlatformTime::Seconds() - StartTimeSeconds < TimeoutSeconds)
+		{
+			return false;
+		}
+	}
+
+	Test->TestEqual(TEXT("startup ant count"), WorldState.Ants.Num(), 26);
+	Test->TestEqual(TEXT("startup food count"), WorldState.Foods.Num(), 80);
+	return true;
 }
 
 bool FGatherersWaitForStartupPIECleanupCommand::Update()
@@ -49,7 +61,7 @@ bool FGatherersWaitForStartupPIECleanupCommand::Update()
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FGatherersStartupSmokeAutomationTest,
-	"supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsOneAntAndTwoFoods",
+	"supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsRustLikeFullSimulationCounts",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FGatherersStartupSmokeAutomationTest::RunTest(const FString& Parameters)

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/StartupSmokeTest.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/StartupSmokeTest.cpp
@@ -36,10 +36,11 @@ bool FGatherersWaitForStartupActorsCommand::Update()
 		return true;
 	}
 
-	const GatherersWorldAssertions::FObservedWorldState WorldState = GatherersWorldAssertions::Observe(World);
+	const GatherersWorldAssertions::FObservedMassVisualState VisualState = GatherersWorldAssertions::ObserveMassVisuals(World);
 	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
 	Test->TestNotNull(TEXT("startup world should expose the gatherers Mass subsystem"), MassSubsystem);
-	if (WorldState.Ants.Num() != 26 || WorldState.Foods.Num() != 80)
+	const GatherersWorldAssertions::FObservedWorldState ActorState = GatherersWorldAssertions::Observe(World);
+	if (VisualState.AntPositions.Num() != 26 || VisualState.FoodPositions.Num() != 80)
 	{
 		if (FPlatformTime::Seconds() - StartTimeSeconds < TimeoutSeconds)
 		{
@@ -47,8 +48,12 @@ bool FGatherersWaitForStartupActorsCommand::Update()
 		}
 	}
 
-	Test->TestEqual(TEXT("startup ant count"), WorldState.Ants.Num(), 26);
-	Test->TestEqual(TEXT("startup food count"), WorldState.Foods.Num(), 80);
+	Test->TestEqual(TEXT("startup ant actor count"), ActorState.Ants.Num(), 0);
+	Test->TestEqual(TEXT("startup food actor count"), ActorState.Foods.Num(), 0);
+	Test->TestEqual(TEXT("startup ant entity count"), VisualState.AntPositions.Num(), 26);
+	Test->TestEqual(TEXT("startup food entity count"), VisualState.FoodPositions.Num(), 80);
+	Test->TestEqual(TEXT("startup ant visual count"), VisualState.AntVisualPositions.Num(), 26);
+	Test->TestEqual(TEXT("startup food visual count"), VisualState.FoodVisualPositions.Num(), 80);
 	if (MassSubsystem != nullptr)
 	{
 		Test->TestEqual(TEXT("startup managed ant count"), MassSubsystem->GetManagedAntCount(), 26);

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/StartupSmokeTest.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/StartupSmokeTest.cpp
@@ -3,6 +3,7 @@
 #include "Editor.h"
 #include "HAL/PlatformTime.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "TestLogic/GatherersWorldAssertions.h"
 #include "Tests/AutomationCommon.h"
@@ -36,6 +37,8 @@ bool FGatherersWaitForStartupActorsCommand::Update()
 	}
 
 	const GatherersWorldAssertions::FObservedWorldState WorldState = GatherersWorldAssertions::Observe(World);
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	Test->TestNotNull(TEXT("startup world should expose the gatherers Mass subsystem"), MassSubsystem);
 	if (WorldState.Ants.Num() != 26 || WorldState.Foods.Num() != 80)
 	{
 		if (FPlatformTime::Seconds() - StartTimeSeconds < TimeoutSeconds)
@@ -46,6 +49,11 @@ bool FGatherersWaitForStartupActorsCommand::Update()
 
 	Test->TestEqual(TEXT("startup ant count"), WorldState.Ants.Num(), 26);
 	Test->TestEqual(TEXT("startup food count"), WorldState.Foods.Num(), 80);
+	if (MassSubsystem != nullptr)
+	{
+		Test->TestEqual(TEXT("startup managed ant count"), MassSubsystem->GetManagedAntCount(), 26);
+		Test->TestEqual(TEXT("startup managed food count"), MassSubsystem->GetManagedFoodCount(), 80);
+	}
 	return true;
 }
 

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/TestLogic/GatherersWorldAssertions.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/TestLogic/GatherersWorldAssertions.cpp
@@ -2,15 +2,56 @@
 
 #include "Actors/Ant.h"
 #include "Actors/Food.h"
+#include "Components/InstancedStaticMeshComponent.h"
 #include "EngineUtils.h"
 #include "HAL/PlatformTime.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/PackageName.h"
+#include "Simulation/GatherersAntSimulation.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Tests/AutomationCommon.h"
 
 namespace GatherersWorldAssertions
 {
+namespace
+{
+TArray<FVector> CollectInstanceLocations(const UInstancedStaticMeshComponent* Instances)
+{
+	TArray<FVector> Locations;
+	if (Instances == nullptr)
+	{
+		return Locations;
+	}
+
+	for (int32 InstanceIndex = 0; InstanceIndex < Instances->GetInstanceCount(); ++InstanceIndex)
+	{
+		FTransform InstanceTransform;
+		if (Instances->GetInstanceTransform(InstanceIndex, InstanceTransform, true))
+		{
+			Locations.Add(InstanceTransform.GetLocation());
+		}
+	}
+
+	return Locations;
+}
+
+bool ContainsLocation(const TArray<FVector>& Locations, const FVector& ExpectedLocation, float PositionTolerance)
+{
+	for (const FVector& Location : Locations)
+	{
+		if (Location.Equals(ExpectedLocation, PositionTolerance))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+}
+
 bool FObservedWorldState::HasSingleAntAndTwoFoods() const
 {
 	return Ants.Num() == 1 && Foods.Num() == 2;
@@ -48,6 +89,55 @@ AFood* FObservedWorldState::GetFirstAttachedFood() const
 	return nullptr;
 }
 
+bool FObservedMassVisualState::HasSingleAntAndTwoFoods() const
+{
+	return AntPositions.Num() == 1 && FoodPositions.Num() == 2;
+}
+
+bool FObservedMassVisualState::HasSingleAntAndOneFood() const
+{
+	return AntPositions.Num() == 1 && FoodPositions.Num() == 1
+		&& AntVisualPositions.Num() == 1 && FoodVisualPositions.Num() == 1;
+}
+
+bool FObservedMassVisualState::HasCarriedFoodVisual(float CarriedFoodHeight, float PositionTolerance) const
+{
+	if (AntPositions.Num() != 1)
+	{
+		return false;
+	}
+
+	return ContainsLocation(
+		FoodVisualPositions,
+		AntPositions[0] + ComputeCarriedFoodRelativeLocation(CarriedFoodHeight),
+		PositionTolerance);
+}
+
+bool FObservedMassVisualState::SingleAntAndFoodVisualsMatchSimulation(
+	float CarriedFoodHeight,
+	float PositionTolerance) const
+{
+	if (!HasSingleAntAndOneFood())
+	{
+		return false;
+	}
+
+	const bool bAntMatches = AntPositions[0].Equals(AntVisualPositions[0], PositionTolerance);
+	if (!bAntMatches)
+	{
+		return false;
+	}
+
+	if (LooseFoodCount > 0)
+	{
+		return FoodPositions[0].Equals(FoodVisualPositions[0], PositionTolerance);
+	}
+
+	return FoodVisualPositions[0].Equals(
+		AntPositions[0] + ComputeCarriedFoodRelativeLocation(CarriedFoodHeight),
+		PositionTolerance);
+}
+
 FObservedWorldState Observe(UWorld* World)
 {
 	FObservedWorldState WorldState;
@@ -67,6 +157,57 @@ FObservedWorldState Observe(UWorld* World)
 	}
 
 	return WorldState;
+}
+
+FObservedMassVisualState ObserveMassVisuals(UWorld* World)
+{
+	FObservedMassVisualState VisualState;
+	if (World == nullptr)
+	{
+		return VisualState;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	if (MassSubsystem == nullptr || MassEntitySubsystem == nullptr)
+	{
+		return VisualState;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+
+	for (const FMassEntityHandle Entity : MassSubsystem->ManagedAntEntities)
+	{
+		if (!EntityManager.IsEntityValid(Entity))
+		{
+			continue;
+		}
+
+		FMassEntityView AntView(EntityManager, Entity);
+		const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+		VisualState.AntPositions.Add(AntFragment.Position);
+	}
+
+	for (const FMassEntityHandle Entity : MassSubsystem->ManagedFoodEntities)
+	{
+		if (!EntityManager.IsEntityValid(Entity))
+		{
+			continue;
+		}
+
+		FMassEntityView FoodView(EntityManager, Entity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		VisualState.FoodPositions.Add(FoodFragment.Position);
+		if (FoodFragment.bIsLoose)
+		{
+			++VisualState.LooseFoodCount;
+		}
+	}
+
+	VisualState.AntVisualPositions = CollectInstanceLocations(MassSubsystem->GetAntVisualComponent());
+	VisualState.FoodVisualPositions = CollectInstanceLocations(MassSubsystem->GetFoodVisualComponent());
+
+	return VisualState;
 }
 
 void AssertPickupState(
@@ -133,6 +274,104 @@ void AssertFirstDropState(
 	Test.TestTrue(
 		*(CountPrefix + TEXT("one loose food sits away from the original forward spawn after the first drop")),
 		bFoundDroppedFoodAwayFromForwardSpawn);
+}
+
+void AssertMassPickupState(
+	FAutomationTestBase& Test,
+	const FObservedMassVisualState& VisualState,
+	const FGatherersSpawnPlan& Plan,
+	const FString& LabelPrefix,
+	float CarriedFoodHeight,
+	float PositionTolerance)
+{
+	const FString CountPrefix = LabelPrefix.IsEmpty() ? TEXT("") : LabelPrefix + TEXT(" ");
+	Test.TestEqual(*(CountPrefix + TEXT("ant entity count")), VisualState.AntPositions.Num(), 1);
+	Test.TestEqual(*(CountPrefix + TEXT("food entity count")), VisualState.FoodPositions.Num(), 2);
+	Test.TestEqual(*(CountPrefix + TEXT("ant visual instance count")), VisualState.AntVisualPositions.Num(), 1);
+	Test.TestEqual(*(CountPrefix + TEXT("food visual instance count")), VisualState.FoodVisualPositions.Num(), 2);
+	Test.TestTrue(
+		*(CountPrefix + TEXT("one food is visibly carried by the ant")),
+		VisualState.HasCarriedFoodVisual(CarriedFoodHeight, PositionTolerance));
+
+	if (VisualState.AntPositions.Num() != 1)
+	{
+		return;
+	}
+
+	Test.TestTrue(
+		*(CountPrefix + TEXT("ant moves from its spawn point")),
+		!VisualState.AntPositions[0].Equals(Plan.AntSpawns[0].GetLocation(), PositionTolerance));
+}
+
+void AssertMassFirstDropState(
+	FAutomationTestBase& Test,
+	const FObservedMassVisualState& VisualState,
+	const FGatherersSpawnPlan& Plan,
+	const FString& LabelPrefix,
+	float PositionTolerance)
+{
+	const FString CountPrefix = LabelPrefix.IsEmpty() ? TEXT("") : LabelPrefix + TEXT(" ");
+	Test.TestEqual(*(CountPrefix + TEXT("ant entity count")), VisualState.AntPositions.Num(), 1);
+	Test.TestEqual(*(CountPrefix + TEXT("food entity count")), VisualState.FoodPositions.Num(), 2);
+	Test.TestEqual(*(CountPrefix + TEXT("ant visual instance count")), VisualState.AntVisualPositions.Num(), 1);
+	Test.TestEqual(*(CountPrefix + TEXT("food visual instance count")), VisualState.FoodVisualPositions.Num(), 2);
+	Test.TestFalse(
+		*(CountPrefix + TEXT("no food remains visibly carried after the first drop")),
+		VisualState.HasCarriedFoodVisual(20.0f, PositionTolerance));
+
+	if (VisualState.AntPositions.Num() != 1)
+	{
+		return;
+	}
+
+	Test.TestTrue(
+		*(CountPrefix + TEXT("ant moved from its spawn point before the first drop")),
+		!VisualState.AntPositions[0].Equals(Plan.AntSpawns[0].GetLocation(), PositionTolerance));
+
+	bool bFoundDroppedFoodAwayFromForwardSpawn = false;
+	for (const FVector& FoodVisualPosition : VisualState.FoodVisualPositions)
+	{
+		bFoundDroppedFoodAwayFromForwardSpawn |=
+			!FoodVisualPosition.Equals(Plan.FoodSpawns[0].GetLocation(), PositionTolerance);
+	}
+
+	Test.TestTrue(
+		*(CountPrefix + TEXT("one loose food visual sits away from the original forward spawn after the first drop")),
+		bFoundDroppedFoodAwayFromForwardSpawn);
+}
+
+bool PollForMassPickupState(
+	FAutomationTestBase& Test,
+	UWorld* World,
+	const FGatherersSpawnPlan& Plan,
+	double StartTimeSeconds,
+	double TimeoutSeconds,
+	const FString& LabelPrefix,
+	float CarriedFoodHeight,
+	float PositionTolerance)
+{
+	Test.TestNotNull(*(LabelPrefix + TEXT(" world should exist")), World);
+	if (World == nullptr)
+	{
+		return true;
+	}
+
+	const FObservedMassVisualState VisualState = ObserveMassVisuals(World);
+	const bool bHasExpectedCounts = VisualState.HasSingleAntAndTwoFoods();
+	const bool bAntMoved = VisualState.AntPositions.Num() == 1
+		&& !VisualState.AntPositions[0].Equals(Plan.AntSpawns[0].GetLocation(), PositionTolerance);
+	const bool bFoodVisiblyCarried = VisualState.HasCarriedFoodVisual(CarriedFoodHeight, PositionTolerance);
+
+	if (!(bHasExpectedCounts && bAntMoved && bFoodVisiblyCarried))
+	{
+		if (FPlatformTime::Seconds() - StartTimeSeconds < TimeoutSeconds)
+		{
+			return false;
+		}
+	}
+
+	AssertMassPickupState(Test, VisualState, Plan, LabelPrefix, CarriedFoodHeight, PositionTolerance);
+	return true;
 }
 
 bool PollForPickupState(

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/TestLogic/GatherersWorldAssertions.h
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/TestLogic/GatherersWorldAssertions.h
@@ -21,7 +21,24 @@ struct FObservedWorldState
 	AFood* GetFirstAttachedFood() const;
 };
 
+struct FObservedMassVisualState
+{
+	TArray<FVector> AntPositions;
+	TArray<FVector> FoodPositions;
+	TArray<FVector> AntVisualPositions;
+	TArray<FVector> FoodVisualPositions;
+	int32 LooseFoodCount = 0;
+
+	bool HasSingleAntAndTwoFoods() const;
+	bool HasSingleAntAndOneFood() const;
+	bool HasCarriedFoodVisual(float CarriedFoodHeight, float PositionTolerance = KINDA_SMALL_NUMBER) const;
+	bool SingleAntAndFoodVisualsMatchSimulation(
+		float CarriedFoodHeight,
+		float PositionTolerance = KINDA_SMALL_NUMBER) const;
+};
+
 FObservedWorldState Observe(UWorld* World);
+FObservedMassVisualState ObserveMassVisuals(UWorld* World);
 
 bool PollForPickupState(
 	FAutomationTestBase& Test,
@@ -30,6 +47,16 @@ bool PollForPickupState(
 	double StartTimeSeconds,
 	double TimeoutSeconds,
 	const FString& LabelPrefix,
+	float PositionTolerance = KINDA_SMALL_NUMBER);
+
+bool PollForMassPickupState(
+	FAutomationTestBase& Test,
+	UWorld* World,
+	const FGatherersSpawnPlan& Plan,
+	double StartTimeSeconds,
+	double TimeoutSeconds,
+	const FString& LabelPrefix,
+	float CarriedFoodHeight,
 	float PositionTolerance = KINDA_SMALL_NUMBER);
 
 bool PollForPIEToEnd(
@@ -51,5 +78,20 @@ void AssertFirstDropState(
 	const FObservedWorldState& WorldState,
 	const FGatherersSpawnPlan& Plan,
 	const FString& LabelPrefix,
+	float PositionTolerance = KINDA_SMALL_NUMBER);
+
+void AssertMassFirstDropState(
+	FAutomationTestBase& Test,
+	const FObservedMassVisualState& VisualState,
+	const FGatherersSpawnPlan& Plan,
+	const FString& LabelPrefix,
+	float PositionTolerance = KINDA_SMALL_NUMBER);
+
+void AssertMassPickupState(
+	FAutomationTestBase& Test,
+	const FObservedMassVisualState& VisualState,
+	const FGatherersSpawnPlan& Plan,
+	const FString& LabelPrefix,
+	float CarriedFoodHeight,
 	float PositionTolerance = KINDA_SMALL_NUMBER);
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualFullSimulationDemo.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualFullSimulationDemo.spec.cpp
@@ -6,6 +6,7 @@
 #include "LevelEditorViewport.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/PackageName.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 
@@ -60,6 +61,20 @@ public:
 
 	virtual bool Update() override
 	{
+		UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+		Test->TestNotNull(TEXT("visual full-sim editor world should exist"), World);
+		if (World == nullptr)
+		{
+			return true;
+		}
+
+		UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+		Test->TestNotNull(TEXT("visual full-sim editor world should expose the gatherers Mass subsystem"), MassSubsystem);
+		if (MassSubsystem == nullptr)
+		{
+			return true;
+		}
+
 		Test->TestNotNull(TEXT("visual full-sim ant should remain valid"), Ant);
 		if (Ant == nullptr)
 		{
@@ -98,7 +113,7 @@ public:
 			return false;
 		}
 
-		Ant->Tick(VisualStepSeconds);
+		MassSubsystem->Tick(VisualStepSeconds);
 		LastStepTimeSeconds = NowSeconds;
 		return false;
 	}
@@ -136,6 +151,15 @@ bool FGatherersVisualFullSimulationAutomationTest::RunTest(const FString& Parame
 		return false;
 	}
 
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("editor world should expose the gatherers Mass subsystem"), MassSubsystem);
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+
 	const FGatherersSpawnPlan Plan = BuildFullSimulationVisualSpawnPlan();
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
 	TestEqual(TEXT("full-sim visual spawned ant count"), Result.Ants.Num(), 1);
@@ -146,7 +170,6 @@ bool FGatherersVisualFullSimulationAutomationTest::RunTest(const FString& Parame
 		return false;
 	}
 
-	Result.Ants[0]->SetFullSimulationTurnJitterRadians(0.0f);
 	FrameVisualFullSimulationInViewport(Plan);
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersAdvanceVisibleFullSimulationCommand(this, Result.Ants[0], Result.Foods));
 	return true;

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualFullSimulationDemo.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualFullSimulationDemo.spec.cpp
@@ -1,5 +1,3 @@
-#include "Actors/Ant.h"
-#include "Actors/Food.h"
 #include "Editor.h"
 #include "FileHelpers.h"
 #include "HAL/PlatformTime.h"
@@ -9,6 +7,7 @@
 #include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
+#include "TestLogic/GatherersWorldAssertions.h"
 
 namespace
 {
@@ -50,10 +49,8 @@ void FrameVisualFullSimulationInViewport(const FGatherersSpawnPlan& Plan)
 class FGatherersAdvanceVisibleFullSimulationCommand : public IAutomationLatentCommand
 {
 public:
-	FGatherersAdvanceVisibleFullSimulationCommand(FAutomationTestBase* InTest, AAnt* InAnt, const TArray<AFood*>& InFoods)
+	explicit FGatherersAdvanceVisibleFullSimulationCommand(FAutomationTestBase* InTest)
 		: Test(InTest),
-		  Ant(InAnt),
-		  Foods(InFoods),
 		  StartTimeSeconds(FPlatformTime::Seconds()),
 		  LastStepTimeSeconds(StartTimeSeconds)
 	{
@@ -75,22 +72,8 @@ public:
 			return true;
 		}
 
-		Test->TestNotNull(TEXT("visual full-sim ant should remain valid"), Ant);
-		if (Ant == nullptr)
-		{
-			return true;
-		}
-
-		int32 AttachedFoodCount = 0;
-		for (AFood* Food : Foods)
-		{
-			if (Food != nullptr && Food->GetAttachParentActor() == Ant)
-			{
-				++AttachedFoodCount;
-			}
-		}
-
-		if (AttachedFoodCount == 1)
+		const GatherersWorldAssertions::FObservedMassVisualState VisualState = GatherersWorldAssertions::ObserveMassVisuals(World);
+		if (VisualState.HasCarriedFoodVisual(20.0f))
 		{
 			++ObservedAttachedFoodFrames;
 		}
@@ -120,8 +103,6 @@ public:
 
 private:
 	FAutomationTestBase* Test;
-	AAnt* Ant;
-	TArray<AFood*> Foods;
 	double StartTimeSeconds;
 	double LastStepTimeSeconds;
 	int32 ObservedAttachedFoodFrames = 0;
@@ -160,17 +141,20 @@ bool FGatherersVisualFullSimulationAutomationTest::RunTest(const FString& Parame
 
 	MassSubsystem->ResetSimulation();
 
-	const FGatherersSpawnPlan Plan = BuildFullSimulationVisualSpawnPlan();
+	FGatherersSpawnPlan Plan = BuildFullSimulationVisualSpawnPlan();
+	Plan.bSpawnActorVisuals = false;
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("full-sim visual spawned ant count"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("full-sim visual spawned food count"), Result.Foods.Num(), 3);
+	TestEqual(TEXT("full-sim visual spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("full-sim visual spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("full-sim visual managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("full-sim visual managed food count"), MassSubsystem->GetManagedFoodCount(), 3);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 3)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 3)
 	{
 		return false;
 	}
 
 	FrameVisualFullSimulationInViewport(Plan);
-	ADD_LATENT_AUTOMATION_COMMAND(FGatherersAdvanceVisibleFullSimulationCommand(this, Result.Ants[0], Result.Foods));
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersAdvanceVisibleFullSimulationCommand(this));
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualFullSimulationDemo.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualFullSimulationDemo.spec.cpp
@@ -1,0 +1,153 @@
+#include "Actors/Ant.h"
+#include "Actors/Food.h"
+#include "Editor.h"
+#include "FileHelpers.h"
+#include "HAL/PlatformTime.h"
+#include "LevelEditorViewport.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/PackageName.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+
+namespace
+{
+constexpr TCHAR SimBlankMapPackage[] = TEXT("/Game/SimBlank/Levels/SimBlank");
+constexpr double VisualStepSeconds = 0.1;
+constexpr double VisualTimeoutSeconds = 8.0;
+
+bool LoadSimBlankIntoEditorWorld()
+{
+	const FString MapFilename = FPackageName::LongPackageNameToFilename(
+		SimBlankMapPackage,
+		FPackageName::GetMapPackageExtension());
+	return FEditorFileUtils::LoadMap(MapFilename, false, false);
+}
+
+void FrameVisualFullSimulationInViewport(const FGatherersSpawnPlan& Plan)
+{
+	if (GCurrentLevelEditingViewportClient == nullptr)
+	{
+		return;
+	}
+
+	FBox FocusBounds(EForceInit::ForceInit);
+	for (const FTransform& AntSpawn : Plan.AntSpawns)
+	{
+		FocusBounds += AntSpawn.GetLocation();
+	}
+
+	for (const FTransform& FoodSpawn : Plan.FoodSpawns)
+	{
+		FocusBounds += FoodSpawn.GetLocation();
+	}
+
+	FocusBounds = FocusBounds.ExpandBy(FVector(150.0f, 200.0f, 150.0f));
+	GCurrentLevelEditingViewportClient->FocusViewportOnBox(FocusBounds, true);
+	GCurrentLevelEditingViewportClient->Invalidate();
+}
+
+class FGatherersAdvanceVisibleFullSimulationCommand : public IAutomationLatentCommand
+{
+public:
+	FGatherersAdvanceVisibleFullSimulationCommand(FAutomationTestBase* InTest, AAnt* InAnt, const TArray<AFood*>& InFoods)
+		: Test(InTest),
+		  Ant(InAnt),
+		  Foods(InFoods),
+		  StartTimeSeconds(FPlatformTime::Seconds()),
+		  LastStepTimeSeconds(StartTimeSeconds)
+	{
+	}
+
+	virtual bool Update() override
+	{
+		Test->TestNotNull(TEXT("visual full-sim ant should remain valid"), Ant);
+		if (Ant == nullptr)
+		{
+			return true;
+		}
+
+		int32 AttachedFoodCount = 0;
+		for (AFood* Food : Foods)
+		{
+			if (Food != nullptr && Food->GetAttachParentActor() == Ant)
+			{
+				++AttachedFoodCount;
+			}
+		}
+
+		if (AttachedFoodCount == 1)
+		{
+			++ObservedAttachedFoodFrames;
+		}
+
+		if (ObservedAttachedFoodFrames >= 2)
+		{
+			Test->TestTrue(TEXT("full-sim visual path reaches a second visible pickup for inspection"), true);
+			return true;
+		}
+
+		const double NowSeconds = FPlatformTime::Seconds();
+		if (NowSeconds - StartTimeSeconds >= VisualTimeoutSeconds)
+		{
+			Test->TestTrue(TEXT("full-sim visual path reaches a second visible pickup for inspection"), false);
+			return true;
+		}
+
+		if (NowSeconds - LastStepTimeSeconds < VisualStepSeconds)
+		{
+			return false;
+		}
+
+		Ant->Tick(VisualStepSeconds);
+		LastStepTimeSeconds = NowSeconds;
+		return false;
+	}
+
+private:
+	FAutomationTestBase* Test;
+	AAnt* Ant;
+	TArray<AFood*> Foods;
+	double StartTimeSeconds;
+	double LastStepTimeSeconds;
+	int32 ObservedAttachedFoodFrames = 0;
+};
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersVisualFullSimulationAutomationTest,
+	"manual.unreal_gatherers.Visual.FullSimulationSecondPickupStaysVisible",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersVisualFullSimulationAutomationTest::RunTest(const FString& Parameters)
+{
+	const bool bLoadedMap = LoadSimBlankIntoEditorWorld();
+	TestTrue(TEXT("should load SimBlank into the editor world"), bLoadedMap);
+
+	if (!bLoadedMap)
+	{
+		return false;
+	}
+
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist after loading SimBlank"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	const FGatherersSpawnPlan Plan = BuildFullSimulationVisualSpawnPlan();
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	TestEqual(TEXT("full-sim visual spawned ant count"), Result.Ants.Num(), 1);
+	TestEqual(TEXT("full-sim visual spawned food count"), Result.Foods.Num(), 3);
+
+	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 3)
+	{
+		return false;
+	}
+
+	Result.Ants[0]->SetFullSimulationTurnJitterRadians(0.0f);
+	FrameVisualFullSimulationInViewport(Plan);
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersAdvanceVisibleFullSimulationCommand(this, Result.Ants[0], Result.Foods));
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualPickupDemo.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualPickupDemo.spec.cpp
@@ -1,5 +1,3 @@
-#include "Actors/Ant.h"
-#include "Actors/Food.h"
 #include "Editor.h"
 #include "FileHelpers.h"
 #include "HAL/PlatformTime.h"
@@ -71,23 +69,22 @@ public:
 		}
 
 		const FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
-		const GatherersWorldAssertions::FObservedWorldState WorldState = GatherersWorldAssertions::Observe(World);
-		AFood* AttachedFood = WorldState.GetFirstAttachedFood();
-		if (AttachedFood != nullptr)
+		const GatherersWorldAssertions::FObservedMassVisualState VisualState = GatherersWorldAssertions::ObserveMassVisuals(World);
+		if (VisualState.HasCarriedFoodVisual(20.0f))
 		{
-			bSawAttachedFood = true;
+			bSawCarriedFoodVisual = true;
 		}
 
-		if (WorldState.HasSingleAntAndTwoFoods() && bSawAttachedFood && AttachedFood == nullptr)
+		if (VisualState.HasSingleAntAndTwoFoods() && bSawCarriedFoodVisual && !VisualState.HasCarriedFoodVisual(20.0f))
 		{
-			GatherersWorldAssertions::AssertFirstDropState(*Test, WorldState, Plan, TEXT("visual"));
+			GatherersWorldAssertions::AssertMassFirstDropState(*Test, VisualState, Plan, TEXT("visual"));
 			return true;
 		}
 
 		const double NowSeconds = FPlatformTime::Seconds();
 		if (NowSeconds - StartTimeSeconds >= VisualTimeoutSeconds)
 		{
-			GatherersWorldAssertions::AssertFirstDropState(*Test, WorldState, Plan, TEXT("visual"));
+			GatherersWorldAssertions::AssertMassFirstDropState(*Test, VisualState, Plan, TEXT("visual"));
 			return true;
 		}
 
@@ -105,7 +102,7 @@ private:
 	FAutomationTestBase* Test;
 	double StartTimeSeconds;
 	double LastStepTimeSeconds;
-	bool bSawAttachedFood = false;
+	bool bSawCarriedFoodVisual = false;
 };
 }
 
@@ -141,12 +138,15 @@ bool FGatherersVisualPickupAutomationTest::RunTest(const FString& Parameters)
 
 	MassSubsystem->ResetSimulation();
 
-	const FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+	FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+	Plan.bSpawnActorVisuals = false;
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
-	TestEqual(TEXT("visual spawned ant count"), Result.Ants.Num(), 1);
-	TestEqual(TEXT("visual spawned food count"), Result.Foods.Num(), 2);
+	TestEqual(TEXT("visual spawned ant actor count"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("visual spawned food actor count"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("visual managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("visual managed food count"), MassSubsystem->GetManagedFoodCount(), 2);
 
-	if (Result.Ants.Num() != 1 || Result.Foods.Num() != 2)
+	if (MassSubsystem->GetManagedAntCount() != 1 || MassSubsystem->GetManagedFoodCount() != 2)
 	{
 		return false;
 	}

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualPickupDemo.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/VisualPickupDemo.spec.cpp
@@ -6,6 +6,7 @@
 #include "LevelEditorViewport.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/PackageName.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 #include "TestLogic/GatherersWorldAssertions.h"
@@ -62,6 +63,13 @@ public:
 			return true;
 		}
 
+		UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+		Test->TestNotNull(TEXT("visual editor world should expose the gatherers Mass subsystem"), MassSubsystem);
+		if (MassSubsystem == nullptr)
+		{
+			return true;
+		}
+
 		const FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
 		const GatherersWorldAssertions::FObservedWorldState WorldState = GatherersWorldAssertions::Observe(World);
 		AFood* AttachedFood = WorldState.GetFirstAttachedFood();
@@ -88,11 +96,7 @@ public:
 			return false;
 		}
 
-		if (AAnt* Ant = WorldState.GetSingleAnt())
-		{
-			Ant->Tick(VisualStepSeconds);
-		}
-
+		MassSubsystem->Tick(VisualStepSeconds);
 		LastStepTimeSeconds = NowSeconds;
 		return false;
 	}
@@ -127,6 +131,15 @@ bool FGatherersVisualPickupAutomationTest::RunTest(const FString& Parameters)
 	{
 		return false;
 	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("editor world should expose the gatherers Mass subsystem"), MassSubsystem);
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
 
 	const FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
 	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/WorldSpawner.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/WorldSpawner.spec.cpp
@@ -3,8 +3,10 @@
 #include "Editor.h"
 #include "EngineUtils.h"
 #include "Misc/AutomationTest.h"
+#include "Simulation/GatherersMassSubsystem.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
+#include "TestLogic/GatherersWorldAssertions.h"
 
 namespace
 {
@@ -26,6 +28,11 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	"default.unreal_gatherers.Spawning.WorldSpawnerCreatesAntAndTwoFoodActors",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersMassWorldSpawnerAutomationTest,
+	"default.unreal_gatherers.Spawning.MassDefaultSpawnerSkipsAntAndFoodActors",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
 bool FGatherersWorldSpawnerAutomationTest::RunTest(const FString& Parameters)
 {
 	constexpr float PositionTolerance = KINDA_SMALL_NUMBER;
@@ -37,7 +44,8 @@ bool FGatherersWorldSpawnerAutomationTest::RunTest(const FString& Parameters)
 		return false;
 	}
 
-	const FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+	FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+	Plan.bSpawnActorVisuals = true;
 	AAnt* ExistingAnt = World->SpawnActor<AAnt>(AAnt::StaticClass(), FTransform(FVector(-100.0f, 0.0f, 50.0f)));
 	AFood* ExistingFood = World->SpawnActor<AFood>(AFood::StaticClass(), FTransform(FVector(-200.0f, 0.0f, 50.0f)));
 	TestNotNull(TEXT("preexisting ant should spawn"), ExistingAnt);
@@ -99,5 +107,46 @@ bool FGatherersWorldSpawnerAutomationTest::RunTest(const FString& Parameters)
 		}
 	}
 
+	return true;
+}
+
+bool FGatherersMassWorldSpawnerAutomationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	TestNotNull(TEXT("editor world should exist"), World);
+
+	if (World == nullptr)
+	{
+		return false;
+	}
+
+	UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+	TestNotNull(TEXT("gatherers Mass subsystem should exist"), MassSubsystem);
+
+	if (MassSubsystem == nullptr)
+	{
+		return false;
+	}
+
+	MassSubsystem->ResetSimulation();
+	const FGatherersSpawnPlan Plan = BuildInitialGatherersSpawnPlan();
+	const TArray<AAnt*> AntsBeforeSpawn = CollectActors<AAnt>(World);
+	const TArray<AFood*> FoodsBeforeSpawn = CollectActors<AFood>(World);
+	const FGatherersSpawnResult Result = SpawnGatherersActors(*World, Plan);
+	MassSubsystem->Tick(0.1f);
+	const TArray<AAnt*> AntsInWorld = CollectActors<AAnt>(World);
+	const TArray<AFood*> FoodsInWorld = CollectActors<AFood>(World);
+	const GatherersWorldAssertions::FObservedMassVisualState VisualState = GatherersWorldAssertions::ObserveMassVisuals(World);
+
+	TestEqual(TEXT("default Mass-backed spawn plan does not return ant actors"), Result.Ants.Num(), 0);
+	TestEqual(TEXT("default Mass-backed spawn plan does not return food actors"), Result.Foods.Num(), 0);
+	TestEqual(TEXT("default Mass-backed spawn plan does not add ant actors to the world"), AntsInWorld.Num(), AntsBeforeSpawn.Num());
+	TestEqual(TEXT("default Mass-backed spawn plan does not add food actors to the world"), FoodsInWorld.Num(), FoodsBeforeSpawn.Num());
+	TestEqual(TEXT("default Mass-backed spawn plan still manages one ant entity"), MassSubsystem->GetManagedAntCount(), 1);
+	TestEqual(TEXT("default Mass-backed spawn plan still manages two food entities"), MassSubsystem->GetManagedFoodCount(), 2);
+	TestEqual(TEXT("default Mass-backed spawn plan still renders one ant instance"), VisualState.AntVisualPositions.Num(), 1);
+	TestEqual(TEXT("default Mass-backed spawn plan still renders two food instances"), VisualState.FoodVisualPositions.Num(), 2);
+
+	MassSubsystem->ResetSimulation();
 	return true;
 }

--- a/unreal_gatherers/Source/unreal_gatherersTests/unreal_gatherersTests.Build.cs
+++ b/unreal_gatherers/Source/unreal_gatherersTests/unreal_gatherersTests.Build.cs
@@ -11,6 +11,10 @@ public class unreal_gatherersTests : ModuleRules
 			"Core",
 			"CoreUObject",
 			"Engine",
+			"MassEntity",
+			"MassCommon",
+			"MassActors",
+			"MassSimulation",
 			"UnrealEd",
 			"unreal_gatherers",
 		});

--- a/unreal_gatherers/Source/unreal_gatherersTests/unreal_gatherersTests.Build.cs
+++ b/unreal_gatherers/Source/unreal_gatherersTests/unreal_gatherersTests.Build.cs
@@ -15,6 +15,7 @@ public class unreal_gatherersTests : ModuleRules
 			"MassCommon",
 			"MassActors",
 			"MassSimulation",
+			"MassRepresentation",
 			"UnrealEd",
 			"unreal_gatherers",
 		});

--- a/unreal_gatherers/unreal_gatherers.uproject
+++ b/unreal_gatherers/unreal_gatherers.uproject
@@ -30,6 +30,10 @@
 		{
 			"Name": "GeoReferencing",
 			"Enabled": true
+		},
+		{
+			"Name": "MassGameplay",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- switch the Unreal full-simulation path from actor-owned behavior to Mass-backed ant and food state, including heading movement, pickup/drop, cooldown, startup spawning, and repeated gathering coverage
- move the runtime visual path to instanced meshes owned by the gatherers Mass subsystem so Play mode no longer depends on spawned `AAnt`/`AFood` actors
- retarget the Unreal automation and manual visual tests to assert against Mass entities and Mass visuals, including a live-frame stability regression for the visual sync path

## Test plan
- [x] `./scripts/test_unreal.sh`
- [x] `./scripts/test_unreal.sh --no-build --test supplemental.unreal_gatherers`
- [x] `./scripts/test_unreal.sh --no-build --test manual.unreal_gatherers.Visual`
- [x] Manual Play-mode check in the Unreal editor


Made with [Cursor](https://cursor.com)