### PR TITLE
Move Unreal simulation stepping into Mass processors

### DIFF
--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassRuntime.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassRuntime.cpp
@@ -1,0 +1,16 @@
+#include "Simulation/GatherersMassRuntime.h"
+
+#include "Math/RandomStream.h"
+#include "Simulation/GatherersAntSimulation.h"
+#include "Simulation/GatherersMassSubsystem.h"
+
+FVector ConsumeAntTurnDirection(FGatherersMassAntFragment& AntFragment)
+{
+	FRandomStream RandomStream(AntFragment.RandomSeed);
+	const FVector TurnDirection = ComputeAntTurnDirection(
+		AntFragment.Direction,
+		RandomStream.FRandRange(-1.0f, 1.0f),
+		AntFragment.TurnJitterRadians);
+	AntFragment.RandomSeed = RandomStream.GetCurrentSeed();
+	return TurnDirection;
+}

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassRuntime.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassRuntime.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct FGatherersMassAntFragment;
+
+inline constexpr float GatherersMassPickupRadius = 15.0f;
+inline constexpr float GatherersMassCarriedFoodHeight = 20.0f;
+inline constexpr float GatherersMassPickupSeparationDistance = 50.0f;
+inline constexpr float GatherersMassSafeMovementStepDistance = 18.0f;
+
+FVector ConsumeAntTurnDirection(FGatherersMassAntFragment& AntFragment);

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/GatherersMassSubsystem.cpp
@@ -5,22 +5,22 @@
 #include "Components/SceneComponent.h"
 #include "Engine/StaticMesh.h"
 #include "GameFramework/Actor.h"
-#include "Math/RandomStream.h"
+#include "MassExecutor.h"
 #include "MassEntityManager.h"
+#include "MassProcessingContext.h"
 #include "MassEntitySubsystem.h"
 #include "MassEntityView.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Materials/MaterialInterface.h"
 #include "StructUtils/InstancedStruct.h"
 #include "Simulation/GatherersAntSimulation.h"
