### PR TITLE
Add measured max-correct Unreal time mode

### DIFF
--- a/scripts/measure_unreal_max_speed.sh
+++ b/scripts/measure_unreal_max_speed.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+exec "${repo_root}/scripts/test_unreal.sh" \
+  "$@" \
+  --test supplemental.unreal_gatherers.TimeControl.MaxCorrectSpeedSweepReportsHighestPassingDilation

--- a/unreal_gatherers/README.md
+++ b/unreal_gatherers/README.md
@@ -62,7 +62,29 @@ Useful targeted reruns:
 -ExecCmds="Automation RunTest default.unreal_gatherers.FullSimulationActorFixture;Quit"
 -ExecCmds="Automation RunTest default.unreal_gatherers.Mass;Quit"
 -ExecCmds="Automation RunTest supplemental.unreal_gatherers.Spawning.StartupSmokeSpawnsRustLikeFullSimulationCounts;Quit"
+-ExecCmds="Automation RunTest supplemental.unreal_gatherers.TimeControl.MaxCorrectSpeedSweepReportsHighestPassingDilation;Quit"
 -ExecCmds="Automation RunTest supplemental.unreal_gatherers.Mass.MassVisualsStayStableAcrossLiveFrames;Quit"
+```
+
+## Measure max correct speed
+
+Run the supplemental machine-local sweep with:
+
+```sh
+./scripts/measure_unreal_max_speed.sh
+```
+
+This targets `supplemental.unreal_gatherers.TimeControl.MaxCorrectSpeedSweepReportsHighestPassingDilation`.
+The automation log prints each tested dilation and a final summary line such as:
+
+```text
+time-dilation sweep highest passing dilation: 27x
+```
+
+If you want to skip rebuilding the editor target for a rerun:
+
+```sh
+./scripts/measure_unreal_max_speed.sh --no-build
 ```
 
 ## Run the visual gather demos

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Input/GatherersPlayerController.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Input/GatherersPlayerController.cpp
@@ -1,0 +1,24 @@
+#include "Input/GatherersPlayerController.h"
+
+#include "UI/GatherersTimeControlWidget.h"
+#include "unreal_gatherers/unreal_gatherersGameModeBase.h"
+
+void AGatherersPlayerController::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (TimeControlWidget == nullptr && IsLocalController())
+	{
+		TimeControlWidget = CreateWidget<UGatherersTimeControlWidget>(this, UGatherersTimeControlWidget::StaticClass());
+		if (TimeControlWidget != nullptr)
+		{
+			if (Aunreal_gatherersGameModeBase* GatherersGameMode = GetWorld() ? GetWorld()->GetAuthGameMode<Aunreal_gatherersGameModeBase>() : nullptr)
+			{
+				TimeControlWidget->InitializeForGameMode(*GatherersGameMode);
+				GatherersGameMode->SetTimeControlWidget(TimeControlWidget);
+			}
+
+			TimeControlWidget->AddToViewport();
+		}
+	}
+}

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -143,10 +143,14 @@ bool UGatherersMassSubsystem::EnsureVisualComponents()
 
 	if (!VisualizerActor)
 	{
-		FActorSpawnParameters SpawnParameters;
-		SpawnParameters.Name = VisualizerActorName;
-		SpawnParameters.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-		VisualizerActor = World->SpawnActor<AActor>(AActor::StaticClass(), FTransform::Identity, SpawnParameters);
+		VisualizerActor = FindObject<AActor>(World->PersistentLevel, VisualizerActorName);
+		if (!VisualizerActor)
+		{
+			FActorSpawnParameters SpawnParameters;
+			SpawnParameters.Name = VisualizerActorName;
+			SpawnParameters.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+			VisualizerActor = World->SpawnActor<AActor>(AActor::StaticClass(), FTransform::Identity, SpawnParameters);
+		}
 	}
 
 	if (VisualizerActor == nullptr)
@@ -516,6 +520,8 @@ void UGatherersMassSubsystem::Tick(float DeltaTime)
 		return;
 	}
 
+	AccumulatedSimulationSeconds += DeltaTime;
+
 	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
 	for (const FMassEntityHandle Entity : ManagedAntEntities)
 	{
@@ -706,6 +712,13 @@ void UGatherersMassSubsystem::ResetSimulation()
 	{
 		FoodRepresentationComponent->ClearInstances();
 	}
+	if (VisualizerActor != nullptr)
+	{
+		VisualizerActor->Destroy();
+		VisualizerActor = nullptr;
+		AntVisualComponent = nullptr;
+		FoodRepresentationComponent = nullptr;
+	}
 
 	for (const FMassEntityHandle Entity : ManagedAntEntities)
 	{
@@ -726,6 +739,7 @@ void UGatherersMassSubsystem::ResetSimulation()
 	ManagedAntEntities.Reset();
 	ManagedFoodEntities.Reset();
 	SimulationBounds = FBox(EForceInit::ForceInit);
+	AccumulatedSimulationSeconds = 0.0f;
 }
 
 int32 UGatherersMassSubsystem::GetManagedAntCount() const
@@ -741,6 +755,11 @@ int32 UGatherersMassSubsystem::GetManagedFoodCount() const
 bool UGatherersMassSubsystem::HasManagedSimulation() const
 {
 	return ManagedAntEntities.Num() > 0 || ManagedFoodEntities.Num() > 0;
+}
+
+float UGatherersMassSubsystem::GetAccumulatedSimulationSeconds() const
+{
+	return AccumulatedSimulationSeconds;
 }
 
 const FBox& UGatherersMassSubsystem::GetSimulationBounds() const

--- a/unreal_gatherers/Source/unreal_gatherers/Private/UI/GatherersTimeControlWidget.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/UI/GatherersTimeControlWidget.cpp
@@ -1,0 +1,113 @@
+#include "UI/GatherersTimeControlWidget.h"
+
+#include "Components/Button.h"
+#include "Components/CanvasPanel.h"
+#include "Components/CanvasPanelSlot.h"
+#include "Components/TextBlock.h"
+#include "Blueprint/WidgetTree.h"
+
+namespace
+{
+FString BuildModeLabel(EGatherersTimeControlMode Mode)
+{
+	switch (Mode)
+	{
+	case EGatherersTimeControlMode::MaxCorrect:
+		return TEXT("Max Correct (27x)");
+
+	case EGatherersTimeControlMode::Fast:
+		return TEXT("Fast");
+
+	case EGatherersTimeControlMode::Normal:
+	default:
+		return TEXT("Normal");
+	}
+}
+}
+
+void UGatherersTimeControlWidget::InitializeForGameMode(Aunreal_gatherersGameModeBase& InGameMode)
+{
+	GameMode = &InGameMode;
+	RefreshLabel();
+}
+
+FString UGatherersTimeControlWidget::GetCurrentModeLabel() const
+{
+	return ModeLabelText ? ModeLabelText->GetText().ToString() : FString();
+}
+
+void UGatherersTimeControlWidget::TriggerToggleFromUI()
+{
+	if (Aunreal_gatherersGameModeBase* GatherersGameMode = GameMode.Get())
+	{
+		GatherersGameMode->ToggleTimeControlMode();
+	}
+
+	RefreshLabel();
+}
+
+void UGatherersTimeControlWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	BuildWidgetTreeIfNeeded();
+	if (ToggleButton != nullptr && !ToggleButton->OnClicked.IsAlreadyBound(this, &UGatherersTimeControlWidget::TriggerToggleFromUI))
+	{
+		ToggleButton->OnClicked.AddDynamic(this, &UGatherersTimeControlWidget::TriggerToggleFromUI);
+	}
+
+	RefreshLabel();
+}
+
+void UGatherersTimeControlWidget::BuildWidgetTreeIfNeeded()
+{
+	if (WidgetTree == nullptr)
+	{
+		return;
+	}
+
+	if (ToggleButton != nullptr && ModeLabelText != nullptr)
+	{
+		return;
+	}
+
+	UCanvasPanel* RootPanel = Cast<UCanvasPanel>(WidgetTree->RootWidget);
+	if (RootPanel == nullptr)
+	{
+		RootPanel = WidgetTree->ConstructWidget<UCanvasPanel>(UCanvasPanel::StaticClass(), TEXT("RootPanel"));
+		WidgetTree->RootWidget = RootPanel;
+	}
+
+	if (ToggleButton == nullptr)
+	{
+		ToggleButton = WidgetTree->ConstructWidget<UButton>(UButton::StaticClass(), TEXT("TimeToggleButton"));
+		UCanvasPanelSlot* ButtonSlot = RootPanel->AddChildToCanvas(ToggleButton);
+		if (ButtonSlot != nullptr)
+		{
+			ButtonSlot->SetAutoSize(true);
+			ButtonSlot->SetPosition(FVector2D(16.0f, 16.0f));
+		}
+	}
+
+	if (ModeLabelText == nullptr)
+	{
+		ModeLabelText = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass(), TEXT("TimeModeLabel"));
+		if (ToggleButton != nullptr)
+		{
+			ToggleButton->AddChild(ModeLabelText);
+		}
+	}
+}
+
+void UGatherersTimeControlWidget::RefreshLabel()
+{
+	if (ModeLabelText == nullptr)
+	{
+		return;
+	}
+
+	const EGatherersTimeControlMode Mode = GameMode.IsValid()
+		? GameMode->GetTimeControlMode()
+		: EGatherersTimeControlMode::Normal;
+	ModeLabelText->SetText(FText::FromString(BuildModeLabel(Mode)));
+}

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Input/GatherersPlayerController.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Input/GatherersPlayerController.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "GameFramework/PlayerController.h"
+#include "GatherersPlayerController.generated.h"
+
+class UGatherersTimeControlWidget;
+
+UCLASS()
+class UNREAL_GATHERERS_API AGatherersPlayerController : public APlayerController
+{
+	GENERATED_BODY()
+
+public:
+	virtual void BeginPlay() override;
+
+private:
+	UPROPERTY(Transient)
+	TObjectPtr<UGatherersTimeControlWidget> TimeControlWidget = nullptr;
+};

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
@@ -69,6 +69,7 @@ public:
 	int32 GetManagedAntCount() const;
 	int32 GetManagedFoodCount() const;
 	bool HasManagedSimulation() const;
+	float GetAccumulatedSimulationSeconds() const;
 	const FBox& GetSimulationBounds() const;
 	const UInstancedStaticMeshComponent* GetAntVisualComponent() const;
 	const UInstancedStaticMeshComponent* GetFoodRepresentationComponent() const;
@@ -83,6 +84,7 @@ public:
 	TArray<FMassEntityHandle> ManagedAntEntities;
 	TArray<FMassEntityHandle> ManagedFoodEntities;
 	FBox SimulationBounds = FBox(EForceInit::ForceInit);
+	float AccumulatedSimulationSeconds = 0.0f;
 
 private:
 	UPROPERTY(Transient)

--- a/unreal_gatherers/Source/unreal_gatherers/Public/UI/GatherersTimeControlWidget.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/UI/GatherersTimeControlWidget.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Blueprint/UserWidget.h"
+#include "unreal_gatherers/unreal_gatherersGameModeBase.h"
+#include "GatherersTimeControlWidget.generated.h"
+
+class UButton;
+class UTextBlock;
+
+UCLASS()
+class UNREAL_GATHERERS_API UGatherersTimeControlWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	void InitializeForGameMode(Aunreal_gatherersGameModeBase& InGameMode);
+	FString GetCurrentModeLabel() const;
+
+	UFUNCTION()
+	void TriggerToggleFromUI();
+
+protected:
+	virtual void NativeConstruct() override;
+
+private:
+	void BuildWidgetTreeIfNeeded();
+	void RefreshLabel();
+
+	TWeakObjectPtr<Aunreal_gatherersGameModeBase> GameMode = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UButton> ToggleButton = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UTextBlock> ModeLabelText = nullptr;
+};

--- a/unreal_gatherers/Source/unreal_gatherers/unreal_gatherers.Build.cs
+++ b/unreal_gatherers/Source/unreal_gatherers/unreal_gatherers.Build.cs
@@ -19,9 +19,14 @@ public class unreal_gatherers : ModuleRules
 			"MassActors",
 			"MassSimulation",
 			"MassRepresentation",
+			"UMG",
 		});
 
-		PrivateDependencyModuleNames.AddRange(new string[] {  });
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"Slate",
+			"SlateCore",
+		});
 
 		// Uncomment if you are using Slate UI
 		// PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });

--- a/unreal_gatherers/Source/unreal_gatherers/unreal_gatherersGameModeBase.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/unreal_gatherersGameModeBase.cpp
@@ -5,13 +5,21 @@
 
 #include "HAL/PlatformTime.h"
 #include "GameFramework/WorldSettings.h"
+#include "Input/GatherersPlayerController.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
+#include "UI/GatherersTimeControlWidget.h"
 
 namespace
 {
 const FBox DefaultGamePlayAreaBounds(FVector(-640.0f, -360.0f, -100.0f), FVector(640.0f, 360.0f, 100.0f));
 constexpr float GatherersFastTimeDilation = 4.0f;
+constexpr float GatherersMaxCorrectTimeDilation = 27.0f;
+}
+
+Aunreal_gatherersGameModeBase::Aunreal_gatherersGameModeBase()
+{
+	PlayerControllerClass = AGatherersPlayerController::StaticClass();
 }
 
 void Aunreal_gatherersGameModeBase::StartPlay()
@@ -37,6 +45,13 @@ void Aunreal_gatherersGameModeBase::ApplyTimeControlMode(EGatherersTimeControlMo
 	{
 		CurrentTimeControlMode = NewMode;
 	}
+
+	RefreshTimeControlWidget();
+}
+
+void Aunreal_gatherersGameModeBase::ToggleTimeControlMode()
+{
+	ApplyTimeControlMode(GetNextTimeControlMode(CurrentTimeControlMode));
 }
 
 void Aunreal_gatherersGameModeBase::ApplyTimeControlModeToWorld(UWorld& World, EGatherersTimeControlMode NewMode)
@@ -49,6 +64,23 @@ void Aunreal_gatherersGameModeBase::ApplyTimeControlModeToWorld(UWorld& World, E
 	if (Aunreal_gatherersGameModeBase* GatherersGameMode = World.GetAuthGameMode<Aunreal_gatherersGameModeBase>())
 	{
 		GatherersGameMode->CurrentTimeControlMode = NewMode;
+		GatherersGameMode->RefreshTimeControlWidget();
+	}
+}
+
+EGatherersTimeControlMode Aunreal_gatherersGameModeBase::GetNextTimeControlMode(EGatherersTimeControlMode Mode)
+{
+	switch (Mode)
+	{
+	case EGatherersTimeControlMode::Normal:
+		return EGatherersTimeControlMode::Fast;
+
+	case EGatherersTimeControlMode::Fast:
+		return EGatherersTimeControlMode::MaxCorrect;
+
+	case EGatherersTimeControlMode::MaxCorrect:
+	default:
+		return EGatherersTimeControlMode::Normal;
 	}
 }
 
@@ -62,16 +94,38 @@ EGatherersTimeControlMode Aunreal_gatherersGameModeBase::GetStartupTimeControlMo
 	return StartupTimeControlMode;
 }
 
+UGatherersTimeControlWidget* Aunreal_gatherersGameModeBase::GetTimeControlWidget() const
+{
+	return TimeControlWidget;
+}
+
+void Aunreal_gatherersGameModeBase::SetTimeControlWidget(UGatherersTimeControlWidget* Widget)
+{
+	TimeControlWidget = Widget;
+	RefreshTimeControlWidget();
+}
+
 float Aunreal_gatherersGameModeBase::GetTimeDilationForMode(EGatherersTimeControlMode Mode)
 {
 	switch (Mode)
 	{
+	case EGatherersTimeControlMode::MaxCorrect:
+		return GatherersMaxCorrectTimeDilation;
+
 	case EGatherersTimeControlMode::Fast:
 		return GatherersFastTimeDilation;
 
 	case EGatherersTimeControlMode::Normal:
 	default:
 		return 1.0f;
+	}
+}
+
+void Aunreal_gatherersGameModeBase::RefreshTimeControlWidget()
+{
+	if (TimeControlWidget != nullptr)
+	{
+		TimeControlWidget->InitializeForGameMode(*this);
 	}
 }
 

--- a/unreal_gatherers/Source/unreal_gatherers/unreal_gatherersGameModeBase.h
+++ b/unreal_gatherers/Source/unreal_gatherers/unreal_gatherersGameModeBase.h
@@ -6,11 +6,14 @@
 #include "GameFramework/GameModeBase.h"
 #include "unreal_gatherersGameModeBase.generated.h"
 
+class UGatherersTimeControlWidget;
+
 UENUM()
 enum class EGatherersTimeControlMode : uint8
 {
 	Normal,
 	Fast,
+	MaxCorrect,
 };
 
 UCLASS()
@@ -19,18 +22,28 @@ class UNREAL_GATHERERS_API Aunreal_gatherersGameModeBase : public AGameModeBase
 	GENERATED_BODY()
 
 public:
+	Aunreal_gatherersGameModeBase();
 	virtual void StartPlay() override;
 
 	void ApplyTimeControlMode(EGatherersTimeControlMode NewMode);
+	void ToggleTimeControlMode();
 	static void ApplyTimeControlModeToWorld(UWorld& World, EGatherersTimeControlMode NewMode);
+	static EGatherersTimeControlMode GetNextTimeControlMode(EGatherersTimeControlMode Mode);
 	EGatherersTimeControlMode GetTimeControlMode() const;
 	EGatherersTimeControlMode GetStartupTimeControlMode() const;
+	UGatherersTimeControlWidget* GetTimeControlWidget() const;
+	void SetTimeControlWidget(UGatherersTimeControlWidget* Widget);
 	static float GetTimeDilationForMode(EGatherersTimeControlMode Mode);
 
 private:
+	void RefreshTimeControlWidget();
+
 	UPROPERTY(EditDefaultsOnly, Category = "Simulation")
 	EGatherersTimeControlMode StartupTimeControlMode = EGatherersTimeControlMode::Normal;
 
 	UPROPERTY(Transient)
 	EGatherersTimeControlMode CurrentTimeControlMode = EGatherersTimeControlMode::Normal;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UGatherersTimeControlWidget> TimeControlWidget = nullptr;
 };

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/TimeControl.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/TimeControl.spec.cpp
@@ -11,6 +11,7 @@
 #include "Tests/AutomationEditorCommon.h"
 #include "TestLogic/GatherersWorldAssertions.h"
 #include "Templates/SharedPointer.h"
+#include "UI/GatherersTimeControlWidget.h"
 #include "unreal_gatherers/unreal_gatherersGameModeBase.h"
 
 namespace
@@ -22,9 +23,11 @@ struct FTimeControlObservationResults
 {
 	float NormalDistance = 0.0f;
 	float FastDistance = 0.0f;
+	float NormalSimulatedSeconds = 0.0f;
+	float FastSimulatedSeconds = 0.0f;
 };
 
-FGatherersSpawnPlan BuildTimeControlFixturePlan()
+FGatherersSpawnPlan BuildSingleAntTimeControlFixturePlan()
 {
 	FGatherersSpawnPlan Plan;
 	Plan.bUseFullSimulationMode = true;
@@ -36,12 +39,39 @@ FGatherersSpawnPlan BuildTimeControlFixturePlan()
 	return Plan;
 }
 
+FGatherersSpawnPlan BuildDenseTimeControlFixturePlan()
+{
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.FullSimulationTurnJitterRadians = 0.0f;
+	Plan.FullSimulationMovementSpeed = 100.0f;
+
+	for (int32 AntIndex = 0; AntIndex < 8; ++AntIndex)
+	{
+		Plan.AntSpawns.Add(FTransform(FVector(0.0f, -175.0f + (AntIndex * 50.0f), 0.0f)));
+		Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+	}
+
+	for (int32 FoodIndex = 0; FoodIndex < 16; ++FoodIndex)
+	{
+		Plan.FoodSpawns.Add(FTransform(FVector(-400.0f + (FoodIndex * 40.0f), 300.0f, 0.0f)));
+	}
+
+	return Plan;
+}
+
 class FGatherersPrepareTimeControlFixtureCommand : public IAutomationLatentCommand
 {
 public:
-	FGatherersPrepareTimeControlFixtureCommand(FAutomationTestBase* InTest, EGatherersTimeControlMode InMode)
+	FGatherersPrepareTimeControlFixtureCommand(
+		FAutomationTestBase* InTest,
+		EGatherersTimeControlMode InMode,
+		FGatherersSpawnPlan InPlan)
 		: Test(InTest),
-		  Mode(InMode)
+		  Mode(InMode),
+		  Plan(MoveTemp(InPlan))
 	{
 	}
 
@@ -63,15 +93,18 @@ public:
 
 		Aunreal_gatherersGameModeBase::ApplyTimeControlModeToWorld(*World, Mode);
 		MassSubsystem->ResetSimulation();
-		const FGatherersSpawnPlan Plan = BuildTimeControlFixturePlan();
 		SpawnGatherersActors(*World, Plan);
-		Test->TestEqual(TEXT("time-control fixture managed ant count"), MassSubsystem->GetManagedAntCount(), 1);
+		Test->TestEqual(
+			TEXT("time-control fixture managed ant count should match the requested plan"),
+			MassSubsystem->GetManagedAntCount(),
+			Plan.AntSpawns.Num());
 		return true;
 	}
 
 private:
 	FAutomationTestBase* Test;
 	EGatherersTimeControlMode Mode;
+	FGatherersSpawnPlan Plan;
 };
 
 class FGatherersObserveTimeControlDistanceCommand : public IAutomationLatentCommand
@@ -123,10 +156,12 @@ public:
 		if (bObserveFastDistance)
 		{
 			Results->FastDistance = AntFragment.Position.X;
+			Results->FastSimulatedSeconds = MassSubsystem->GetAccumulatedSimulationSeconds();
 		}
 		else
 		{
 			Results->NormalDistance = AntFragment.Position.X;
+			Results->NormalSimulatedSeconds = MassSubsystem->GetAccumulatedSimulationSeconds();
 		}
 		return true;
 	}
@@ -154,14 +189,172 @@ public:
 	{
 		Test->TestTrue(TEXT("normal mode should advance the ant at least a little"), Results->NormalDistance > 1.0f);
 		Test->TestTrue(
+			TEXT("normal mode should accumulate simulated seconds while the fixture runs"),
+			Results->NormalSimulatedSeconds >= 0.20f);
+		Test->TestTrue(
 			TEXT("fast world time should advance the ant farther than normal over the same wall-clock window"),
 			Results->FastDistance > (Results->NormalDistance + 10.0f));
+		Test->TestTrue(
+			TEXT("fast world time should accumulate about four times the simulated seconds seen in normal mode"),
+			Results->FastSimulatedSeconds >= (Results->NormalSimulatedSeconds * 3.5f));
 		return true;
 	}
 
 private:
 	FAutomationTestBase* Test;
 	TSharedRef<FTimeControlObservationResults> Results;
+};
+
+class FGatherersAssertDenseFastTimeFixtureCommand : public IAutomationLatentCommand
+{
+public:
+	FGatherersAssertDenseFastTimeFixtureCommand(
+		FAutomationTestBase* InTest,
+		double InObservationWindowSeconds)
+		: Test(InTest),
+		  ObservationWindowSeconds(InObservationWindowSeconds)
+	{
+	}
+
+	bool Update() override
+	{
+		if (!StartTimeSeconds.IsSet())
+		{
+			StartTimeSeconds = FPlatformTime::Seconds();
+		}
+
+		if (FPlatformTime::Seconds() - StartTimeSeconds.GetValue() < ObservationWindowSeconds)
+		{
+			return false;
+		}
+
+		UWorld* World = GEditor ? GEditor->PlayWorld : nullptr;
+		Test->TestNotNull(TEXT("dense time-control play world should exist"), World);
+		if (World == nullptr)
+		{
+			return true;
+		}
+
+		UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+		UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+		Test->TestNotNull(TEXT("dense time-control Mass subsystem should exist"), MassSubsystem);
+		Test->TestNotNull(TEXT("dense time-control Mass entity subsystem should exist"), MassEntitySubsystem);
+		if (MassSubsystem == nullptr || MassEntitySubsystem == nullptr)
+		{
+			return true;
+		}
+
+		Test->TestEqual(TEXT("dense fast fixture should preserve ant count"), MassSubsystem->GetManagedAntCount(), 8);
+		Test->TestEqual(TEXT("dense fast fixture should preserve food count"), MassSubsystem->GetManagedFoodCount(), 16);
+		Test->TestTrue(
+			TEXT("dense fast fixture should accumulate roughly the expected simulated seconds"),
+			MassSubsystem->GetAccumulatedSimulationSeconds() >= 0.70f);
+
+		FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+		for (const FMassEntityHandle AntEntity : MassSubsystem->ManagedAntEntities)
+		{
+			if (!EntityManager.IsEntityValid(AntEntity))
+			{
+				continue;
+			}
+
+			FMassEntityView AntView(EntityManager, AntEntity);
+			const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+			Test->TestTrue(TEXT("dense fast fixture ant X position should remain finite"), FMath::IsFinite(AntFragment.Position.X));
+			Test->TestTrue(TEXT("dense fast fixture ant Y position should remain finite"), FMath::IsFinite(AntFragment.Position.Y));
+		}
+
+		return true;
+	}
+
+private:
+	FAutomationTestBase* Test;
+	double ObservationWindowSeconds;
+	TOptional<double> StartTimeSeconds;
+};
+
+class FGatherersAssertTimeControlWidgetToggleCommand : public IAutomationLatentCommand
+{
+public:
+	explicit FGatherersAssertTimeControlWidgetToggleCommand(FAutomationTestBase* InTest)
+		: Test(InTest)
+	{
+	}
+
+	bool Update() override
+	{
+		UWorld* World = GEditor ? GEditor->PlayWorld : nullptr;
+		Test->TestNotNull(TEXT("time-control widget play world should exist"), World);
+		if (World == nullptr)
+		{
+			return true;
+		}
+
+		Aunreal_gatherersGameModeBase* GameMode = World->GetAuthGameMode<Aunreal_gatherersGameModeBase>();
+		Test->TestNotNull(TEXT("time-control widget game mode should exist"), GameMode);
+		if (GameMode == nullptr)
+		{
+			return true;
+		}
+
+		UGatherersTimeControlWidget* Widget = GameMode->GetTimeControlWidget();
+		Test->TestNotNull(TEXT("time-control widget should be created for the playable world"), Widget);
+		if (Widget == nullptr)
+		{
+			return true;
+		}
+
+		Test->TestEqual(
+			TEXT("time-control widget should show the current startup mode"),
+			Widget->GetCurrentModeLabel(),
+			FString(TEXT("Normal")));
+		Test->TestEqual(
+			TEXT("startup mode should begin at normal"),
+			GameMode->GetTimeControlMode(),
+			EGatherersTimeControlMode::Normal);
+
+		Widget->TriggerToggleFromUI();
+
+		Test->TestEqual(
+			TEXT("UI toggle should switch the world time mode to fast"),
+			GameMode->GetTimeControlMode(),
+			EGatherersTimeControlMode::Fast);
+		Test->TestEqual(
+			TEXT("time-control widget should update its label after toggling"),
+			Widget->GetCurrentModeLabel(),
+			FString(TEXT("Fast")));
+
+		Test->TestTrue(
+			TEXT("max-correct mode should use a higher dilation than the existing fast mode"),
+			Aunreal_gatherersGameModeBase::GetTimeDilationForMode(EGatherersTimeControlMode::MaxCorrect)
+				> Aunreal_gatherersGameModeBase::GetTimeDilationForMode(EGatherersTimeControlMode::Fast));
+
+		Widget->TriggerToggleFromUI();
+
+		Test->TestEqual(
+			TEXT("a second UI toggle should switch the world time mode to max-correct"),
+			GameMode->GetTimeControlMode(),
+			EGatherersTimeControlMode::MaxCorrect);
+		Test->TestEqual(
+			TEXT("time-control widget should show the measured max-correct dilation"),
+			Widget->GetCurrentModeLabel(),
+			FString(TEXT("Max Correct (27x)")));
+
+		Widget->TriggerToggleFromUI();
+
+		Test->TestEqual(
+			TEXT("a third UI toggle should cycle the world time mode back to normal"),
+			GameMode->GetTimeControlMode(),
+			EGatherersTimeControlMode::Normal);
+		Test->TestEqual(
+			TEXT("time-control widget should return to the normal label after the full cycle"),
+			Widget->GetCurrentModeLabel(),
+			FString(TEXT("Normal")));
+		return true;
+	}
+
+private:
+	FAutomationTestBase* Test;
 };
 
 DEFINE_LATENT_AUTOMATION_COMMAND_THREE_PARAMETER(
@@ -189,6 +382,16 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	"default.unreal_gatherers.TimeControl.FastWorldTimeAdvancesSimulationFurtherThanNormal",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersTimeControlWidgetAutomationTest,
+	"default.unreal_gatherers.TimeControl.UiButtonTogglesWorldTimeMode",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersDenseFixtureFastWorldTimeAutomationTest,
+	"default.unreal_gatherers.TimeControl.FastWorldTimeKeepsDenseFixtureStable",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
 bool FGatherersWorldTimeControlAutomationTest::RunTest(const FString& Parameters)
 {
 	const bool bOpenedMap = AutomationOpenMap(SimBlankMapPath);
@@ -200,13 +403,53 @@ bool FGatherersWorldTimeControlAutomationTest::RunTest(const FString& Parameters
 
 	const TSharedRef<FTimeControlObservationResults> ObservationResults = MakeShared<FTimeControlObservationResults>();
 
-	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareTimeControlFixtureCommand(this, EGatherersTimeControlMode::Normal));
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareTimeControlFixtureCommand(
+		this,
+		EGatherersTimeControlMode::Normal,
+		BuildSingleAntTimeControlFixturePlan()));
 	ADD_LATENT_AUTOMATION_COMMAND(
 		FGatherersObserveTimeControlDistanceCommand(this, ObservationWindowSeconds, ObservationResults, false));
-	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareTimeControlFixtureCommand(this, EGatherersTimeControlMode::Fast));
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareTimeControlFixtureCommand(
+		this,
+		EGatherersTimeControlMode::Fast,
+		BuildSingleAntTimeControlFixturePlan()));
 	ADD_LATENT_AUTOMATION_COMMAND(
 		FGatherersObserveTimeControlDistanceCommand(this, ObservationWindowSeconds, ObservationResults, true));
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersAssertFastModeAdvancesFurtherCommand(this, ObservationResults));
+	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForTimeControlPIECleanupCommand(this, FPlatformTime::Seconds(), 5.0));
+	return true;
+}
+
+bool FGatherersTimeControlWidgetAutomationTest::RunTest(const FString& Parameters)
+{
+	const bool bOpenedMap = AutomationOpenMap(SimBlankMapPath);
+	TestTrue(TEXT("should open SimBlank map"), bOpenedMap);
+	if (!bOpenedMap)
+	{
+		return false;
+	}
+
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersAssertTimeControlWidgetToggleCommand(this));
+	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForTimeControlPIECleanupCommand(this, FPlatformTime::Seconds(), 5.0));
+	return true;
+}
+
+bool FGatherersDenseFixtureFastWorldTimeAutomationTest::RunTest(const FString& Parameters)
+{
+	const bool bOpenedMap = AutomationOpenMap(SimBlankMapPath);
+	TestTrue(TEXT("should open SimBlank map"), bOpenedMap);
+	if (!bOpenedMap)
+	{
+		return false;
+	}
+
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersPrepareTimeControlFixtureCommand(
+		this,
+		EGatherersTimeControlMode::Fast,
+		BuildDenseTimeControlFixturePlan()));
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersAssertDenseFastTimeFixtureCommand(this, ObservationWindowSeconds));
 	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
 	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForTimeControlPIECleanupCommand(this, FPlatformTime::Seconds(), 5.0));
 	return true;

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/TimeControlSweep.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/TimeControlSweep.spec.cpp
@@ -1,0 +1,315 @@
+#include "Editor.h"
+#include "HAL/PlatformTime.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityView.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Optional.h"
+#include "Simulation/GatherersMassSubsystem.h"
+#include "Simulation/GatherersSpawnPlan.h"
+#include "Simulation/GatherersWorldSpawner.h"
+#include "TestLogic/GatherersWorldAssertions.h"
+#include "Tests/AutomationCommon.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Templates/SharedPointer.h"
+
+namespace
+{
+constexpr TCHAR SimBlankMapPath[] = TEXT("/Game/SimBlank/Levels/SimBlank");
+constexpr double SweepObservationWindowSeconds = 0.25;
+constexpr int32 SweepFixtureAntCount = 8;
+constexpr int32 SweepFixtureFoodCount = 8;
+constexpr int32 MaxSweepDilation = 1024;
+
+struct FTimeDilationSweepCandidateResult
+{
+	int32 Dilation = 1;
+	bool bPassed = false;
+	float AccumulatedSimulationSeconds = 0.0f;
+	int32 CarriedFoodCount = 0;
+	int32 LooseFoodCount = 0;
+};
+
+struct FTimeDilationSweepResults
+{
+	TArray<FTimeDilationSweepCandidateResult> CandidateResults;
+	int32 HighestPassingDilation = 0;
+	bool bReachedMaxTestedDilation = false;
+};
+
+FGatherersSpawnPlan BuildTimeDilationSweepFixturePlan()
+{
+	FGatherersSpawnPlan Plan;
+	Plan.bUseFullSimulationMode = true;
+	Plan.bSpawnActorVisuals = false;
+	Plan.PlayAreaBounds = FBox(FVector(-500.0f, -500.0f, -100.0f), FVector(500.0f, 500.0f, 100.0f));
+	Plan.FullSimulationMovementSpeed = 100.0f;
+	Plan.FullSimulationTurnJitterRadians = 0.0f;
+
+	for (int32 AntIndex = 0; AntIndex < SweepFixtureAntCount; ++AntIndex)
+	{
+		const float RowY = -175.0f + (AntIndex * 50.0f);
+		Plan.AntSpawns.Add(FTransform(FVector::ZeroVector + FVector(0.0f, RowY, 0.0f)));
+		Plan.AntInitialDirections.Add(FVector(1.0f, 0.0f, 0.0f));
+		Plan.FoodSpawns.Add(FTransform(FVector(0.0f, RowY + 14.0f, 0.0f)));
+	}
+
+	return Plan;
+}
+
+FTimeDilationSweepCandidateResult EvaluateSweepCandidate(UGatherersMassSubsystem& MassSubsystem, UMassEntitySubsystem& MassEntitySubsystem, int32 Dilation)
+{
+	FTimeDilationSweepCandidateResult Result;
+	Result.Dilation = Dilation;
+	Result.AccumulatedSimulationSeconds = MassSubsystem.GetAccumulatedSimulationSeconds();
+
+	if (MassSubsystem.GetManagedAntCount() != SweepFixtureAntCount || MassSubsystem.GetManagedFoodCount() != SweepFixtureFoodCount)
+	{
+		return Result;
+	}
+
+	bool bAllAntPositionsFinite = true;
+	FMassEntityManager& EntityManager = MassEntitySubsystem.GetMutableEntityManager();
+	for (const FMassEntityHandle AntEntity : MassSubsystem.ManagedAntEntities)
+	{
+		if (!EntityManager.IsEntityValid(AntEntity))
+		{
+			bAllAntPositionsFinite = false;
+			break;
+		}
+
+		FMassEntityView AntView(EntityManager, AntEntity);
+		const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
+		bAllAntPositionsFinite &= FMath::IsFinite(AntFragment.Position.X);
+		bAllAntPositionsFinite &= FMath::IsFinite(AntFragment.Position.Y);
+		bAllAntPositionsFinite &= FMath::IsFinite(AntFragment.Position.Z);
+		if (AntFragment.CarriedFoodEntity.IsValid())
+		{
+			++Result.CarriedFoodCount;
+		}
+	}
+
+	for (const FMassEntityHandle FoodEntity : MassSubsystem.ManagedFoodEntities)
+	{
+		if (!EntityManager.IsEntityValid(FoodEntity))
+		{
+			bAllAntPositionsFinite = false;
+			break;
+		}
+
+		FMassEntityView FoodView(EntityManager, FoodEntity);
+		const FGatherersMassFoodFragment& FoodFragment = FoodView.GetFragmentData<FGatherersMassFoodFragment>();
+		if (FoodFragment.bIsLoose)
+		{
+			++Result.LooseFoodCount;
+		}
+	}
+
+	const float ExpectedSimulatedSecondsLowerBound = static_cast<float>(SweepObservationWindowSeconds * Dilation * 0.75);
+	Result.bPassed = bAllAntPositionsFinite
+		&& Result.CarriedFoodCount == SweepFixtureFoodCount
+		&& Result.LooseFoodCount == 0
+		&& Result.AccumulatedSimulationSeconds >= ExpectedSimulatedSecondsLowerBound;
+	return Result;
+}
+
+class FGatherersRunTimeDilationSweepCommand : public IAutomationLatentCommand
+{
+public:
+	FGatherersRunTimeDilationSweepCommand(
+		FAutomationTestBase* InTest,
+		double InObservationWindowSeconds,
+		TSharedRef<FTimeDilationSweepResults> InResults)
+		: Test(InTest),
+		  ObservationWindowSeconds(InObservationWindowSeconds),
+		  Results(InResults)
+	{
+	}
+
+	bool Update() override
+	{
+		UWorld* World = GEditor ? GEditor->PlayWorld : nullptr;
+		Test->TestNotNull(TEXT("time-dilation sweep play world should exist"), World);
+		if (World == nullptr)
+		{
+			return true;
+		}
+
+		UGatherersMassSubsystem* MassSubsystem = World->GetSubsystem<UGatherersMassSubsystem>();
+		UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+		Test->TestNotNull(TEXT("time-dilation sweep Mass subsystem should exist"), MassSubsystem);
+		Test->TestNotNull(TEXT("time-dilation sweep Mass entity subsystem should exist"), MassEntitySubsystem);
+		if (MassSubsystem == nullptr || MassEntitySubsystem == nullptr || World->GetWorldSettings() == nullptr)
+		{
+			return true;
+		}
+
+		if (!bCandidatePrepared)
+		{
+			World->GetWorldSettings()->SetTimeDilation(static_cast<float>(CurrentCandidateDilation));
+			MassSubsystem->ResetSimulation();
+			SpawnGatherersActors(*World, BuildTimeDilationSweepFixturePlan());
+			CandidateStartTimeSeconds = FPlatformTime::Seconds();
+			bCandidatePrepared = true;
+			return false;
+		}
+
+		if (FPlatformTime::Seconds() - CandidateStartTimeSeconds.GetValue() < ObservationWindowSeconds)
+		{
+			return false;
+		}
+
+		const FTimeDilationSweepCandidateResult CandidateResult =
+			EvaluateSweepCandidate(*MassSubsystem, *MassEntitySubsystem, CurrentCandidateDilation);
+		Results->CandidateResults.Add(CandidateResult);
+		Test->AddInfo(FString::Printf(
+			TEXT("time-dilation sweep candidate %dx: %s (sim_seconds=%.3f carried=%d loose=%d)"),
+			CandidateResult.Dilation,
+			CandidateResult.bPassed ? TEXT("PASS") : TEXT("FAIL"),
+			CandidateResult.AccumulatedSimulationSeconds,
+			CandidateResult.CarriedFoodCount,
+			CandidateResult.LooseFoodCount));
+
+		if (CandidateResult.bPassed)
+		{
+			Results->HighestPassingDilation = FMath::Max(Results->HighestPassingDilation, CurrentCandidateDilation);
+		}
+
+		MassSubsystem->ResetSimulation();
+		World->GetWorldSettings()->SetTimeDilation(1.0f);
+		bCandidatePrepared = false;
+		CandidateStartTimeSeconds.Reset();
+
+		if (!bBinarySearch)
+		{
+			if (CandidateResult.bPassed)
+			{
+				if (CurrentCandidateDilation >= MaxSweepDilation)
+				{
+					Results->bReachedMaxTestedDilation = true;
+					return true;
+				}
+
+				const int32 NextCandidate = CurrentCandidateDilation * 2;
+				if (NextCandidate > MaxSweepDilation)
+				{
+					Results->bReachedMaxTestedDilation = true;
+					return true;
+				}
+
+				PreviousPassingDilation = CurrentCandidateDilation;
+				CurrentCandidateDilation = NextCandidate;
+				return false;
+			}
+
+			if (PreviousPassingDilation == 0 || PreviousPassingDilation + 1 > CurrentCandidateDilation - 1)
+			{
+				return true;
+			}
+
+			bBinarySearch = true;
+			BinarySearchLow = PreviousPassingDilation + 1;
+			BinarySearchHigh = CurrentCandidateDilation - 1;
+			CurrentCandidateDilation = (BinarySearchLow + BinarySearchHigh) / 2;
+			return false;
+		}
+
+		if (CandidateResult.bPassed)
+		{
+			BinarySearchLow = CurrentCandidateDilation + 1;
+		}
+		else
+		{
+			BinarySearchHigh = CurrentCandidateDilation - 1;
+		}
+
+		if (BinarySearchLow > BinarySearchHigh)
+		{
+			return true;
+		}
+
+		CurrentCandidateDilation = (BinarySearchLow + BinarySearchHigh) / 2;
+		return false;
+	}
+
+private:
+	FAutomationTestBase* Test;
+	double ObservationWindowSeconds;
+	TSharedRef<FTimeDilationSweepResults> Results;
+	int32 CurrentCandidateDilation = 1;
+	int32 PreviousPassingDilation = 0;
+	int32 BinarySearchLow = 0;
+	int32 BinarySearchHigh = 0;
+	bool bBinarySearch = false;
+	bool bCandidatePrepared = false;
+	TOptional<double> CandidateStartTimeSeconds;
+};
+
+class FGatherersAssertTimeDilationSweepResultsCommand : public IAutomationLatentCommand
+{
+public:
+	FGatherersAssertTimeDilationSweepResultsCommand(
+		FAutomationTestBase* InTest,
+		TSharedRef<FTimeDilationSweepResults> InResults)
+		: Test(InTest),
+		  Results(InResults)
+	{
+	}
+
+	bool Update() override
+	{
+		Test->TestTrue(TEXT("time-dilation sweep should evaluate at least one candidate"), Results->CandidateResults.Num() > 0);
+		Test->TestTrue(TEXT("time-dilation sweep should find at least a modest passing dilation"), Results->HighestPassingDilation >= 4);
+		Test->AddInfo(FString::Printf(
+			TEXT("time-dilation sweep highest passing dilation: %dx%s"),
+			Results->HighestPassingDilation,
+			Results->bReachedMaxTestedDilation ? TEXT(" (reached max tested candidate)") : TEXT("")));
+		return true;
+	}
+
+private:
+	FAutomationTestBase* Test;
+	TSharedRef<FTimeDilationSweepResults> Results;
+};
+
+DEFINE_LATENT_AUTOMATION_COMMAND_THREE_PARAMETER(
+	FGatherersWaitForSweepPIECleanupCommand,
+	FAutomationTestBase*,
+	Test,
+	double,
+	StartTimeSeconds,
+	double,
+	TimeoutSeconds);
+
+bool FGatherersWaitForSweepPIECleanupCommand::Update()
+{
+	return GatherersWorldAssertions::PollForPIEToEnd(
+		*Test,
+		SimBlankMapPath,
+		StartTimeSeconds,
+		TimeoutSeconds,
+		TEXT("time-dilation sweep"));
+}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGatherersTimeControlSweepAutomationTest,
+	"supplemental.unreal_gatherers.TimeControl.MaxCorrectSpeedSweepReportsHighestPassingDilation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGatherersTimeControlSweepAutomationTest::RunTest(const FString& Parameters)
+{
+	const bool bOpenedMap = AutomationOpenMap(SimBlankMapPath);
+	TestTrue(TEXT("should open SimBlank map"), bOpenedMap);
+	if (!bOpenedMap)
+	{
+		return false;
+	}
+
+	const TSharedRef<FTimeDilationSweepResults> SweepResults = MakeShared<FTimeDilationSweepResults>();
+	ADD_LATENT_AUTOMATION_COMMAND(
+		FGatherersRunTimeDilationSweepCommand(this, SweepObservationWindowSeconds, SweepResults));
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersAssertTimeDilationSweepResultsCommand(this, SweepResults));
+	ADD_LATENT_AUTOMATION_COMMAND(FEndPlayMapCommand());
+	ADD_LATENT_AUTOMATION_COMMAND(FGatherersWaitForSweepPIECleanupCommand(this, FPlatformTime::Seconds(), 5.0));
+	return true;
+}

--- a/unreal_gatherers/Source/unreal_gatherersTests/unreal_gatherersTests.Build.cs
+++ b/unreal_gatherers/Source/unreal_gatherersTests/unreal_gatherersTests.Build.cs
@@ -16,6 +16,7 @@ public class unreal_gatherersTests : ModuleRules
 			"MassActors",
 			"MassSimulation",
 			"MassRepresentation",
+			"UMG",
 			"UnrealEd",
 			"unreal_gatherers",
 		});


### PR DESCRIPTION
## Summary
- strengthen Unreal time-control coverage with direct simulated-time observation and a denser fast-time PIE fixture so the current checks measure more than just "fast is faster"
- add a supplemental sweep harness plus `scripts/measure_unreal_max_speed.sh` so this machine can report the highest passing dilation instead of relying on the earlier weak `>=128x` lower bound
- expose the measured result as a new `Max Correct` runtime mode and cycle it through the existing time-control UI with a visible `27x` label

## Test plan
- [x] `./scripts/test_unreal.sh --no-build --test default.unreal_gatherers.TimeControl`
- [x] `./scripts/test_unreal.sh --no-build --test default.unreal_gatherers.FullSimulationActorFixture`
- [x] `./scripts/measure_unreal_max_speed.sh --no-build`
- [x] `./scripts/test_unreal.sh --no-build`

Made with [Cursor](https://cursor.com)