+#include "Simulation/GatherersMassRuntime.h"
+#include "Simulation/Processors/GatherersSimulationProcessors.h"
 #include "Simulation/GatherersSpawnPlan.h"
 #include "Simulation/GatherersWorldSpawner.h"
 
 namespace
 {
-constexpr float MassPickupRadius = 15.0f;
-constexpr float MassCarriedFoodHeight = 20.0f;
-constexpr float MassPickupSeparationDistance = 50.0f;
 const FLinearColor MassAntColor(0.8f, 0.8f, 0.8f, 1.0f);
 const FLinearColor MassFoodColor(192.0f / 255.0f, 2.0f / 255.0f, 2.0f / 255.0f, 1.0f);
 const FVector MassAntVisualScale(0.2f, 0.2f, 0.2f);
@@ -32,17 +32,6 @@ constexpr TCHAR VisualizerRootName[] = TEXT("Root");
 constexpr TCHAR AntInstancesName[] = TEXT("AntInstances");
 constexpr TCHAR FoodInstancesName[] = TEXT("FoodInstances");
 constexpr ECollisionChannel FoodQueryChannel = ECC_GameTraceChannel1;
-
-FVector ConsumeAntTurnDirection(FGatherersMassAntFragment& AntFragment)
-{
-	FRandomStream RandomStream(AntFragment.RandomSeed);
-	const FVector TurnDirection = ComputeAntTurnDirection(
-		AntFragment.Direction,
-		RandomStream.FRandRange(-1.0f, 1.0f),
-		AntFragment.TurnJitterRadians);
-	AntFragment.RandomSeed = RandomStream.GetCurrentSeed();
-	return TurnDirection;
-}
 
 void ConfigureVisualComponent(
 	UInstancedStaticMeshComponent& Component,
@@ -91,12 +80,112 @@ FVector ComputeFoodVisualPosition(
 		const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 		if (AntFragment.CarriedFoodEntity == FoodEntity)
 		{
-			return AntFragment.Position + ComputeCarriedFoodRelativeLocation(MassCarriedFoodHeight);
+			return AntFragment.Position + ComputeCarriedFoodRelativeLocation(GatherersMassCarriedFoodHeight);
 		}
 	}
 
 	return FoodFragment.Position;
 }
+}
+
+void UGatherersMassSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	bProcessorPipelinesInitialized = false;
+}
+
+void UGatherersMassSubsystem::Deinitialize()
+{
+	SimulationProcessorPipeline.Reset();
+	VisualProcessorPipeline.Reset();
+	bProcessorPipelinesInitialized = false;
+	Super::Deinitialize();
+}
+
+bool UGatherersMassSubsystem::EnsureProcessorPipelines(UMassEntitySubsystem& MassEntitySubsystem)
+{
+	if (bProcessorPipelinesInitialized)
+	{
+		return true;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem.GetMutableEntityManager();
+	const TArray<TSubclassOf<UMassProcessor>> SimulationProcessors = {
+		UGatherersTimeAccumulationProcessor::StaticClass(),
+		UGatherersAntMovementProcessor::StaticClass(),
+		UGatherersFoodInteractionProcessor::StaticClass(),
+	};
+	SimulationProcessorPipeline.InitializeFromClassArray(SimulationProcessors, *this, EntityManager.AsShared());
+
+	const TArray<TSubclassOf<UMassProcessor>> VisualProcessors = {
+		UGatherersVisualSyncProcessor::StaticClass(),
+	};
+	VisualProcessorPipeline.InitializeFromClassArray(VisualProcessors, *this, EntityManager.AsShared());
+
+	bProcessorPipelinesInitialized = true;
+	return true;
+}
+
+void UGatherersMassSubsystem::RunProcessorPipelines(float DeltaTime, bool bIncludeVisualSync)
+{
+	if (!HasManagedSimulation())
+	{
+		return;
+	}
+
+	UWorld* World = GetWorld();
+	if (World == nullptr)
+	{
+		return;
+	}
+
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	if (MassEntitySubsystem == nullptr || !EnsureProcessorPipelines(*MassEntitySubsystem))
+	{
+		return;
+	}
+
+	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
+	FMassProcessingContext SimulationContext(EntityManager, DeltaTime);
+	UE::Mass::Executor::Run(SimulationProcessorPipeline, SimulationContext);
+
+	if (bIncludeVisualSync)
+	{
+		FMassProcessingContext VisualContext(EntityManager, DeltaTime);
+		UE::Mass::Executor::Run(VisualProcessorPipeline, VisualContext);
+	}
+}
+
+void UGatherersMassSubsystem::RunSimulationProcessorsForTesting(float DeltaTime)
+{
+	RunProcessorPipelines(DeltaTime, false);
+}
+
+void UGatherersMassSubsystem::AdvanceAccumulatedSimulationSeconds(float DeltaTime)
+{
+	AccumulatedSimulationSeconds += FMath::Max(0.0f, DeltaTime);
+}
+
+void UGatherersMassSubsystem::SyncManagedVisuals()
+{
+	if (!HasManagedSimulation())
+	{
+		return;
+	}
+
+	UWorld* World = GetWorld();
+	if (World == nullptr)
+	{
+		return;
+	}
+
+	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
+	if (MassEntitySubsystem == nullptr)
+	{
+		return;
+	}
+
+	SyncVisualInstances(*MassEntitySubsystem);
 }
 
 bool UGatherersMassSubsystem::EnsureVisualComponents()
@@ -502,127 +591,7 @@ void UGatherersMassSubsystem::SyncVisualInstances(UMassEntitySubsystem& MassEnti
 void UGatherersMassSubsystem::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
-
-	if (!HasManagedSimulation())
-	{
-		return;
-	}
-
-	UWorld* World = GetWorld();
-	if (World == nullptr)
-	{
-		return;
-	}
-
-	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
-	if (MassEntitySubsystem == nullptr)
-	{
-		return;
-	}
-
-	AccumulatedSimulationSeconds += DeltaTime;
-
-	FMassEntityManager& EntityManager = MassEntitySubsystem->GetMutableEntityManager();
-	for (const FMassEntityHandle Entity : ManagedAntEntities)
-	{
-		if (!EntityManager.IsEntityValid(Entity))
-		{
-			continue;
-		}
-
-		FMassEntityView AntView(EntityManager, Entity);
-		FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
-		AntFragment.PickupCooldownRemainingSeconds = ComputeRemainingPickupCooldown(
-			AntFragment.PickupCooldownRemainingSeconds,
-			DeltaTime);
-		const FVector PreviousPosition = AntFragment.Position;
-		AntFragment.Position = ComputeAntHeadingMovementStep(
-			AntFragment.Position,
-			AntFragment.Direction,
-			AntFragment.MovementSpeed,
-			18.0f,
-			DeltaTime);
-
-		if (SimulationBounds.IsValid)
-		{
-			FVector InwardBoundaryNormal = FVector::ZeroVector;
-			if (AntFragment.Position.X < SimulationBounds.Min.X)
-			{
-				AntFragment.Position.X = SimulationBounds.Min.X;
-				InwardBoundaryNormal += FVector(1.0f, 0.0f, 0.0f);
-			}
-			else if (AntFragment.Position.X > SimulationBounds.Max.X)
-			{
-				AntFragment.Position.X = SimulationBounds.Max.X;
-				InwardBoundaryNormal += FVector(-1.0f, 0.0f, 0.0f);
-			}
-
-			if (AntFragment.Position.Y < SimulationBounds.Min.Y)
-			{
-				AntFragment.Position.Y = SimulationBounds.Min.Y;
-				InwardBoundaryNormal += FVector(0.0f, 1.0f, 0.0f);
-			}
-			else if (AntFragment.Position.Y > SimulationBounds.Max.Y)
-			{
-				AntFragment.Position.Y = SimulationBounds.Max.Y;
-				InwardBoundaryNormal += FVector(0.0f, -1.0f, 0.0f);
-			}
-
-			if (!InwardBoundaryNormal.IsNearlyZero())
-			{
-				AntFragment.Direction = ComputeBoundaryTurnBackDirection(AntFragment.Direction, InwardBoundaryNormal);
-			}
-		}
-
-		const TArray<FMassEntityHandle> NearbyFoodEntities = QueryLooseFoodEntitiesAlongSweep(
-			PreviousPosition,
-			AntFragment.Position,
-			MassPickupRadius);
-		const FMassEntityHandle NearbyFoodEntity = NearbyFoodEntities.IsEmpty()
-			? FMassEntityHandle()
-			: NearbyFoodEntities[0];
-		FGatherersMassFoodFragment* NearbyFood = nullptr;
-		if (NearbyFoodEntity.IsSet() && EntityManager.IsEntityValid(NearbyFoodEntity))
-		{
-			FMassEntityView NearbyFoodView(EntityManager, NearbyFoodEntity);
-			NearbyFood = &NearbyFoodView.GetFragmentData<FGatherersMassFoodFragment>();
-		}
-
-		if (AntFragment.CarriedFoodEntity.IsValid() && NearbyFood != nullptr)
-		{
-			AntFragment.Direction = ConsumeAntTurnDirection(AntFragment);
-
-			if (EntityManager.IsEntityValid(AntFragment.CarriedFoodEntity))
-			{
-				FMassEntityView CarriedFoodView(EntityManager, AntFragment.CarriedFoodEntity);
-				FGatherersMassFoodFragment& CarriedFoodFragment = CarriedFoodView.GetFragmentData<FGatherersMassFoodFragment>();
-				CarriedFoodFragment.bIsLoose = true;
-				CarriedFoodFragment.Position = AntFragment.Position;
-
-				if (AFood* CarriedFoodProxy = CarriedFoodFragment.ProxyActor.Get())
-				{
-					CarriedFoodProxy->DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
-					CarriedFoodProxy->SetActorLocation(AntFragment.Position);
-				}
-			}
-
-			AntFragment.CarriedFoodEntity.Reset();
-			AntFragment.PickupCooldownRemainingSeconds = ComputePickupCooldownForSeparationDistance(
-				MassPickupSeparationDistance,
-				AntFragment.MovementSpeed);
-		}
-		else if (!AntFragment.CarriedFoodEntity.IsValid() && AntFragment.PickupCooldownRemainingSeconds <= 0.0f)
-		{
-			if (NearbyFood != nullptr)
-			{
-				AntFragment.Direction = ConsumeAntTurnDirection(AntFragment);
-				AntFragment.CarriedFoodEntity = NearbyFoodEntity;
-				NearbyFood->bIsLoose = false;
-			}
-		}
-	}
-
-	SyncVisualInstances(*MassEntitySubsystem);
+	RunProcessorPipelines(DeltaTime, true);
 }
 
 TStatId UGatherersMassSubsystem::GetStatId() const
@@ -657,13 +626,16 @@ void UGatherersMassSubsystem::InitializeHybridSimulation(const FGatherersSpawnRe
 
 		TArray<FInstancedStruct, TInlineAllocator<1>> FoodFragments;
 		FoodFragments.Add(FInstancedStruct::Make(FoodFragment));
-		ManagedFoodEntities.Add(EntityManager.CreateEntity(FoodFragments));
+		const FMassEntityHandle FoodEntity = EntityManager.CreateEntity(FoodFragments);
+		EntityManager.AddTagToEntity(FoodEntity, FGatherersMassFoodTag::StaticStruct());
+		ManagedFoodEntities.Add(FoodEntity);
 	}
 
 	for (int32 AntIndex = 0; AntIndex < Plan.AntSpawns.Num(); ++AntIndex)
 	{
 		FGatherersMassAntFragment AntFragment;
 		AntFragment.Position = Plan.AntSpawns[AntIndex].GetLocation();
+		AntFragment.PreviousPosition = AntFragment.Position;
 		AntFragment.Direction = Plan.AntInitialDirections.IsValidIndex(AntIndex)
 			? Plan.AntInitialDirections[AntIndex].GetSafeNormal()
 			: FVector(1.0f, 0.0f, 0.0f);
@@ -679,7 +651,9 @@ void UGatherersMassSubsystem::InitializeHybridSimulation(const FGatherersSpawnRe
 
 		TArray<FInstancedStruct, TInlineAllocator<1>> AntFragments;
 		AntFragments.Add(FInstancedStruct::Make(AntFragment));
-		ManagedAntEntities.Add(EntityManager.CreateEntity(AntFragments));
+		const FMassEntityHandle AntEntity = EntityManager.CreateEntity(AntFragments);
+		EntityManager.AddTagToEntity(AntEntity, FGatherersMassAntTag::StaticStruct());
+		ManagedAntEntities.Add(AntEntity);
 	}
 
 	RebuildVisualInstances(*MassEntitySubsystem);
@@ -740,6 +714,9 @@ void UGatherersMassSubsystem::ResetSimulation()
 	ManagedFoodEntities.Reset();
 	SimulationBounds = FBox(EForceInit::ForceInit);
 	AccumulatedSimulationSeconds = 0.0f;
+	SimulationProcessorPipeline.Reset();
+	VisualProcessorPipeline.Reset();
+	bProcessorPipelinesInitialized = false;
 }
 
 int32 UGatherersMassSubsystem::GetManagedAntCount() const

--- a/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/Processors/GatherersSimulationProcessors.cpp
+++ b/unreal_gatherers/Source/unreal_gatherers/Private/Simulation/Processors/GatherersSimulationProcessors.cpp
@@ -1,0 +1,196 @@
+#include "Simulation/Processors/GatherersSimulationProcessors.h"
+
+#include "Actors/Food.h"
+#include "MassEntityManager.h"
+#include "MassEntityView.h"
+#include "MassExecutionContext.h"
+#include "Simulation/GatherersAntSimulation.h"
+#include "Simulation/GatherersMassRuntime.h"
+#include "Simulation/GatherersMassSubsystem.h"
+
+namespace
+{
+uint8 GatherersProcessorExecutionFlags()
+{
+	return static_cast<uint8>(EProcessorExecutionFlags::All);
+}
+}
+
+UGatherersTimeAccumulationProcessor::UGatherersTimeAccumulationProcessor()
+{
+	bAutoRegisterWithProcessingPhases = false;
+	bRequiresGameThreadExecution = true;
+	ExecutionFlags = GatherersProcessorExecutionFlags();
+	ProcessorRequirements.AddSubsystemRequirement<UGatherersMassSubsystem>(EMassFragmentAccess::ReadWrite);
+}
+
+void UGatherersTimeAccumulationProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	Context.GetMutableSubsystemChecked<UGatherersMassSubsystem>().AdvanceAccumulatedSimulationSeconds(
+		Context.GetDeltaTimeSeconds());
+}
+
+UGatherersAntMovementProcessor::UGatherersAntMovementProcessor()
+{
+	bAutoRegisterWithProcessingPhases = false;
+	bRequiresGameThreadExecution = true;
+	ExecutionFlags = GatherersProcessorExecutionFlags();
+	ProcessorRequirements.AddSubsystemRequirement<UGatherersMassSubsystem>(EMassFragmentAccess::ReadOnly);
+	EntityQuery.RegisterWithProcessor(*this);
+}
+
+void UGatherersAntMovementProcessor::ConfigureQueries(const TSharedRef<FMassEntityManager>& EntityManager)
+{
+	EntityQuery.AddTagRequirement<FGatherersMassAntTag>(EMassFragmentPresence::All);
+	EntityQuery.AddRequirement<FGatherersMassAntFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddSubsystemRequirement<UGatherersMassSubsystem>(EMassFragmentAccess::ReadOnly);
+}
+
+void UGatherersAntMovementProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	const FBox SimulationBounds = Context.GetSubsystemChecked<UGatherersMassSubsystem>().GetSimulationBounds();
+	const float DeltaSeconds = Context.GetDeltaTimeSeconds();
+
+	EntityQuery.ForEachEntityChunk(Context, [SimulationBounds, DeltaSeconds](FMassExecutionContext& ChunkContext)
+	{
+		const TArrayView<FGatherersMassAntFragment> AntFragments =
+			ChunkContext.GetMutableFragmentView<FGatherersMassAntFragment>();
+		for (int32 EntityIndex = 0; EntityIndex < ChunkContext.GetNumEntities(); ++EntityIndex)
+		{
+			FGatherersMassAntFragment& AntFragment = AntFragments[EntityIndex];
+			AntFragment.PickupCooldownRemainingSeconds = ComputeRemainingPickupCooldown(
+				AntFragment.PickupCooldownRemainingSeconds,
+				DeltaSeconds);
+			AntFragment.PreviousPosition = AntFragment.Position;
+			AntFragment.Position = ComputeAntHeadingMovementStep(
+				AntFragment.Position,
+				AntFragment.Direction,
+				AntFragment.MovementSpeed,
+				GatherersMassSafeMovementStepDistance,
+				DeltaSeconds);
+
+			if (!SimulationBounds.IsValid)
+			{
+				continue;
+			}
+
+			FVector InwardBoundaryNormal = FVector::ZeroVector;
+			if (AntFragment.Position.X < SimulationBounds.Min.X)
+			{
+				AntFragment.Position.X = SimulationBounds.Min.X;
+				InwardBoundaryNormal += FVector(1.0f, 0.0f, 0.0f);
+			}
+			else if (AntFragment.Position.X > SimulationBounds.Max.X)
+			{
+				AntFragment.Position.X = SimulationBounds.Max.X;
+				InwardBoundaryNormal += FVector(-1.0f, 0.0f, 0.0f);
+			}
+
+			if (AntFragment.Position.Y < SimulationBounds.Min.Y)
+			{
+				AntFragment.Position.Y = SimulationBounds.Min.Y;
+				InwardBoundaryNormal += FVector(0.0f, 1.0f, 0.0f);
+			}
+			else if (AntFragment.Position.Y > SimulationBounds.Max.Y)
+			{
+				AntFragment.Position.Y = SimulationBounds.Max.Y;
+				InwardBoundaryNormal += FVector(0.0f, -1.0f, 0.0f);
+			}
+
+			if (!InwardBoundaryNormal.IsNearlyZero())
+			{
+				AntFragment.Direction = ComputeBoundaryTurnBackDirection(AntFragment.Direction, InwardBoundaryNormal);
+			}
+		}
+	});
+}
+
+UGatherersFoodInteractionProcessor::UGatherersFoodInteractionProcessor()
+{
+	bAutoRegisterWithProcessingPhases = false;
+	bRequiresGameThreadExecution = true;
+	ExecutionFlags = GatherersProcessorExecutionFlags();
+	ProcessorRequirements.AddSubsystemRequirement<UGatherersMassSubsystem>(EMassFragmentAccess::ReadOnly);
+	EntityQuery.RegisterWithProcessor(*this);
+}
+
+void UGatherersFoodInteractionProcessor::ConfigureQueries(const TSharedRef<FMassEntityManager>& EntityManager)
+{
+	EntityQuery.AddTagRequirement<FGatherersMassAntTag>(EMassFragmentPresence::All);
+	EntityQuery.AddRequirement<FGatherersMassAntFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddSubsystemRequirement<UGatherersMassSubsystem>(EMassFragmentAccess::ReadOnly);
+}
+
+void UGatherersFoodInteractionProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	const UGatherersMassSubsystem& MassSubsystem = Context.GetSubsystemChecked<UGatherersMassSubsystem>();
+
+	EntityQuery.ForEachEntityChunk(Context, [&EntityManager, &MassSubsystem](FMassExecutionContext& ChunkContext)
+	{
+		const TArrayView<FGatherersMassAntFragment> AntFragments =
+			ChunkContext.GetMutableFragmentView<FGatherersMassAntFragment>();
+		for (int32 EntityIndex = 0; EntityIndex < ChunkContext.GetNumEntities(); ++EntityIndex)
+		{
+			FGatherersMassAntFragment& AntFragment = AntFragments[EntityIndex];
+			const TArray<FMassEntityHandle> NearbyFoodEntities = MassSubsystem.QueryLooseFoodEntitiesAlongSweep(
+				AntFragment.PreviousPosition,
+				AntFragment.Position,
+				GatherersMassPickupRadius);
+			const FMassEntityHandle NearbyFoodEntity = NearbyFoodEntities.IsEmpty() ? FMassEntityHandle() : NearbyFoodEntities[0];
+
+			FGatherersMassFoodFragment* NearbyFood = nullptr;
+			if (NearbyFoodEntity.IsSet() && EntityManager.IsEntityValid(NearbyFoodEntity))
+			{
+				FMassEntityView NearbyFoodView(EntityManager, NearbyFoodEntity);
+				NearbyFood = &NearbyFoodView.GetFragmentData<FGatherersMassFoodFragment>();
+			}
+
+			if (AntFragment.CarriedFoodEntity.IsValid() && NearbyFood != nullptr)
+			{
+				AntFragment.Direction = ConsumeAntTurnDirection(AntFragment);
+
+				if (EntityManager.IsEntityValid(AntFragment.CarriedFoodEntity))
+				{
+					FMassEntityView CarriedFoodView(EntityManager, AntFragment.CarriedFoodEntity);
+					FGatherersMassFoodFragment& CarriedFoodFragment =
+						CarriedFoodView.GetFragmentData<FGatherersMassFoodFragment>();
+					CarriedFoodFragment.bIsLoose = true;
+					CarriedFoodFragment.Position = AntFragment.Position;
+
+					if (AFood* CarriedFoodProxy = CarriedFoodFragment.ProxyActor.Get())
+					{
+						CarriedFoodProxy->DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
+						CarriedFoodProxy->SetActorLocation(AntFragment.Position);
+					}
+				}
+
+				AntFragment.CarriedFoodEntity.Reset();
+				AntFragment.PickupCooldownRemainingSeconds = ComputePickupCooldownForSeparationDistance(
+					GatherersMassPickupSeparationDistance,
+					AntFragment.MovementSpeed);
+			}
+			else if (!AntFragment.CarriedFoodEntity.IsValid() && AntFragment.PickupCooldownRemainingSeconds <= 0.0f)
+			{
+				if (NearbyFood != nullptr)
+				{
+					AntFragment.Direction = ConsumeAntTurnDirection(AntFragment);
+					AntFragment.CarriedFoodEntity = NearbyFoodEntity;
+					NearbyFood->bIsLoose = false;
+				}
+			}
+		}
+	});
+}
+
+UGatherersVisualSyncProcessor::UGatherersVisualSyncProcessor()
+{
+	bAutoRegisterWithProcessingPhases = false;
+	bRequiresGameThreadExecution = true;
+	ExecutionFlags = GatherersProcessorExecutionFlags();
+	ProcessorRequirements.AddSubsystemRequirement<UGatherersMassSubsystem>(EMassFragmentAccess::ReadWrite);
+}
+
+void UGatherersVisualSyncProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	Context.GetMutableSubsystemChecked<UGatherersMassSubsystem>().SyncManagedVisuals();
+}

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/GatherersMassSubsystem.h
@@ -4,6 +4,8 @@
 #include "CoreMinimal.h"
 #include "MassEntityElementTypes.h"
 #include "MassEntityHandle.h"
+#include "MassExternalSubsystemTraits.h"
+#include "MassProcessingTypes.h"
 #include "Subsystems/WorldSubsystem.h"
 #include "GatherersMassSubsystem.generated.h"
 
@@ -34,6 +36,7 @@ struct UNREAL_GATHERERS_API FGatherersMassAntFragment : public FMassFragment
 	GENERATED_BODY()
 
 	FVector Position = FVector::ZeroVector;
+	FVector PreviousPosition = FVector::ZeroVector;
 	FVector Direction = FVector(1.0f, 0.0f, 0.0f);
 	FMassEntityHandle CarriedFoodEntity;
 	TWeakObjectPtr<AAnt> ProxyActor = nullptr;
@@ -53,18 +56,42 @@ struct UNREAL_GATHERERS_API FGatherersMassFoodFragment : public FMassFragment
 	bool bIsLoose = true;
 };
 
+template<>
+struct TMassFragmentTraits<FGatherersMassAntFragment> final
+{
+	enum
+	{
+		AuthorAcceptsItsNotTriviallyCopyable = true
+	};
+};
+
+template<>
+struct TMassFragmentTraits<FGatherersMassFoodFragment> final
+{
+	enum
+	{
+		AuthorAcceptsItsNotTriviallyCopyable = true
+	};
+};
+
 UCLASS()
 class UNREAL_GATHERERS_API UGatherersMassSubsystem : public UTickableWorldSubsystem
 {
 	GENERATED_BODY()
 
 public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
 	virtual void Tick(float DeltaTime) override;
 	virtual TStatId GetStatId() const override;
 
 	void InitializeHybridSimulation(const FGatherersSpawnResult& SpawnResult, const FGatherersSpawnPlan& Plan);
 	void ResetSimulation();
+	void RunSimulationProcessorsForTesting(float DeltaTime);
+	void AdvanceAccumulatedSimulationSeconds(float DeltaTime);
+	void SyncManagedVisuals();
 	TArray<FMassEntityHandle> QueryLooseFoodEntitiesOverlappingSphere(const FVector& Center, float Radius) const;
+	TArray<FMassEntityHandle> QueryLooseFoodEntitiesAlongSweep(const FVector& SweepStart, const FVector& SweepEnd, float Radius) const;
 
 	int32 GetManagedAntCount() const;
 	int32 GetManagedFoodCount() const;
@@ -75,8 +102,9 @@ public:
 	const UInstancedStaticMeshComponent* GetFoodRepresentationComponent() const;
 
 private:
+	bool EnsureProcessorPipelines(UMassEntitySubsystem& MassEntitySubsystem);
+	void RunProcessorPipelines(float DeltaTime, bool bIncludeVisualSync);
 	bool EnsureVisualComponents();
-	TArray<FMassEntityHandle> QueryLooseFoodEntitiesAlongSweep(const FVector& SweepStart, const FVector& SweepEnd, float Radius) const;
 	void RebuildVisualInstances(UMassEntitySubsystem& MassEntitySubsystem);
 	void SyncVisualInstances(UMassEntitySubsystem& MassEntitySubsystem);
 
@@ -87,6 +115,10 @@ public:
 	float AccumulatedSimulationSeconds = 0.0f;
 
 private:
+	FMassRuntimePipeline SimulationProcessorPipeline;
+	FMassRuntimePipeline VisualProcessorPipeline;
+	bool bProcessorPipelinesInitialized = false;
+
 	UPROPERTY(Transient)
 	TObjectPtr<AActor> VisualizerActor = nullptr;
 
@@ -104,4 +136,14 @@ private:
 
 	UPROPERTY(Transient)
 	TObjectPtr<UMaterialInstanceDynamic> FoodVisualMaterial = nullptr;
+};
+
+template<>
+struct TMassExternalSubsystemTraits<UGatherersMassSubsystem>
+{
+	enum
+	{
+		GameThreadOnly = true,
+		ThreadSafeWrite = false,
+	};
 };

--- a/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/Processors/GatherersSimulationProcessors.h
+++ b/unreal_gatherers/Source/unreal_gatherers/Public/Simulation/Processors/GatherersSimulationProcessors.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MassEntityQuery.h"
+#include "MassProcessor.h"
+#include "GatherersSimulationProcessors.generated.h"
+
+UCLASS()
+class UNREAL_GATHERERS_API UGatherersTimeAccumulationProcessor : public UMassProcessor
+{
+	GENERATED_BODY()
+
+public:
+	UGatherersTimeAccumulationProcessor();
+
+protected:
+	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
+};
+
+UCLASS()
+class UNREAL_GATHERERS_API UGatherersAntMovementProcessor : public UMassProcessor
+{
+	GENERATED_BODY()
+
+public:
+	UGatherersAntMovementProcessor();
+
+protected:
+	virtual void ConfigureQueries(const TSharedRef<FMassEntityManager>& EntityManager) override;
+	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
+
+private:
+	FMassEntityQuery EntityQuery;
+};
+
+UCLASS()
+class UNREAL_GATHERERS_API UGatherersFoodInteractionProcessor : public UMassProcessor
+{
+	GENERATED_BODY()
+
+public:
+	UGatherersFoodInteractionProcessor();
+
+protected:
+	virtual void ConfigureQueries(const TSharedRef<FMassEntityManager>& EntityManager) override;
+	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
+
+private:
+	FMassEntityQuery EntityQuery;
+};
+
+UCLASS()
+class UNREAL_GATHERERS_API UGatherersVisualSyncProcessor : public UMassProcessor
+{
+	GENERATED_BODY()
+
+public:
+	UGatherersVisualSyncProcessor();
+
+protected:
+	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
+};

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/FullSimulationActor.spec.cpp
@@ -63,7 +63,7 @@ bool FGatherersFullSimulationIgnoresOffPathFoodAutomationTest::RunTest(const FSt
 
 	for (int32 StepIndex = 0; StepIndex < 5; ++StepIndex)
 	{
-		MassSubsystem->Tick(0.1f);
+		MassSubsystem->RunSimulationProcessorsForTesting(0.1f);
 	}
 
 	UMassEntitySubsystem* MassEntitySubsystem = World->GetSubsystem<UMassEntitySubsystem>();
@@ -77,7 +77,7 @@ bool FGatherersFullSimulationIgnoresOffPathFoodAutomationTest::RunTest(const FSt
 	FMassEntityView AntView(EntityManager, MassSubsystem->ManagedAntEntities[0]);
 	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 	TestTrue(
-		TEXT("full-sim ant keeps moving forward instead of steering toward off-path food"),
+		TEXT("full-sim ant keeps moving forward through the processor-driven path instead of steering toward off-path food"),
 		AntFragment.Position.Equals(FVector(50.0f, 0.0f, 0.0f), 1.0f));
 
 	MassSubsystem->ResetSimulation();

--- a/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBridge.spec.cpp
+++ b/unreal_gatherers/Source/unreal_gatherersTests/Private/MassBridge.spec.cpp
@@ -194,11 +194,11 @@ bool FGatherersMassRepresentationBridgeAutomationTest::RunTest(const FString& Pa
 		TEXT("Mass food path should expose a dedicated food instanced visual component"),
 		const_cast<UInstancedStaticMeshComponent*>(MassSubsystem->GetFoodRepresentationComponent()));
 
-	MassSubsystem->Tick(0.1f);
+	MassSubsystem->RunSimulationProcessorsForTesting(0.1f);
 
 	const FGatherersMassAntFragment& AntFragment = AntView.GetFragmentData<FGatherersMassAntFragment>();
 	TestTrue(
-		TEXT("Mass ant can still advance without spawned actor proxies"),
+		TEXT("Mass ant can still advance through the processor-driven path without spawned actor proxies"),
 		AntFragment.Position.Equals(FVector(10.0f, 0.0f, 0.0f), 1.0f));
 
 	MassSubsystem->ResetSimulation();


### PR DESCRIPTION
## Summary
- move Gatherers runtime stepping from the monolithic `UGatherersMassSubsystem::Tick` loop into explicit Mass runtime pipelines and ordered `UMassProcessor` classes
- split simulation and visual sync so tests can exercise processor-driven advancement directly while the live game still runs visual sync as a separate late stage
- preserve existing time-control, sweep-query, and Mass visual behavior while resetting pipeline state cleanly between fixtures

## Test plan
- [x] `./scripts/test_unreal.sh --test default.unreal_gatherers.Mass.EntitiesAdvanceWithoutActorVisualProxies`
- [x] `./scripts/test_unreal.sh --no-build --test default.unreal_gatherers.FullSimulationActorFixture.AntKeepsHeadingWhenFoodIsOffPath`
- [x] `./scripts/test_unreal.sh --no-build --test default.unreal_gatherers.TimeControl`
- [x] `./scripts/test_unreal.sh --no-build --test default.unreal_gatherers.FullSimulationActorFixture`
- [x] `./scripts/test_unreal.sh --no-build --test default.unreal_gatherers.Mass`
- [x] `./scripts/test_unreal.sh --no-build --test supplemental.unreal_gatherers.TimeControl`
- [x] `./scripts/test_unreal.sh --no-build --test supplemental.unreal_gatherers.Mass`
- [x] `./scripts/test_unreal.sh`

Made with [Cursor](https://cursor.com)